### PR TITLE
fix: repair updateWebhook and deleteWebhook MCP tools

### DIFF
--- a/helius-mcp/src/tools/webhooks.ts
+++ b/helius-mcp/src/tools/webhooks.ts
@@ -91,16 +91,16 @@ export function registerWebhookTools(server: McpServer) {
       webhookURL: z.string().describe('Your webhook URL endpoint'),
       webhookType: z.enum(['enhanced', 'raw', 'discord']).describe('Webhook type - use "enhanced" for parsed transaction data with descriptions'),
       accountAddresses: z.array(z.string()).describe('Array of Solana addresses to monitor (up to 100,000 per webhook)'),
-      transactionTypes: z.array(z.enum(TRANSACTION_TYPES as unknown as [string, ...string[]])).optional().describe('Filter by specific transaction types - e.g. ["SWAP", "NFT_SALE", "STAKE_TOKEN"]. Leave empty to receive all transaction types. See common types: NFT_SALE, NFT_MINT, SWAP, TRANSFER, STAKE_TOKEN, UNSTAKE_TOKEN, BUY, SELL, TOKEN_MINT')
+      transactionTypes: z.array(z.enum(TRANSACTION_TYPES as unknown as [string, ...string[]])).describe('Transaction types to monitor - e.g. ["SWAP", "NFT_SALE"]. Use ["ANY"] to receive all types. Common types: NFT_SALE, NFT_MINT, SWAP, TRANSFER, STAKE_TOKEN, UNSTAKE_TOKEN, BUY, SELL, TOKEN_MINT')
     },
     async ({ webhookURL, webhookType, accountAddresses, transactionTypes }) => {
       try {
         const body: any = {
           webhookURL,
           webhookType,
-          accountAddresses
+          accountAddresses,
+          transactionTypes
         };
-        if (transactionTypes) body.transactionTypes = transactionTypes;
 
         const webhook = await restRequest('/v0/webhooks', {
           method: 'POST',
@@ -180,7 +180,6 @@ export function registerWebhookTools(server: McpServer) {
       try {
         await restRequest(`/v0/webhooks/${webhookID}`, {
           method: 'DELETE',
-          body: JSON.stringify({}),
         });
 
         return {

--- a/helius-mcp/src/tools/webhooks.ts
+++ b/helius-mcp/src/tools/webhooks.ts
@@ -129,15 +129,25 @@ export function registerWebhookTools(server: McpServer) {
     {
       webhookID: z.string().describe('Webhook ID to update'),
       webhookURL: z.string().optional().describe('New webhook URL'),
+      webhookType: z.enum(['enhanced', 'raw', 'discord']).optional().describe('Webhook type (required by the Helius API for updates)'),
       accountAddresses: z.array(z.string()).optional().describe('New list of addresses to monitor (replaces existing list)'),
       transactionTypes: z.array(z.enum(TRANSACTION_TYPES as unknown as [string, ...string[]])).optional().describe('New transaction type filters - e.g. ["SWAP", "NFT_SALE"]. Replaces existing filters.')
     },
-    async ({ webhookID, webhookURL, accountAddresses, transactionTypes }) => {
+    async ({ webhookID, webhookURL, webhookType, accountAddresses, transactionTypes }) => {
       try {
-        const body: any = {};
-        if (webhookURL) body.webhookURL = webhookURL;
-        if (accountAddresses) body.accountAddresses = accountAddresses;
-        if (transactionTypes) body.transactionTypes = transactionTypes;
+        // Helius PUT /v0/webhooks requires the full webhook object.
+        // Fetch the existing webhook first so callers only need to supply changed fields.
+        const existing = await restRequest(`/v0/webhooks/${webhookID}`);
+        const body: any = {
+          webhookURL: webhookURL ?? existing.webhookURL,
+          webhookType: webhookType ?? existing.webhookType,
+          accountAddresses: accountAddresses ?? existing.accountAddresses,
+        };
+        if (transactionTypes) {
+          body.transactionTypes = transactionTypes;
+        } else if (existing.transactionTypes) {
+          body.transactionTypes = existing.transactionTypes;
+        }
 
         const webhook = await restRequest(`/v0/webhooks/${webhookID}`, {
           method: 'PUT',
@@ -169,7 +179,8 @@ export function registerWebhookTools(server: McpServer) {
     async ({ webhookID }) => {
       try {
         await restRequest(`/v0/webhooks/${webhookID}`, {
-          method: 'DELETE'
+          method: 'DELETE',
+          body: JSON.stringify({}),
         });
 
         return {

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -96,9 +96,14 @@ export async function restRequest(endpoint: string, options: RequestInit = {}): 
   const separator = endpoint.includes('?') ? '&' : '?';
   const url = `https://api.helius.xyz${endpoint}${separator}api-key=${apiKey}`;
 
+  const headers: Record<string, string> = { ...options.headers as Record<string, string> };
+  if (options.body) {
+    headers['Content-Type'] ??= 'application/json';
+  }
+
   const response = await fetch(url, {
     ...options,
-    headers: { 'Content-Type': 'application/json', ...options.headers },
+    headers,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
**Summary**       
  - updateWebhook was sending a partial object to the Helius API, which requires the full webhook object on PUT. It also lacked 
  webhookType in its schema entirely, so it could never pass that required field. Fixed by auto-fetching the existing webhook
  and merging caller-provided fields on top, and adding webhookType to the Zod schema.                                          
  - deleteWebhook was failing with "Unexpected token 'n', "null" is not valid JSON" because restRequest always sets
  Content-Type: application/json, but DELETE sent no body — causing the Helius API to try parsing null as JSON. Fixed by sending
   an empty JSON body {}.

  **Root causes**
  **updateWebhook (HTTP 400)**
  1. webhookType was missing from the Zod schema, so it was never accepted as a parameter and never sent to the API
  2. The handler only included fields the caller explicitly provided, sending a partial object — but Helius PUT /v0/webhooks/:id
   requires the full webhook object (webhookURL, webhookType, accountAddresses are all mandatory)

  **deleteWebhook (HTTP 400)**
  1. restRequest unconditionally sets Content-Type: application/json on every request
  2. DELETE was sent with no body, so the Helius API received a request with a JSON content type but a null body and failed to
  parse it

  **Test plan**
  - updateWebhook with only webhookID + one changed field (e.g. transactionTypes) succeeds — unchanged fields are preserved from
   existing webhook
  - updateWebhook with explicit webhookType override works
  - deleteWebhook successfully removes a webhook without errors