### PR TITLE
feat: add error handling

### DIFF
--- a/helius-mcp/src/tools/accounts.ts
+++ b/helius-mcp/src/tools/accounts.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getHeliusClient, hasApiKey, getRpcUrl } from '../utils/helius.js';
 import { formatAddress, formatSol } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
+import { mcpText, validateEnum, handleToolError, addressError, paginationError } from '../utils/errors.js';
 
 function formatParsedAccountData(account: {
   data: unknown;
@@ -42,30 +43,23 @@ export function registerAccountTools(server: McpServer) {
     {
       address: z.string().optional().describe('Single account address (base58 encoded). Use this OR addresses, not both.'),
       addresses: z.array(z.string()).optional().describe('Array of account addresses for batch lookup (up to 100). Use this OR address, not both.'),
-      encoding: z.enum(['base58', 'base64', 'jsonParsed']).optional().default('jsonParsed').describe('Data encoding format')
+      encoding: z.string().optional().default('jsonParsed').describe('Data encoding format')
     },
     async ({ address, addresses, encoding }) => {
       if (!hasApiKey()) return noApiKeyResponse();
+
+      const err = validateEnum(encoding, ['base58', 'base64', 'jsonParsed'], 'Account Info Error', 'encoding');
+      if (err) return err;
 
       const url = getRpcUrl();
 
       // Validate: must provide exactly one of address or addresses
       if (!address && (!addresses || addresses.length === 0)) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error:** Provide either \`address\` (single account) or \`addresses\` (batch of up to 100).`
-          }]
-        };
+        return mcpText(`**Error:** Provide either \`address\` (single account) or \`addresses\` (batch of up to 100).`);
       }
 
       if (address && addresses && addresses.length > 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error:** Provide either \`address\` or \`addresses\`, not both.`
-          }]
-        };
+        return mcpText(`**Error:** Provide either \`address\` or \`addresses\`, not both.`);
       }
 
       type AccountInfo = {
@@ -77,138 +71,114 @@ export function registerAccountTools(server: McpServer) {
         space?: number;
       };
 
-      // --- Batch mode ---
-      if (addresses && addresses.length > 0) {
-        if (addresses.length > 100) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Error:** Maximum 100 accounts per request. You provided ${addresses.length}.`
-            }]
+      try {
+        // --- Batch mode ---
+        if (addresses && addresses.length > 0) {
+          if (addresses.length > 100) {
+            return mcpText(`**Error:** Maximum 100 accounts per request. You provided ${addresses.length}.`);
+          }
+
+          const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: 'get-multiple-accounts',
+              method: 'getMultipleAccounts',
+              params: [addresses, { encoding }]
+            })
+          });
+
+          type ApiResponse = {
+            result?: { value: (AccountInfo | null)[] };
+            error?: { message: string };
           };
+
+          const data = await response.json() as ApiResponse;
+
+          if (data.error) {
+            return mcpText(`**Error**\n\n${data.error.message}`);
+          }
+
+          const accounts = data.result?.value || [];
+          const lines = [`**Multiple Accounts** (${addresses.length} requested)`, ''];
+
+          addresses.forEach((addr, i) => {
+            const account = accounts[i];
+            if (!account) {
+              lines.push(`**${formatAddress(addr)}:** Not found`);
+            } else {
+              lines.push(`**${formatAddress(addr)}**`);
+              lines.push(`  Balance: ${formatSol(account.lamports)}`);
+              lines.push(`  Owner: ${account.owner}`);
+              lines.push(`  Executable: ${account.executable ? 'Yes' : 'No'}`);
+              if (account.space !== undefined) {
+                lines.push(`  Data Size: ${account.space} bytes`);
+              }
+              // Show parsed data (Token-2022 extensions, mint info, etc.)
+              const parsedLines = formatParsedAccountData(account);
+              lines.push(...parsedLines);
+            }
+            lines.push('');
+          });
+
+          return mcpText(lines.join('\n'));
         }
 
+        // --- Single account mode ---
         const response = await fetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             jsonrpc: '2.0',
-            id: 'get-multiple-accounts',
-            method: 'getMultipleAccounts',
-            params: [addresses, { encoding }]
+            id: 'get-account-info',
+            method: 'getAccountInfo',
+            params: [address, { encoding }]
           })
         });
 
         type ApiResponse = {
-          result?: { value: (AccountInfo | null)[] };
+          result?: { value: AccountInfo | null };
           error?: { message: string };
         };
 
         const data = await response.json() as ApiResponse;
 
         if (data.error) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Error**\n\n${data.error.message}`
-            }]
-          };
+          return mcpText(`**Error**\n\n${data.error.message}`);
         }
 
-        const accounts = data.result?.value || [];
-        const lines = [`**Multiple Accounts** (${addresses.length} requested)`, ''];
+        const account = data.result?.value;
 
-        addresses.forEach((addr, i) => {
-          const account = accounts[i];
-          if (!account) {
-            lines.push(`**${formatAddress(addr)}:** Not found`);
-          } else {
-            lines.push(`**${formatAddress(addr)}**`);
-            lines.push(`  Balance: ${formatSol(account.lamports)}`);
-            lines.push(`  Owner: ${account.owner}`);
-            lines.push(`  Executable: ${account.executable ? 'Yes' : 'No'}`);
-            if (account.space !== undefined) {
-              lines.push(`  Data Size: ${account.space} bytes`);
-            }
-            // Show parsed data (Token-2022 extensions, mint info, etc.)
-            const parsedLines = formatParsedAccountData(account);
-            lines.push(...parsedLines);
-          }
-          lines.push('');
-        });
+        if (!account) {
+          return mcpText(`**Account ${formatAddress(address!)}**\n\nAccount not found or has no data.`);
+        }
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: lines.join('\n')
-          }]
-        };
+        const lines = [
+          `**Account ${formatAddress(address!)}**`,
+          '',
+          `**Balance:** ${formatSol(account.lamports)} (${account.lamports.toLocaleString()} lamports)`,
+          `**Owner:** ${account.owner}`,
+          `**Executable:** ${account.executable ? 'Yes' : 'No'}`,
+        ];
+
+        if (account.space !== undefined) {
+          lines.push(`**Data Size:** ${account.space} bytes`);
+        }
+
+        // Show parsed data details when using jsonParsed
+        const parsedLines = formatParsedAccountData(account);
+        if (parsedLines.length > 0) {
+          lines.push('', '**Parsed Data:**');
+          lines.push(...parsedLines);
+        }
+
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching account info', [
+          addressError('Account Info'),
+        ]);
       }
-
-      // --- Single account mode ---
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 'get-account-info',
-          method: 'getAccountInfo',
-          params: [address, { encoding }]
-        })
-      });
-
-      type ApiResponse = {
-        result?: { value: AccountInfo | null };
-        error?: { message: string };
-      };
-
-      const data = await response.json() as ApiResponse;
-
-      if (data.error) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error**\n\n${data.error.message}`
-          }]
-        };
-      }
-
-      const account = data.result?.value;
-
-      if (!account) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Account ${formatAddress(address!)}**\n\nAccount not found or has no data.`
-          }]
-        };
-      }
-
-      const lines = [
-        `**Account ${formatAddress(address!)}**`,
-        '',
-        `**Balance:** ${formatSol(account.lamports)} (${account.lamports.toLocaleString()} lamports)`,
-        `**Owner:** ${account.owner}`,
-        `**Executable:** ${account.executable ? 'Yes' : 'No'}`,
-      ];
-
-      if (account.space !== undefined) {
-        lines.push(`**Data Size:** ${account.space} bytes`);
-      }
-
-      // Show parsed data details when using jsonParsed
-      const parsedLines = formatParsedAccountData(account);
-      if (parsedLines.length > 0) {
-        lines.push('', '**Parsed Data:**');
-        lines.push(...parsedLines);
-      }
-
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
     }
   );
 
@@ -227,12 +197,7 @@ export function registerAccountTools(server: McpServer) {
       const helius = getHeliusClient();
 
       if (!owner && !mint) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error:** You must provide at least one of: owner or mint address.`
-          }]
-        };
+        return mcpText(`**Error:** You must provide at least one of: owner or mint address.`);
       }
 
       type TokenAccountParams = {
@@ -246,7 +211,15 @@ export function registerAccountTools(server: McpServer) {
       if (owner) params.owner = owner;
       if (mint) params.mint = mint;
 
-      const response = await helius.getTokenAccounts(params);
+      let response;
+      try {
+        response = await helius.getTokenAccounts(params);
+      } catch (err) {
+        return handleToolError(err, 'Error fetching token accounts', [
+          addressError('Token Accounts', 'Invalid Solana address. Please provide valid base58-encoded addresses for owner and/or mint.'),
+          paginationError('Token Accounts'),
+        ]);
+      }
 
       type TokenAccount = {
         address: string;
@@ -265,12 +238,7 @@ export function registerAccountTools(server: McpServer) {
           : owner
             ? `owner=${formatAddress(owner)}`
             : `mint=${formatAddress(mint!)}`;
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Token Accounts** (${filterDesc})\n\nNo token accounts found.`
-          }]
-        };
+        return mcpText(`**Token Accounts** (${filterDesc})\n\nNo token accounts found.`);
       }
 
       const lines = [`**Token Accounts** (${response.total || items.length} total, page ${page})`, ''];
@@ -291,12 +259,7 @@ export function registerAccountTools(server: McpServer) {
         lines.push('');
       });
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
+      return mcpText(lines.join('\n'));
     }
   );
 
@@ -307,12 +270,15 @@ export function registerAccountTools(server: McpServer) {
     {
       programId: z.string().describe('Program ID (base58 encoded) — the owner program of the accounts to find'),
       limit: z.number().optional().default(20).describe('Maximum accounts to return (default 20, max 100)'),
-      encoding: z.enum(['base58', 'base64', 'jsonParsed']).optional().default('base64').describe('Data encoding format'),
+      encoding: z.string().optional().default('base64').describe('Data encoding format'),
       dataSize: z.number().optional().describe('Filter by exact account data size in bytes (e.g. 165 for SPL token accounts)'),
       paginationKey: z.string().optional().describe('Pagination cursor from a previous response to fetch the next page')
     },
     async ({ programId, limit, encoding, dataSize, paginationKey }) => {
       if (!hasApiKey()) return noApiKeyResponse();
+
+      const encErr = validateEnum(encoding, ['base58', 'base64', 'jsonParsed'], 'Program Accounts Error', 'encoding');
+      if (encErr) return encErr;
 
       const url = getRpcUrl();
 
@@ -377,32 +343,19 @@ export function registerAccountTools(server: McpServer) {
         });
         data = await response.json() as ApiResponse;
       } catch (err) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error fetching program accounts:** ${err instanceof Error ? err.message : String(err)}`
-          }]
-        };
+        return handleToolError(err, 'Error fetching program accounts', [
+          addressError('Program Accounts'),
+        ]);
       }
 
       if (data.error) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error**\n\n${data.error.message}`
-          }]
-        };
+        return mcpText(`**Error**\n\n${data.error.message}`);
       }
 
       const accounts = data.result?.accounts || [];
 
       if (accounts.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Program Accounts for ${formatAddress(programId)}**\n\nNo accounts found.`
-          }]
-        };
+        return mcpText(`**Program Accounts for ${formatAddress(programId)}**\n\nNo accounts found.`);
       }
 
       const totalLabel = data.result?.totalResults
@@ -423,12 +376,7 @@ export function registerAccountTools(server: McpServer) {
         lines.push('', `**Next Page:** Pass \`paginationKey: "${data.result.paginationKey}"\` to fetch the next page.`);
       }
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
+      return mcpText(lines.join('\n'));
     }
   );
 }

--- a/helius-mcp/src/tools/assets.ts
+++ b/helius-mcp/src/tools/assets.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatAddress } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
+import { mcpText, handleToolError, addressError, paginationError, notFoundError } from '../utils/errors.js';
 
 export function registerAssetTools(server: McpServer) {
   // Get Assets by Owner (NFTs and tokens via DAS)
@@ -17,19 +18,23 @@ export function registerAssetTools(server: McpServer) {
     async ({ address, limit, page }) => {
       if (!hasApiKey()) return noApiKeyResponse();
       const helius = getHeliusClient();
-      const response = await helius.getAssetsByOwner({
-        ownerAddress: address,
-        page,
-        limit
-      });
+      let response;
+      try {
+        response = await helius.getAssetsByOwner({
+          ownerAddress: address,
+          page,
+          limit
+        });
+      } catch (err) {
+        const header = `Assets for ${formatAddress(address)}`;
+        return handleToolError(err, 'Error fetching assets', [
+          addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded wallet address.'),
+          paginationError(header),
+        ]);
+      }
 
       if (!response.items || response.items.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Assets for ${formatAddress(address)}**\n\nNo assets found.`
-          }]
-        };
+        return mcpText(`**Assets for ${formatAddress(address)}**\n\nNo assets found.`);
       }
 
       type AssetItem = {
@@ -75,12 +80,7 @@ export function registerAssetTools(server: McpServer) {
         lines.push(`  ID: ${formatAddress(asset.id)}`);
       });
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
+      return mcpText(lines.join('\n'));
     }
   );
 
@@ -98,21 +98,11 @@ export function registerAssetTools(server: McpServer) {
 
       // Validate: must provide exactly one of id or ids
       if (!id && (!ids || ids.length === 0)) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error:** Provide either "id" (single asset) or "ids" (batch of up to 1000).`
-          }]
-        };
+        return mcpText(`**Error:** Provide either "id" (single asset) or "ids" (batch of up to 1000).`);
       }
 
       if (id && ids && ids.length > 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error:** Provide either "id" or "ids", not both.`
-          }]
-        };
+        return mcpText(`**Error:** Provide either "id" or "ids", not both.`);
       }
 
       type Creator = { address: string; share: number; verified: boolean };
@@ -142,24 +132,22 @@ export function registerAssetTools(server: McpServer) {
       // --- Batch mode ---
       if (ids && ids.length > 0) {
         if (ids.length > 1000) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Error:** Maximum 1000 assets per batch. You provided ${ids.length}.`
-            }]
-          };
+          return mcpText(`**Error:** Maximum 1000 assets per batch. You provided ${ids.length}.`);
         }
 
-        const assets = await helius.getAssetBatch({ ids });
+        let assets;
+        try {
+          assets = await helius.getAssetBatch({ ids });
+        } catch (err) {
+          return handleToolError(err, 'Error fetching assets', [
+            addressError('Asset Batch Error', 'One or more provided IDs are not valid Solana addresses. Please check the mint addresses and try again.'),
+            notFoundError('Asset Batch Results', 'One or more assets were not found. Please check the mint addresses and try again.'),
+          ]);
+        }
         const items = (assets || []) as AssetResponse[];
 
         if (items.length === 0) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Asset Batch Results**\n\nNo assets found.`
-            }]
-          };
+          return mcpText(`**Asset Batch Results**\n\nNo assets found.`);
         }
 
         const lines = [`**Asset Batch Results** (${items.length} assets)`, ''];
@@ -174,24 +162,23 @@ export function registerAssetTools(server: McpServer) {
           }
         });
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: lines.join('\n')
-          }]
-        };
+        return mcpText(lines.join('\n'));
       }
 
       // --- Single asset mode ---
-      const asset = await helius.getAsset({ id: id! }) as AssetResponse | null;
+      let asset: AssetResponse | null;
+      try {
+        asset = await helius.getAsset({ id: id! }) as AssetResponse | null;
+      } catch (err) {
+        const header = `Asset ${formatAddress(id!)}`;
+        return handleToolError(err, 'Error fetching asset', [
+          addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded mint address.'),
+          notFoundError(header, 'Asset not found. This mint address does not exist or has not been indexed.'),
+        ]);
+      }
 
       if (!asset) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `Asset ${formatAddress(id!)} not found.`
-          }]
-        };
+        return mcpText(`Asset ${formatAddress(id!)} not found.`);
       }
 
       const metadata = asset.content?.metadata;
@@ -275,12 +262,7 @@ export function registerAssetTools(server: McpServer) {
         lines.push(`**Status:** ${flags.join(', ')}`);
       }
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
+      return mcpText(lines.join('\n'));
     }
   );
 
@@ -325,32 +307,43 @@ export function registerAssetTools(server: McpServer) {
 
       // Smart routing: authority-only → getAssetsByAuthority
       if (authorityAddress && !creatorAddress && !ownerAddress && !name && compressed === undefined && burnt === undefined && frozen === undefined) {
-        response = await helius.getAssetsByAuthority({
-          authorityAddress,
-          page,
-          limit
-        }) as ListResponse;
+        try {
+          response = await helius.getAssetsByAuthority({
+            authorityAddress,
+            page,
+            limit
+          }) as ListResponse;
+        } catch (err) {
+          const header = `Assets by Authority ${formatAddress(authorityAddress)}`;
+          return handleToolError(err, 'Error searching assets', [
+            addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded address.'),
+            paginationError(header),
+          ]);
+        }
         headerLabel = `Assets by Authority ${formatAddress(authorityAddress)}`;
       }
       // Smart routing: creator (with optional onlyVerified) → getAssetsByCreator
       else if (creatorAddress && !authorityAddress && !ownerAddress && !name && compressed === undefined && burnt === undefined && frozen === undefined) {
-        response = await helius.getAssetsByCreator({
-          creatorAddress,
-          onlyVerified,
-          page,
-          limit
-        }) as ListResponse;
+        try {
+          response = await helius.getAssetsByCreator({
+            creatorAddress,
+            onlyVerified,
+            page,
+            limit
+          }) as ListResponse;
+        } catch (err) {
+          const header = `Assets by Creator ${formatAddress(creatorAddress)}`;
+          return handleToolError(err, 'Error searching assets', [
+            addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded address.'),
+            paginationError(header),
+          ]);
+        }
         headerLabel = `Assets by Creator ${formatAddress(creatorAddress)}`;
       }
       // General search → searchAssets
       else {
         if (name && !ownerAddress) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Search Error:** Searching by name requires an owner address. Please also provide \`ownerAddress\` to search for assets named "${name}".`
-            }]
-          };
+          return mcpText(`**Search Error:** Searching by name requires an owner address. Please also provide \`ownerAddress\` to search for assets named "${name}".`);
         }
 
         type SearchParams = {
@@ -375,12 +368,10 @@ export function registerAssetTools(server: McpServer) {
         try {
           response = await helius.searchAssets(params) as ListResponse;
         } catch (err) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `Error searching assets: ${err instanceof Error ? err.message : String(err)}`
-            }]
-          };
+          return handleToolError(err, 'Error searching assets', [
+            addressError('Asset Search'),
+            paginationError('Asset Search'),
+          ]);
         }
         headerLabel = 'Asset Search Results';
       }
@@ -388,12 +379,7 @@ export function registerAssetTools(server: McpServer) {
       const items = (response.items || []) as AssetItem[];
 
       if (items.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**${headerLabel}**\n\nNo assets found matching the criteria.`
-          }]
-        };
+        return mcpText(`**${headerLabel}**\n\nNo assets found matching the criteria.`);
       }
 
       const lines = [`**${headerLabel}** (${response.total || items.length} total, page ${page})`, ''];
@@ -413,12 +399,7 @@ export function registerAssetTools(server: McpServer) {
         }
       });
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
+      return mcpText(lines.join('\n'));
     }
   );
 
@@ -436,12 +417,21 @@ export function registerAssetTools(server: McpServer) {
       if (!hasApiKey()) return noApiKeyResponse();
       const helius = getHeliusClient();
 
-      const response = await helius.getAssetsByGroup({
-        groupKey,
-        groupValue,
-        page,
-        limit
-      });
+      let response;
+      try {
+        response = await helius.getAssetsByGroup({
+          groupKey,
+          groupValue,
+          page,
+          limit
+        });
+      } catch (err) {
+        const header = `Assets in Group ${groupKey}=${formatAddress(groupValue)}`;
+        return handleToolError(err, 'Error fetching group assets', [
+          addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded address.'),
+          paginationError(header),
+        ]);
+      }
 
       type AssetItem = {
         id: string;
@@ -453,12 +443,7 @@ export function registerAssetTools(server: McpServer) {
       const items = (response.items || []) as AssetItem[];
 
       if (items.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Assets in Group ${groupKey}=${formatAddress(groupValue)}**\n\nNo assets found.`
-          }]
-        };
+        return mcpText(`**Assets in Group ${groupKey}=${formatAddress(groupValue)}**\n\nNo assets found.`);
       }
 
       const lines = [`**Assets in Group ${groupKey}=${formatAddress(groupValue)}** (${response.total || items.length} total, page ${page})`, ''];
@@ -472,12 +457,7 @@ export function registerAssetTools(server: McpServer) {
         }
       });
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
+      return mcpText(lines.join('\n'));
     }
   );
 }

--- a/helius-mcp/src/tools/balance.ts
+++ b/helius-mcp/src/tools/balance.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatSol, formatAddress } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
+import { mcpText, getErrorMessage, handleToolError, addressError } from '../utils/errors.js';
 
 export function registerBalanceTools(server: McpServer) {
   // Get SOL Balance
@@ -14,16 +15,17 @@ export function registerBalanceTools(server: McpServer) {
     },
     async ({ address }) => {
       if (!hasApiKey()) return noApiKeyResponse();
-      const helius = getHeliusClient();
-      const balance = await helius.getBalance(address);
-      const lamports = Number(balance.value);
+      try {
+        const helius = getHeliusClient();
+        const balance = await helius.getBalance(address);
+        const lamports = Number(balance.value);
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `**SOL Balance for ${formatAddress(address)}**\n\n${formatSol(lamports)} (${lamports.toLocaleString()} lamports)`
-        }]
-      };
+        return mcpText(`**SOL Balance for ${formatAddress(address)}**\n\n${formatSol(lamports)} (${lamports.toLocaleString()} lamports)`);
+      } catch (err) {
+        return handleToolError(err, 'Error fetching balance', [
+          addressError(`SOL Balance for ${formatAddress(address)}`, 'Invalid Solana address. Please provide a valid base58-encoded wallet address.'),
+        ]);
+      }
     }
   );
 
@@ -76,8 +78,8 @@ export function registerBalanceTools(server: McpServer) {
             });
             const items = response.items || [];
             return { items, hasMore: items.length === currentLimit };
-          } catch (err: unknown) {
-            const errorMsg = err instanceof Error ? err.message : String(err);
+          } catch (err) {
+            const errorMsg = getErrorMessage(err);
             if (errorMsg.includes('too big') || errorMsg.includes('Response is too big')) {
               if (currentLimit > 5) currentLimit = 5;
               else if (currentLimit > 2) currentLimit = 2;
@@ -92,16 +94,18 @@ export function registerBalanceTools(server: McpServer) {
       }
 
       // Step 1: Fetch first page to probe
-      const firstResult = await fetchPage(1);
+      let firstResult;
+      try {
+        firstResult = await fetchPage(1);
+      } catch (err) {
+        return handleToolError(err, 'Error fetching token balances', [
+          addressError(`Token Balances for ${formatAddress(address)}`, 'Invalid Solana address. Please provide a valid base58-encoded wallet address.'),
+        ]);
+      }
       const allAssets: Asset[] = [...firstResult.items];
 
       if (allAssets.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Token Balances for ${formatAddress(address)}**\n\nNo tokens found.`
-          }]
-        };
+        return mcpText(`**Token Balances for ${formatAddress(address)}**\n\nNo tokens found.`);
       }
 
       // Step 2: If first page is full, fetch remaining pages in parallel
@@ -140,12 +144,7 @@ export function registerBalanceTools(server: McpServer) {
       );
 
       if (fungibleTokens.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Token Balances for ${formatAddress(address)}**\n\nNo fungible tokens found.`
-          }]
-        };
+        return mcpText(`**Token Balances for ${formatAddress(address)}**\n\nNo fungible tokens found.`);
       }
 
       // Enrich tokens missing name/symbol by fetching full asset data
@@ -216,12 +215,7 @@ export function registerBalanceTools(server: McpServer) {
         }
       }
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `${header}\n\n${lines.join('\n')}`
-        }]
-      };
+      return mcpText(`${header}\n\n${lines.join('\n')}`);
     }
   );
 }

--- a/helius-mcp/src/tools/blocks.ts
+++ b/helius-mcp/src/tools/blocks.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { hasApiKey, getRpcUrl } from '../utils/helius.js';
 import { formatSol, formatTimestamp } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
+import { mcpText, validateEnum, handleToolError } from '../utils/errors.js';
 
 export function registerBlockTools(server: McpServer) {
   server.tool(
@@ -10,133 +11,125 @@ export function registerBlockTools(server: McpServer) {
     'Get detailed information about a specific Solana block by slot number. Returns block time, blockhash, parent slot, transaction count, and reward summary. Use transactionDetails to control how much transaction data is included: "none" for just block metadata, "signatures" for a list of transaction signatures, or "full" for complete transaction data.',
     {
       slot: z.number().describe('Slot number of the block to fetch'),
-      transactionDetails: z.enum(['none', 'signatures', 'full']).optional().default('signatures').describe('"none" = block metadata only, "signatures" = list of tx signatures (default), "full" = complete transaction data')
+      transactionDetails: z.string().optional().default('signatures').describe('"none" = block metadata only, "signatures" = list of tx signatures (default), "full" = complete transaction data')
     },
     async ({ slot, transactionDetails }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
+      const err = validateEnum(transactionDetails, ['none', 'signatures', 'full'], 'Block Error', 'transactionDetails');
+      if (err) return err;
+
       const url = getRpcUrl();
 
-      const requestBody = {
-        jsonrpc: '2.0',
-        id: 'get-block',
-        method: 'getBlock',
-        params: [
-          slot,
-          {
-            encoding: 'jsonParsed',
-            transactionDetails,
-            maxSupportedTransactionVersion: 0,
-            rewards: true
-          }
-        ]
-      };
-
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody)
-      });
-
-      type Reward = {
-        pubkey: string;
-        lamports: number;
-        postBalance: number;
-        rewardType: string;
-        commission?: number;
-      };
-
-      type BlockResult = {
-        blockhash: string;
-        previousBlockhash: string;
-        parentSlot: number;
-        blockTime: number | null;
-        blockHeight: number | null;
-        transactions?: unknown[];
-        signatures?: string[];
-        rewards?: Reward[];
-      };
-
-      type ApiResponse = {
-        result?: BlockResult;
-        error?: { message: string };
-      };
-
-      const data = await response.json() as ApiResponse;
-
-      if (data.error) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error**\n\n${data.error.message}`
-          }]
+      try {
+        const requestBody = {
+          jsonrpc: '2.0',
+          id: 'get-block',
+          method: 'getBlock',
+          params: [
+            slot,
+            {
+              encoding: 'jsonParsed',
+              transactionDetails,
+              maxSupportedTransactionVersion: 0,
+              rewards: true
+            }
+          ]
         };
-      }
 
-      const block = data.result;
-      if (!block) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Block at Slot ${slot.toLocaleString()}**\n\nBlock not found. It may have been skipped or not yet confirmed.`
-          }]
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody)
+        });
+
+        type Reward = {
+          pubkey: string;
+          lamports: number;
+          postBalance: number;
+          rewardType: string;
+          commission?: number;
         };
-      }
 
-      const lines = [
-        `**Block at Slot ${slot.toLocaleString()}**`,
-        '',
-        `**Blockhash:** ${block.blockhash}`,
-        `**Parent Slot:** ${block.parentSlot.toLocaleString()}`,
-        `**Previous Blockhash:** ${block.previousBlockhash}`,
-      ];
+        type BlockResult = {
+          blockhash: string;
+          previousBlockhash: string;
+          parentSlot: number;
+          blockTime: number | null;
+          blockHeight: number | null;
+          transactions?: unknown[];
+          signatures?: string[];
+          rewards?: Reward[];
+        };
 
-      if (block.blockHeight !== null) {
-        lines.push(`**Block Height:** ${block.blockHeight.toLocaleString()}`);
-      }
-      if (block.blockTime) {
-        lines.push(`**Block Time:** ${formatTimestamp(block.blockTime)}`);
-      }
+        type ApiResponse = {
+          result?: BlockResult;
+          error?: { message: string };
+        };
 
-      // Transaction count
-      if (transactionDetails === 'signatures' && block.signatures) {
-        lines.push(`**Transactions:** ${block.signatures.length}`);
-      } else if (transactionDetails === 'full' && block.transactions) {
-        lines.push(`**Transactions:** ${block.transactions.length}`);
-      }
+        const data = await response.json() as ApiResponse;
 
-      // Rewards summary
-      if (block.rewards && block.rewards.length > 0) {
-        const totalRewards = block.rewards.reduce((sum, r) => sum + r.lamports, 0);
-        const rewardTypes = new Map<string, number>();
-        block.rewards.forEach((r) => {
-          rewardTypes.set(r.rewardType, (rewardTypes.get(r.rewardType) || 0) + r.lamports);
-        });
-
-        lines.push('', `**Rewards:** ${formatSol(totalRewards)} total (${block.rewards.length} recipients)`);
-        rewardTypes.forEach((lamports, type) => {
-          lines.push(`- ${type}: ${formatSol(lamports)}`);
-        });
-      }
-
-      // Show signatures if in signatures mode
-      if (transactionDetails === 'signatures' && block.signatures && block.signatures.length > 0) {
-        const maxShow = 20;
-        lines.push('', `**Transaction Signatures** (${block.signatures.length} total):`);
-        block.signatures.slice(0, maxShow).forEach((sig) => {
-          lines.push(`- ${sig}`);
-        });
-        if (block.signatures.length > maxShow) {
-          lines.push(`... +${block.signatures.length - maxShow} more`);
+        if (data.error) {
+          return mcpText(`**Error**\n\n${data.error.message}`);
         }
-      }
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
+        const block = data.result;
+        if (!block) {
+          return mcpText(`**Block at Slot ${slot.toLocaleString()}**\n\nBlock not found. It may have been skipped or not yet confirmed.`);
+        }
+
+        const lines = [
+          `**Block at Slot ${slot.toLocaleString()}**`,
+          '',
+          `**Blockhash:** ${block.blockhash}`,
+          `**Parent Slot:** ${block.parentSlot.toLocaleString()}`,
+          `**Previous Blockhash:** ${block.previousBlockhash}`,
+        ];
+
+        if (block.blockHeight !== null) {
+          lines.push(`**Block Height:** ${block.blockHeight.toLocaleString()}`);
+        }
+        if (block.blockTime) {
+          lines.push(`**Block Time:** ${formatTimestamp(block.blockTime)}`);
+        }
+
+        // Transaction count
+        if (transactionDetails === 'signatures' && block.signatures) {
+          lines.push(`**Transactions:** ${block.signatures.length}`);
+        } else if (transactionDetails === 'full' && block.transactions) {
+          lines.push(`**Transactions:** ${block.transactions.length}`);
+        }
+
+        // Rewards summary
+        if (block.rewards && block.rewards.length > 0) {
+          const totalRewards = block.rewards.reduce((sum, r) => sum + r.lamports, 0);
+          const rewardTypes = new Map<string, number>();
+          block.rewards.forEach((r) => {
+            rewardTypes.set(r.rewardType, (rewardTypes.get(r.rewardType) || 0) + r.lamports);
+          });
+
+          lines.push('', `**Rewards:** ${formatSol(totalRewards)} total (${block.rewards.length} recipients)`);
+          rewardTypes.forEach((lamports, type) => {
+            lines.push(`- ${type}: ${formatSol(lamports)}`);
+          });
+        }
+
+        // Show signatures if in signatures mode
+        if (transactionDetails === 'signatures' && block.signatures && block.signatures.length > 0) {
+          const maxShow = 20;
+          lines.push('', `**Transaction Signatures** (${block.signatures.length} total):`);
+          block.signatures.slice(0, maxShow).forEach((sig) => {
+            lines.push(`- ${sig}`);
+          });
+          if (block.signatures.length > maxShow) {
+            lines.push(`... +${block.signatures.length - maxShow} more`);
+          }
+        }
+
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching block');
+      }
     }
   );
 }

--- a/helius-mcp/src/tools/config.ts
+++ b/helius-mcp/src/tools/config.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { setApiKey, setNetwork, hasApiKey, getHeliusClient } from '../utils/helius.js';
+import { mcpText, validateEnum, getErrorMessage } from '../utils/errors.js';
 
 export function registerConfigTools(server: McpServer) {
   const keyFromEnv = hasApiKey();
@@ -12,45 +13,33 @@ export function registerConfigTools(server: McpServer) {
       : 'Set the Helius API key for the current session. Required before using any other Helius tools. The key is stored in memory only and not persisted to disk. Get your key at https://dashboard.helius.dev/api-keys',
     {
       apiKey: z.string().describe('Your Helius API key from https://dashboard.helius.dev/api-keys'),
-      network: z.enum(['mainnet-beta', 'devnet']).optional().default('mainnet-beta').describe('Network to use (default: mainnet-beta)')
+      network: z.string().optional().default('mainnet-beta').describe('Network to use (default: mainnet-beta)')
     },
     async ({ apiKey, network }) => {
+      const err = validateEnum(network, ['mainnet-beta', 'devnet'], 'API Key Error', 'network');
+      if (err) return err;
+
       if (hasApiKey() && process.env.HELIUS_API_KEY) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `✅ API key is already configured via environment. You don't need to set it - just use the other Helius tools directly (getBalance, parseTransactions, getAsset, etc.)`
-          }]
-        };
+        return mcpText(`✅ API key is already configured via environment. You don't need to set it - just use the other Helius tools directly (getBalance, parseTransactions, getAsset, etc.)`);
       }
 
       setApiKey(apiKey);
       if (network) {
-        setNetwork(network);
+        setNetwork(network as 'mainnet-beta' | 'devnet');
       }
 
       try {
         const helius = getHeliusClient();
         await helius.getBlockHeight();
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
+      } catch (e: unknown) {
+        const errorMsg = getErrorMessage(e);
         if (errorMsg.includes('invalid api key') || errorMsg.includes('401') || errorMsg.includes('Unauthorized')) {
           setApiKey('');
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `❌ Invalid API key. Please check your key and try again.\n\nGet your key at https://dashboard.helius.dev/api-keys`
-            }]
-          };
+          return mcpText(`❌ Invalid API key. Please check your key and try again.\n\nGet your key at https://dashboard.helius.dev/api-keys`);
         }
       }
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `✅ Helius API key configured for ${network}! You can now query the Solana blockchain.`
-        }]
-      };
+      return mcpText(`✅ Helius API key configured for ${network}! You can now query the Solana blockchain.`);
     }
   );
 }

--- a/helius-mcp/src/tools/das-extras.ts
+++ b/helius-mcp/src/tools/das-extras.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { dasRequest } from '../utils/helius.js';
 import { formatAddress } from '../utils/formatters.js';
+import { mcpText, mcpError, handleToolError, addressError, notFoundError, paginationError } from '../utils/errors.js';
 
 export function registerDasExtraTools(server: McpServer) {
   server.tool(
@@ -13,15 +14,13 @@ export function registerDasExtraTools(server: McpServer) {
     async ({ id }) => {
       try {
         const proof = await dasRequest('getAssetProof', { id });
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Merkle Proof for ${formatAddress(id)}**\n\n**Root:** ${formatAddress(proof.root)}\n**Leaf:** ${formatAddress(proof.leaf)}\n**Tree ID:** ${formatAddress(proof.tree_id)}\n**Proof Length:** ${proof.proof.length} nodes`
-          }]
-        };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(`**Merkle Proof for ${formatAddress(id)}**\n\n**Root:** ${formatAddress(proof.root)}\n**Leaf:** ${formatAddress(proof.leaf)}\n**Tree ID:** ${formatAddress(proof.tree_id)}\n**Proof Length:** ${proof.proof.length} nodes`);
+      } catch (err) {
+        const header = `Merkle Proof for ${formatAddress(id)}`;
+        return handleToolError(err, 'Error fetching asset proof', [
+          notFoundError(header, 'Asset proof not found. This asset may not be a compressed NFT (cNFT), or the mint address does not exist.'),
+          addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded mint address.'),
+        ]);
       }
     }
   );
@@ -35,19 +34,16 @@ export function registerDasExtraTools(server: McpServer) {
     async ({ ids }) => {
       try {
         if (ids.length > 1000) {
-          return { content: [{ type: 'text' as const, text: 'Max 1000 proofs per batch' }], isError: true };
+          return mcpError('Max 1000 proofs per batch');
         }
         const result = await dasRequest('getAssetProofBatch', { ids });
         const proofsArray = Array.isArray(result) ? result : Object.values(result);
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Batch Merkle Proofs** (${proofsArray.length})\n\n${proofsArray.map((p: any, i: number) => `${i + 1}. ${formatAddress(ids[i])}\n   Root: ${formatAddress(p.root)}`).join('\n\n')}`
-          }]
-        };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(`**Batch Merkle Proofs** (${proofsArray.length})\n\n${proofsArray.map((p: any, i: number) => `${i + 1}. ${formatAddress(ids[i])}\n   Root: ${formatAddress(p.root)}`).join('\n\n')}`);
+      } catch (err) {
+        return handleToolError(err, 'Error fetching asset proofs', [
+          notFoundError('Batch Merkle Proofs', 'One or more asset proofs were not found. Some assets may not be compressed NFTs (cNFTs), or the mint addresses may not exist.'),
+          addressError('Batch Merkle Proofs', 'One or more provided IDs are not valid Solana addresses. Please check the mint addresses and try again.'),
+        ]);
       }
     }
   );
@@ -64,17 +60,21 @@ export function registerDasExtraTools(server: McpServer) {
       try {
         const result = await dasRequest('getSignaturesForAsset', { id, page, limit });
         if (!result.items?.length) {
-          return { content: [{ type: 'text' as const, text: `**Signatures for ${formatAddress(id)}**\n\nNo transactions found.` }] };
+          return mcpText(`**Signatures for ${formatAddress(id)}**\n\nNo transactions found.`);
         }
         const lines = [`**Signatures for ${formatAddress(id)}** (${result.total} total)`, ''];
         result.items.forEach((sig: any, i: number) => {
           lines.push(`${i + 1}. ${sig.signature}`);
           if (sig.blockTime) lines.push(`   Time: ${new Date(sig.blockTime * 1000).toLocaleString()}`);
         });
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        const header = `Signatures for ${formatAddress(id)}`;
+        return handleToolError(err, 'Error fetching signatures', [
+          notFoundError(header, 'Asset not found. This mint address does not exist or has not been indexed.'),
+          addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded mint address.'),
+          paginationError(header),
+        ]);
       }
     }
   );
@@ -91,7 +91,7 @@ export function registerDasExtraTools(server: McpServer) {
       try {
         const result = await dasRequest('getNftEditions', { mint, page, limit });
         if (!result.editions?.length) {
-          return { content: [{ type: 'text' as const, text: `**Editions for ${formatAddress(mint)}**\n\nNo editions found.` }] };
+          return mcpText(`**Editions for ${formatAddress(mint)}**\n\nNo editions found.`);
         }
         const lines = [`**Editions for ${formatAddress(mint)}** (${result.total} total)`, ''];
         result.editions.forEach((edition: any, i: number) => {
@@ -99,13 +99,15 @@ export function registerDasExtraTools(server: McpServer) {
           lines.push(`   Mint: ${formatAddress(edition.mint)}`);
           if (edition.owner) lines.push(`   Owner: ${formatAddress(edition.owner)}`);
         });
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        if (errorMsg.includes('null value was encountered while decoding')) {
-          return { content: [{ type: 'text' as const, text: `**Editions for ${formatAddress(mint)}**\n\nThis mint is not a master edition NFT. getNftEditions only works with master edition mints.` }] };
-        }
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        const header = `Editions for ${formatAddress(mint)}`;
+        return handleToolError(err, 'Error fetching editions', [
+          { match: (m) => m.includes('null value was encountered'), respond: () => mcpText(`**${header}**\n\nThis mint is not a master edition NFT. getNftEditions only works with master edition mints.`) },
+          notFoundError(header, 'Asset not found. This mint address does not exist or has not been indexed.'),
+          addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded mint address.'),
+          paginationError(header),
+        ]);
       }
     }
   );

--- a/helius-mcp/src/tools/enhanced-websockets.ts
+++ b/helius-mcp/src/tools/enhanced-websockets.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { getEnhancedWebSocketUrl } from '../utils/helius.js';
+import { mcpText, validateEnum, handleToolError, warnInvalidAddresses, warnInvalidAddress, warnAddressConflicts } from '../utils/errors.js';
 
 export function registerEnhancedWebSocketTools(server: McpServer) {
 
@@ -14,13 +15,46 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
       accountInclude: z.array(z.string()).optional().describe('Accounts to include (OR logic)'),
       accountExclude: z.array(z.string()).optional().describe('Accounts to exclude'),
       accountRequired: z.array(z.string()).optional().describe('Accounts required (AND logic)'),
-      commitment: z.enum(['processed', 'confirmed', 'finalized']).optional().default('confirmed'),
-      encoding: z.enum(['base58', 'base64', 'jsonParsed']).optional().default('jsonParsed'),
-      transactionDetails: z.enum(['full', 'signatures', 'accounts', 'none']).optional().default('full'),
+      commitment: z.string().optional().default('confirmed'),
+      encoding: z.string().optional().default('jsonParsed'),
+      transactionDetails: z.string().optional().default('full'),
       showRewards: z.boolean().optional().default(false),
       maxSupportedTransactionVersion: z.number().optional().default(0)
     },
     async (params) => {
+      let err;
+      err = validateEnum(params.commitment, ['processed', 'confirmed', 'finalized'], 'Transaction Subscribe Error', 'commitment');
+      if (err) return err;
+      err = validateEnum(params.encoding, ['base58', 'base64', 'jsonParsed'], 'Transaction Subscribe Error', 'encoding');
+      if (err) return err;
+      err = validateEnum(params.transactionDetails, ['full', 'signatures', 'accounts', 'none'], 'Transaction Subscribe Error', 'transactionDetails');
+      if (err) return err;
+
+      // Collect warnings for config issues that would fail at runtime
+      const warnings: string[] = [];
+
+      const addressArrays: [string, string[] | undefined][] = [
+        ['accountInclude', params.accountInclude],
+        ['accountExclude', params.accountExclude],
+        ['accountRequired', params.accountRequired],
+      ];
+      for (const [name, arr] of addressArrays) {
+        if (arr) {
+          if (arr.length === 0) {
+            warnings.push(`${name} is an empty array. This filter will have no effect.`);
+          } else {
+            warnings.push(...warnInvalidAddresses(name, arr));
+          }
+        }
+      }
+
+      const conflict = warnAddressConflicts('accountInclude', params.accountInclude, 'accountExclude', params.accountExclude);
+      if (conflict) warnings.push(conflict);
+
+      if (!params.accountInclude && !params.accountExclude && !params.accountRequired && !params.signature) {
+        warnings.push('No account filters or signature specified. This will stream ALL transactions on the network, which produces very high volume. Consider adding filters to reduce traffic.');
+      }
+
       try {
         const wsUrl = getEnhancedWebSocketUrl();
 
@@ -51,6 +85,15 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
           '',
           `**URL:** \`${wsUrl}\``,
           '',
+        ];
+
+        if (warnings.length > 0) {
+          lines.push('**Warnings:**');
+          warnings.forEach(w => lines.push(`- ${w}`));
+          lines.push('');
+        }
+
+        lines.push(
           '**Subscription Request:**',
           '```json',
           JSON.stringify(subscriptionRequest, null, 2),
@@ -70,12 +113,11 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
           '  }',
           '});',
           '```',
-        ];
+        );
 
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error');
       }
     }
   );
@@ -85,10 +127,22 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
     'Get Enhanced WebSocket config for real-time Solana account monitoring. Track balance changes and data updates. Business+ plans only. Returns connection config and code example.',
     {
       account: z.string().describe('Account public key (base58)'),
-      encoding: z.enum(['base58', 'base64', 'base64+zstd', 'jsonParsed']).optional().default('base58'),
-      commitment: z.enum(['finalized', 'confirmed', 'processed']).optional().default('finalized')
+      encoding: z.string().optional().default('base58'),
+      commitment: z.string().optional().default('finalized')
     },
     async ({ account, encoding, commitment }) => {
+      let err;
+      err = validateEnum(encoding, ['base58', 'base64', 'base64+zstd', 'jsonParsed'], 'Account Subscribe Error', 'encoding');
+      if (err) return err;
+      err = validateEnum(commitment, ['finalized', 'confirmed', 'processed'], 'Account Subscribe Error', 'commitment');
+      if (err) return err;
+
+      // Collect warnings for config issues that would fail at runtime
+      const warnings: string[] = [];
+
+      const addrWarning = warnInvalidAddress('account', account);
+      if (addrWarning) warnings.push(addrWarning);
+
       try {
         const wsUrl = getEnhancedWebSocketUrl();
 
@@ -104,6 +158,15 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
           `**Account:** \`${account}\``,
           `**URL:** \`${wsUrl}\``,
           '',
+        ];
+
+        if (warnings.length > 0) {
+          lines.push('**Warnings:**');
+          warnings.forEach(w => lines.push(`- ${w}`));
+          lines.push('');
+        }
+
+        lines.push(
           '**Subscription Request:**',
           '```json',
           JSON.stringify(subscriptionRequest, null, 2),
@@ -123,12 +186,11 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
           '  }',
           '});',
           '```',
-        ];
+        );
 
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error');
       }
     }
   );
@@ -153,10 +215,9 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
           '',
           '**Docs:** https://www.helius.dev/docs/enhanced-websockets',
         ];
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error');
       }
     }
   );

--- a/helius-mcp/src/tools/fees.ts
+++ b/helius-mcp/src/tools/fees.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { hasApiKey, getRpcUrl } from '../utils/helius.js';
 import { noApiKeyResponse } from './shared.js';
+import { mcpText, validateEnum, handleToolError } from '../utils/errors.js';
 
 export function registerFeeTools(server: McpServer) {
   // Get Priority Fee Estimate
@@ -10,11 +11,16 @@ export function registerFeeTools(server: McpServer) {
     'Get optimal priority fee estimates for Solana transactions. Returns recommended fees in microlamports for different priority levels (Min, Low, Medium, High, VeryHigh, UnsafeMax). Essential for ensuring transaction confirmation during network congestion.',
     {
       accountKeys: z.array(z.string()).optional().describe('Account addresses involved in transaction for more accurate estimates'),
-      priorityLevel: z.enum(['Min', 'Low', 'Medium', 'High', 'VeryHigh', 'UnsafeMax']).optional().describe('Desired priority level'),
+      priorityLevel: z.string().optional().describe('Desired priority level'),
       includeAllLevels: z.boolean().optional().default(true).describe('Return fees for all priority levels')
     },
     async ({ accountKeys, priorityLevel, includeAllLevels }) => {
       if (!hasApiKey()) return noApiKeyResponse();
+
+      if (priorityLevel) {
+        const err = validateEnum(priorityLevel, ['Min', 'Low', 'Medium', 'High', 'VeryHigh', 'UnsafeMax'], 'Priority Fee Estimate', 'priority level');
+        if (err) return err;
+      }
 
       const url = getRpcUrl();
 
@@ -59,59 +65,48 @@ export function registerFeeTools(server: McpServer) {
         }]
       };
 
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody)
-      });
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody)
+        });
 
-      const data = await response.json() as PriorityFeeResponse;
+        const data = await response.json() as PriorityFeeResponse;
 
-      if (data.error) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Priority Fee Estimate Error**\n\n${data.error.message}`
-          }]
-        };
+        if (data.error) {
+          return mcpText(`**Priority Fee Estimate Error**\n\n${data.error.message}`);
+        }
+
+        const result = data.result;
+        if (!result) {
+          return mcpText(`**Priority Fee Estimate**\n\nNo fee data available.`);
+        }
+
+        const lines = ['**Priority Fee Estimate**', ''];
+
+        if (result.priorityFeeLevels) {
+          const levels = result.priorityFeeLevels;
+          lines.push('| Level | Fee (microlamports) |');
+          lines.push('|-------|-------------------|');
+          lines.push(`| Min | ${levels.min.toLocaleString()} |`);
+          lines.push(`| Low | ${levels.low.toLocaleString()} |`);
+          lines.push(`| Medium | ${levels.medium.toLocaleString()} |`);
+          lines.push(`| High | ${levels.high.toLocaleString()} |`);
+          lines.push(`| Very High | ${levels.veryHigh.toLocaleString()} |`);
+          lines.push(`| Unsafe Max | ${levels.unsafeMax.toLocaleString()} |`);
+        } else if (result.priorityFeeEstimate !== undefined) {
+          lines.push(`**Estimated Fee:** ${result.priorityFeeEstimate.toLocaleString()} microlamports`);
+        }
+
+        if (accountKeys && accountKeys.length > 0) {
+          lines.push('', `*Estimate based on ${accountKeys.length} account(s)*`);
+        }
+
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching priority fee estimate');
       }
-
-      const result = data.result;
-      if (!result) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Priority Fee Estimate**\n\nNo fee data available.`
-          }]
-        };
-      }
-
-      const lines = ['**Priority Fee Estimate**', ''];
-
-      if (result.priorityFeeLevels) {
-        const levels = result.priorityFeeLevels;
-        lines.push('| Level | Fee (microlamports) |');
-        lines.push('|-------|-------------------|');
-        lines.push(`| Min | ${levels.min.toLocaleString()} |`);
-        lines.push(`| Low | ${levels.low.toLocaleString()} |`);
-        lines.push(`| Medium | ${levels.medium.toLocaleString()} |`);
-        lines.push(`| High | ${levels.high.toLocaleString()} |`);
-        lines.push(`| Very High | ${levels.veryHigh.toLocaleString()} |`);
-        lines.push(`| Unsafe Max | ${levels.unsafeMax.toLocaleString()} |`);
-      } else if (result.priorityFeeEstimate !== undefined) {
-        lines.push(`**Estimated Fee:** ${result.priorityFeeEstimate.toLocaleString()} microlamports`);
-      }
-
-      if (accountKeys && accountKeys.length > 0) {
-        lines.push('', `*Estimate based on ${accountKeys.length} account(s)*`);
-      }
-
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
     }
   );
 }

--- a/helius-mcp/src/tools/laserstream.ts
+++ b/helius-mcp/src/tools/laserstream.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { getLaserstreamUrl, getNetwork } from '../utils/helius.js';
+import { mcpText, validateEnum, handleToolError, warnInvalidAddresses, warnAddressConflicts } from '../utils/errors.js';
 
 export function registerLaserstreamTools(server: McpServer) {
 
@@ -8,8 +9,8 @@ export function registerLaserstreamTools(server: McpServer) {
     'laserstreamSubscribe',
     'Get Laserstream gRPC config for high-performance Solana streaming. Subscribe to slots, accounts, transactions, blocks, or entries. 24h historical replay. Professional plan for mainnet. Returns connection config and code example.',
     {
-      region: z.enum(['ewr', 'pitt', 'slc', 'lax', 'lon', 'ams', 'fra', 'tyo', 'sgp']).optional().default('ewr'),
-      commitment: z.enum(['processed', 'confirmed', 'finalized']).optional(),
+      region: z.string().optional().default('ewr'),
+      commitment: z.string().optional(),
       subscribeSlots: z.boolean().optional(),
       filterByCommitment: z.boolean().optional(),
       subscribeAccounts: z.array(z.string()).optional().describe('Account public keys to watch'),
@@ -25,9 +26,74 @@ export function registerLaserstreamTools(server: McpServer) {
       keepalive: z.boolean().optional().default(true)
     },
     async (params) => {
+      let err;
+      err = validateEnum(params.region, ['ewr', 'pitt', 'slc', 'lax', 'lon', 'ams', 'fra', 'tyo', 'sgp'], 'Laserstream Error', 'region');
+      if (err) return err;
+      if (params.commitment) {
+        err = validateEnum(params.commitment, ['processed', 'confirmed', 'finalized'], 'Laserstream Error', 'commitment');
+        if (err) return err;
+      }
+
+      // Validate fromSlot is a non-negative integer string
+      if (params.fromSlot !== undefined) {
+        const slotNum = Number(params.fromSlot);
+        if (!Number.isInteger(slotNum) || slotNum < 0) {
+          return mcpText(`**Laserstream Error**\n\nInvalid fromSlot "${params.fromSlot}". Must be a non-negative integer slot number.`);
+        }
+      }
+
+      // Check that at least one subscription type is selected
+      const hasSubscription = params.subscribeSlots || params.subscribeAccounts || params.accountOwners
+        || params.subscribeTransactions || params.transactionAccountInclude || params.transactionAccountExclude || params.transactionAccountRequired
+        || params.subscribeBlocks || params.subscribeBlocksMeta || params.subscribeEntries;
+
+      // Collect warnings for config issues that would fail at runtime
+      const warnings: string[] = [];
+
+      if (!hasSubscription) {
+        warnings.push('No subscription type selected. You must subscribe to at least one of: slots, accounts, transactions, blocks, blocksMeta, or entries.');
+      }
+
+      if (params.filterByCommitment && !params.commitment) {
+        warnings.push('filterByCommitment is set but no commitment level was provided. Add commitment ("processed", "confirmed", or "finalized") for filtering to take effect.');
+      }
+
+      if (params.keepalive === false) {
+        warnings.push('keepalive=false: The gRPC connection will not send keepalive pings. This may cause disconnects on idle streams. The default (true) is recommended.');
+      }
+
+      // Validate address arrays for empty/blank and invalid format
+      const addressArrays: [string, string[] | undefined][] = [
+        ['subscribeAccounts', params.subscribeAccounts],
+        ['accountOwners', params.accountOwners],
+        ['transactionAccountInclude', params.transactionAccountInclude],
+        ['transactionAccountExclude', params.transactionAccountExclude],
+        ['transactionAccountRequired', params.transactionAccountRequired],
+      ];
+      for (const [name, arr] of addressArrays) {
+        if (arr) {
+          if (arr.length === 0) {
+            warnings.push(`${name} is an empty array. This filter will have no effect.`);
+          } else {
+            warnings.push(...warnInvalidAddresses(name, arr));
+          }
+        }
+      }
+
+      const conflict = warnAddressConflicts('transactionAccountInclude', params.transactionAccountInclude, 'transactionAccountExclude', params.transactionAccountExclude);
+      if (conflict) warnings.push(conflict);
+
+      if (params.subscribeTransactions && !params.transactionAccountInclude && !params.transactionAccountExclude && !params.transactionAccountRequired) {
+        warnings.push('subscribeTransactions is enabled with no account filters. This will stream ALL transactions on the network, which produces extremely high volume. Consider adding transactionAccountInclude or transactionAccountRequired filters.');
+      }
+
+      if (params.fromSlot !== undefined && Number(params.fromSlot) === 0) {
+        warnings.push('fromSlot is 0 (genesis). Laserstream only supports 24h historical replay (~216,000 slots). Use a recent slot number for replay.');
+      }
+
       try {
         const network = getNetwork();
-        const endpoint = getLaserstreamUrl(params.region);
+        const endpoint = getLaserstreamUrl(params.region as 'ewr' | 'pitt' | 'slc' | 'lax' | 'lon' | 'ams' | 'fra' | 'tyo' | 'sgp');
         const sub: any = {};
 
         if (params.subscribeSlots) sub.slots = { filterByCommitment: params.filterByCommitment };
@@ -47,6 +113,7 @@ export function registerLaserstreamTools(server: McpServer) {
         if (params.subscribeEntries) sub.entries = {};
         if (params.commitment) sub.commitment = params.commitment.toUpperCase();
         if (params.fromSlot) sub.fromSlot = params.fromSlot;
+        if (params.keepalive === false) sub.keepalive = false;
 
         const lines = [
           '**Laserstream gRPC Subscription**',
@@ -54,6 +121,15 @@ export function registerLaserstreamTools(server: McpServer) {
           `**Network:** ${network}`,
           `**Endpoint:** \`${endpoint}\``,
           '',
+        ];
+
+        if (warnings.length > 0) {
+          lines.push('**Warnings:**');
+          warnings.forEach(w => lines.push(`- ${w}`));
+          lines.push('');
+        }
+
+        lines.push(
           '**Config:**',
           '```json',
           JSON.stringify(sub, null, 2),
@@ -63,7 +139,7 @@ export function registerLaserstreamTools(server: McpServer) {
           '```typescript',
           'import { subscribe } from "@helius/laserstream";',
           '',
-          'await subscribe(', 
+          'await subscribe(',
           `  { apiKey: process.env.HELIUS_API_KEY, endpoint: "${endpoint}" },`,
           '  ' + JSON.stringify(sub) + ',',
           '  (data) => console.log("Update:", data),',
@@ -73,12 +149,11 @@ export function registerLaserstreamTools(server: McpServer) {
           '',
           '**SDK:** npm install @helius/laserstream',
           '**Docs:** https://www.helius.dev/docs/laserstream/grpc',
-        ];
+        );
 
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error');
       }
     }
   );
@@ -108,10 +183,9 @@ export function registerLaserstreamTools(server: McpServer) {
           '**SDKs:** TypeScript (@helius/laserstream), Rust (helius-laserstream), Go (laserstream-go)',
           '**Docs:** https://www.helius.dev/docs/laserstream/grpc',
         ];
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error');
       }
     }
   );

--- a/helius-mcp/src/tools/network.ts
+++ b/helius-mcp/src/tools/network.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { hasApiKey, getRpcUrl } from '../utils/helius.js';
 import { formatSolCompact } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
+import { getErrorMessage, handleToolError } from '../utils/errors.js';
 
 export function registerNetworkTools(server: McpServer) {
   server.tool(
@@ -14,17 +15,21 @@ export function registerNetworkTools(server: McpServer) {
       const url = getRpcUrl();
 
       const makeRequest = async (method: string, params: unknown[] = []) => {
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: method,
-            method,
-            params
-          })
-        });
-        return response.json();
+        try {
+          const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: method,
+              method,
+              params
+            })
+          });
+          return await response.json();
+        } catch (err) {
+          throw new Error(`RPC ${method} failed: ${getErrorMessage(err)}`);
+        }
       };
 
       type EpochInfo = {
@@ -49,70 +54,74 @@ export function registerNetworkTools(server: McpServer) {
         'feature-set': number;
       };
 
-      // Fire all requests in parallel
-      const [epochRes, supplyRes, versionRes] = await Promise.all([
-        makeRequest('getEpochInfo'),
-        makeRequest('getSupply'),
-        makeRequest('getVersion')
-      ]) as [
-        { result: EpochInfo; error?: { message: string } },
-        { result: SupplyResult; error?: { message: string } },
-        { result: VersionResult; error?: { message: string } }
-      ];
+      try {
+        // Fire all requests in parallel
+        const [epochRes, supplyRes, versionRes] = await Promise.all([
+          makeRequest('getEpochInfo'),
+          makeRequest('getSupply'),
+          makeRequest('getVersion')
+        ]) as [
+          { result: EpochInfo; error?: { message: string } },
+          { result: SupplyResult; error?: { message: string } },
+          { result: VersionResult; error?: { message: string } }
+        ];
 
-      // Check for errors
-      const errors: string[] = [];
-      if (epochRes.error) errors.push(`Epoch info: ${epochRes.error.message}`);
-      if (supplyRes.error) errors.push(`Supply: ${supplyRes.error.message}`);
-      if (versionRes.error) errors.push(`Version: ${versionRes.error.message}`);
+        // Check for errors
+        const errors: string[] = [];
+        if (epochRes.error) errors.push(`Epoch info: ${epochRes.error.message}`);
+        if (supplyRes.error) errors.push(`Supply: ${supplyRes.error.message}`);
+        if (versionRes.error) errors.push(`Version: ${versionRes.error.message}`);
 
-      if (errors.length === 3) {
+        if (errors.length === 3) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `**Network Status Error**\n\n${errors.join('\n')}`
+            }]
+          };
+        }
+
+        const lines = ['**Solana Network Status**', ''];
+
+        // Epoch info
+        if (epochRes.result) {
+          const epoch = epochRes.result;
+          const epochProgress = ((epoch.slotIndex / epoch.slotsInEpoch) * 100).toFixed(1);
+          lines.push('**Epoch:**');
+          lines.push(`- Current Epoch: ${epoch.epoch}`);
+          lines.push(`- Progress: ${epochProgress}% (slot ${epoch.slotIndex.toLocaleString()} / ${epoch.slotsInEpoch.toLocaleString()})`);
+          lines.push(`- Absolute Slot: ${epoch.absoluteSlot.toLocaleString()}`);
+          lines.push(`- Block Height: ${epoch.blockHeight.toLocaleString()}`);
+          if (epoch.transactionCount !== null) {
+            lines.push(`- Transaction Count: ${epoch.transactionCount.toLocaleString()}`);
+          }
+          lines.push('');
+        }
+
+        // Supply
+        if (supplyRes.result) {
+          const supply = supplyRes.result.value;
+          lines.push('**SOL Supply:**');
+          lines.push(`- Total: ${formatSolCompact(supply.total)}`);
+          lines.push(`- Circulating: ${formatSolCompact(supply.circulating)}`);
+          lines.push(`- Non-Circulating: ${formatSolCompact(supply.nonCirculating)}`);
+          lines.push('');
+        }
+
+        // Version
+        if (versionRes.result) {
+          lines.push(`**Cluster Version:** ${versionRes.result['solana-core']}`);
+        }
+
         return {
           content: [{
             type: 'text' as const,
-            text: `**Network Status Error**\n\n${errors.join('\n')}`
+            text: lines.join('\n')
           }]
         };
+      } catch (err) {
+        return handleToolError(err, 'Error fetching network status');
       }
-
-      const lines = ['**Solana Network Status**', ''];
-
-      // Epoch info
-      if (epochRes.result) {
-        const epoch = epochRes.result;
-        const epochProgress = ((epoch.slotIndex / epoch.slotsInEpoch) * 100).toFixed(1);
-        lines.push('**Epoch:**');
-        lines.push(`- Current Epoch: ${epoch.epoch}`);
-        lines.push(`- Progress: ${epochProgress}% (slot ${epoch.slotIndex.toLocaleString()} / ${epoch.slotsInEpoch.toLocaleString()})`);
-        lines.push(`- Absolute Slot: ${epoch.absoluteSlot.toLocaleString()}`);
-        lines.push(`- Block Height: ${epoch.blockHeight.toLocaleString()}`);
-        if (epoch.transactionCount !== null) {
-          lines.push(`- Transaction Count: ${epoch.transactionCount.toLocaleString()}`);
-        }
-        lines.push('');
-      }
-
-      // Supply
-      if (supplyRes.result) {
-        const supply = supplyRes.result.value;
-        lines.push('**SOL Supply:**');
-        lines.push(`- Total: ${formatSolCompact(supply.total)}`);
-        lines.push(`- Circulating: ${formatSolCompact(supply.circulating)}`);
-        lines.push(`- Non-Circulating: ${formatSolCompact(supply.nonCirculating)}`);
-        lines.push('');
-      }
-
-      // Version
-      if (versionRes.result) {
-        lines.push(`**Cluster Version:** ${versionRes.result['solana-core']}`);
-      }
-
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
     }
   );
 }

--- a/helius-mcp/src/tools/tokens.ts
+++ b/helius-mcp/src/tools/tokens.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatAddress, formatTokenAmount } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
+import { mcpText, handleToolError, addressError } from '../utils/errors.js';
 
 export function registerTokenTools(server: McpServer) {
   server.tool(
@@ -16,11 +17,18 @@ export function registerTokenTools(server: McpServer) {
       const helius = getHeliusClient();
 
       // Use getTokenAccounts to find top holders
-      const response = await helius.getTokenAccounts({
-        mint,
-        page: 1,
-        limit: 20
-      });
+      let response;
+      try {
+        response = await helius.getTokenAccounts({
+          mint,
+          page: 1,
+          limit: 20
+        });
+      } catch (err) {
+        return handleToolError(err, 'Error fetching token holders', [
+          addressError(`Token Holders for ${formatAddress(mint || '(empty)')}`, 'Invalid Solana address. Please provide a valid base58-encoded mint address.'),
+        ]);
+      }
 
       type TokenAccount = {
         address: string;
@@ -33,12 +41,7 @@ export function registerTokenTools(server: McpServer) {
       const items = (response.token_accounts || []) as TokenAccount[];
 
       if (items.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Token Holders for ${formatAddress(mint)}**\n\nNo holders found.`
-          }]
-        };
+        return mcpText(`**Token Holders for ${formatAddress(mint)}**\n\nNo holders found.`);
       }
 
       // Sort by amount descending (largest holders first)
@@ -77,12 +80,7 @@ export function registerTokenTools(server: McpServer) {
         lines.push(`${idx + 1}. **${formatAddress(account.owner)}** — ${formattedAmount} ${symbol || ''}${flagStr}`);
       });
 
-      return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
-      };
+      return mcpText(lines.join('\n'));
     }
   );
 }

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getHeliusClient, hasApiKey, getRpcUrl } from '../utils/helius.js';
 import { formatSol, formatAddress, formatTimestamp, LAMPORTS_PER_SOL } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
+import { mcpText, getErrorMessage, validateEnum, handleToolError, http400Error } from '../utils/errors.js';
 import bs58 from 'bs58';
 
 // ─── Shared Types ───
@@ -195,9 +196,19 @@ async function fetchTokenMetadata(
   const metadata = new Map<string, AssetInfo>();
   if (mints.size === 0) return metadata;
 
-  const assets = await helius.getAssetBatch({ ids: [...mints] });
-  for (const asset of assets as AssetInfo[]) {
-    if (asset?.id) metadata.set(asset.id, asset);
+  // Filter out empty/invalid mint strings before calling the API
+  const validMints = [...mints].filter(m => m && m.trim().length > 0);
+  if (validMints.length === 0) return metadata;
+
+  try {
+    const assets = await helius.getAssetBatch({ ids: validMints });
+    for (const asset of assets as AssetInfo[]) {
+      if (asset?.id) metadata.set(asset.id, asset);
+    }
+  } catch {
+    // If batch fails (e.g. invalid pubkeys in mint list), return empty metadata
+    // rather than crashing the entire tool call
+    return metadata;
   }
 
   // Enrich tokens missing symbol/name (batch response can have incomplete metadata)
@@ -293,12 +304,7 @@ export function registerTransactionTools(server: McpServer) {
       if (validSigs.length === 0) {
         const lines = ['**Invalid Signature Format**', '', 'None of the provided signatures are valid base58-encoded transaction signatures (expected 86-88 characters).', ''];
         invalidSigs.forEach(sig => lines.push(`- \`${sig}\``));
-        return {
-          content: [{
-            type: 'text' as const,
-            text: lines.join('\n')
-          }]
-        };
+        return mcpText(lines.join('\n'));
       }
 
       let transactions: EnrichedTransaction[];
@@ -307,12 +313,9 @@ export function registerTransactionTools(server: McpServer) {
           transactions: validSigs
         }) as EnrichedTransaction[];
       } catch (err) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error fetching transactions:** ${err instanceof Error ? err.message : String(err)}`
-          }]
-        };
+        return handleToolError(err, 'Error fetching transactions', [
+          http400Error('Parse Transactions Error'),
+        ]);
       }
 
       // Identify valid signatures that weren't returned (not found on-chain)
@@ -330,12 +333,7 @@ export function registerTransactionTools(server: McpServer) {
           lines.push('**Not found on Solana mainnet** (may be pending, very old, or nonexistent):');
           notFoundSigs.forEach(sig => lines.push(`- \`${sig}\``));
         }
-        return {
-          content: [{
-            type: 'text' as const,
-            text: lines.join('\n')
-          }]
-        };
+        return mcpText(lines.join('\n'));
       }
 
       const tokenMetadata = await fetchTokenMetadata(helius, collectMints(transactions));
@@ -517,12 +515,7 @@ export function registerTransactionTools(server: McpServer) {
       }
 
       const fullText = outputLines.join('\n');
-      return {
-        content: [{
-          type: 'text' as const,
-          text: truncateResponse(fullText)
-        }]
-      };
+      return mcpText(truncateResponse(fullText));
     }
   );
 
@@ -532,15 +525,15 @@ export function registerTransactionTools(server: McpServer) {
     'Get transaction history for a Solana wallet. Supports three modes: "parsed" (default) returns human-readable decoded data with types, descriptions, actions, and fees. "signatures" returns a lightweight list of transaction signatures with slot/time/status. "raw" returns full raw data with advanced Helius filters (time/slot ranges, status, token accounts). All modes support sortOrder="asc" for finding wallet funding sources — no pagination needed. By default only successful transactions are shown; set status="any" or status="failed" to include failed ones.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
-      mode: z.enum(['parsed', 'signatures', 'raw']).optional().default('parsed').describe('"parsed" = decoded human-readable history (default), "signatures" = lightweight signature list, "raw" = full data with advanced Helius filters'),
+      mode: z.string().optional().default('parsed').describe('"parsed" = decoded human-readable history (default), "signatures" = lightweight signature list, "raw" = full data with advanced Helius filters'),
       limit: z.number().optional().default(10).describe('Number of results (1-1000 for signatures, 1-100 for full/parsed)'),
-      sortOrder: z.enum(['asc', 'desc']).optional().default('desc').describe('"desc" = newest first (default), "asc" = oldest first (great for finding funding sources)'),
+      sortOrder: z.string().optional().default('desc').describe('"desc" = newest first (default), "asc" = oldest first (great for finding funding sources)'),
       before: z.string().optional().describe('[signatures mode, desc only] Cursor: start searching backwards from this signature'),
       until: z.string().optional().describe('[signatures mode, desc only] Cursor: search until this signature'),
       paginationToken: z.string().optional().describe('Pagination token from previous response for fetching next page'),
-      transactionDetails: z.enum(['signatures', 'full']).optional().default('signatures').describe('[raw mode] "signatures" for basic info (up to 1000), "full" for complete transaction data (up to 100)'),
-      status: z.enum(['succeeded', 'failed', 'any']).optional().default('succeeded').describe('Filter by transaction status. Defaults to "succeeded" — set to "failed" or "any" to include failed transactions.'),
-      tokenAccounts: z.enum(['none', 'balanceChanged', 'all']).optional().describe('"none" = only direct transactions, "balanceChanged" = include token transfers, "all" = all token account activity'),
+      transactionDetails: z.string().optional().default('signatures').describe('[raw mode] "signatures" for basic info (up to 1000), "full" for complete transaction data (up to 100)'),
+      status: z.string().optional().default('succeeded').describe('Filter by transaction status. Defaults to "succeeded" — set to "failed" or "any" to include failed transactions.'),
+      tokenAccounts: z.string().optional().describe('"none" = only direct transactions, "balanceChanged" = include token transfers, "all" = all token account activity'),
       blockTimeGte: z.number().optional().describe('Filter: block time >= this Unix timestamp'),
       blockTimeLte: z.number().optional().describe('Filter: block time <= this Unix timestamp'),
       slotGte: z.number().optional().describe('Filter: slot >= this value'),
@@ -548,6 +541,20 @@ export function registerTransactionTools(server: McpServer) {
     },
     async ({ address, mode, limit, sortOrder, before, until, paginationToken, transactionDetails, status, tokenAccounts, blockTimeGte, blockTimeLte, slotGte, slotLte }) => {
       if (!hasApiKey()) return noApiKeyResponse();
+
+      let err;
+      err = validateEnum(mode, ['parsed', 'signatures', 'raw'], 'Transaction History Error', 'mode');
+      if (err) return err;
+      err = validateEnum(sortOrder, ['asc', 'desc'], 'Transaction History Error', 'sortOrder');
+      if (err) return err;
+      err = validateEnum(transactionDetails, ['signatures', 'full'], 'Transaction History Error', 'transactionDetails');
+      if (err) return err;
+      err = validateEnum(status, ['succeeded', 'failed', 'any'], 'Transaction History Error', 'status');
+      if (err) return err;
+      if (tokenAccounts) {
+        err = validateEnum(tokenAccounts, ['none', 'balanceChanged', 'all'], 'Transaction History Error', 'tokenAccounts');
+        if (err) return err;
+      }
 
       // Build filters object (shared across modes that use getTransactionsForAddress)
       type Filters = {
@@ -609,23 +616,13 @@ export function registerTransactionTools(server: McpServer) {
 
             const json = await response.json() as { result?: SignatureInfo[]; error?: { message: string } };
             if (json.error) {
-              return {
-                content: [{
-                  type: 'text' as const,
-                  text: `Error fetching signatures: ${json.error.message}`
-                }]
-              };
+              return mcpText(`Error fetching signatures: ${json.error.message}`);
             }
 
             const sigs = json.result || [];
 
             if (sigs.length === 0) {
-              return {
-                content: [{
-                  type: 'text' as const,
-                  text: `**Signatures for ${formatAddress(address)}**\n\nNo signatures found.`
-                }]
-              };
+              return mcpText(`**Signatures for ${formatAddress(address)}**\n\nNo signatures found.`);
             }
 
             const lines = [`**Signatures for ${formatAddress(address)}** (${sigs.length} results, newest first${statusNote})`, ''];
@@ -640,160 +637,129 @@ export function registerTransactionTools(server: McpServer) {
               }
             });
 
-            return {
-              content: [{
-                type: 'text' as const,
-                text: lines.join('\n')
-              }]
-            };
+            return mcpText(lines.join('\n'));
           } catch (err) {
-            return {
-              content: [{
-                type: 'text' as const,
-                text: `Error fetching signatures: ${err instanceof Error ? err.message : String(err)}`
-              }]
-            };
+            return handleToolError(err, 'Error fetching signatures');
           }
         }
 
         // Full path: getTransactionsForAddress — needed for asc sort, filters, or paginationToken
-        const data = await fetchTransactionsForAddress(address, {
-          transactionDetails: 'signatures',
-          sortOrder,
-          limit,
-          ...(paginationToken && { paginationToken }),
-          ...(Object.keys(filters).length > 0 && { filters })
-        });
+        try {
+          const data = await fetchTransactionsForAddress(address, {
+            transactionDetails: 'signatures',
+            sortOrder,
+            limit,
+            ...(paginationToken && { paginationToken }),
+            ...(Object.keys(filters).length > 0 && { filters })
+          });
 
-        if (data.error) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Error**\n\n${data.error.message}`
-            }]
-          };
-        }
-
-        const result = data.result;
-        if (!result || !result.data || result.data.length === 0) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Signatures for ${formatAddress(address)}**\n\nNo signatures found.`
-            }]
-          };
-        }
-
-        const items = result.data as SignatureResult[];
-        const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
-        const lines = [`**Signatures for ${formatAddress(address)}** (${items.length} results, ${orderLabel}${statusNote})`, ''];
-
-        items.forEach((item) => {
-          const txStatus = item.err ? '❌' : '✅';
-          const time = item.blockTime ? new Date(item.blockTime * 1000).toISOString() : 'N/A';
-          lines.push(`${txStatus} ${item.signature}`);
-          lines.push(`   Slot: ${item.slot.toLocaleString()} | Time: ${time}`);
-          if (item.memo) {
-            lines.push(`   Memo: ${item.memo}`);
+          if (data.error) {
+            return mcpText(`**Error**\n\n${data.error.message}`);
           }
-        });
 
-        if (result.paginationToken) {
-          lines.push('', `**Next Page Token:** \`${result.paginationToken}\``);
-        }
+          const result = data.result;
+          if (!result || !result.data || result.data.length === 0) {
+            return mcpText(`**Signatures for ${formatAddress(address)}**\n\nNo signatures found.`);
+          }
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: lines.join('\n')
-          }]
-        };
-      }
-
-      // ─── RAW MODE ───
-      if (mode === 'raw') {
-        const data = await fetchTransactionsForAddress(address, {
-          transactionDetails: transactionDetails! as 'signatures' | 'full',
-          sortOrder,
-          limit,
-          ...(paginationToken && { paginationToken }),
-          ...(Object.keys(filters).length > 0 && { filters })
-        });
-
-        if (data.error) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Error**\n\n${data.error.message}`
-            }]
-          };
-        }
-
-        const result = data.result;
-        if (!result || !result.data || result.data.length === 0) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Transactions for ${formatAddress(address)}**\n\nNo transactions found.`
-            }]
-          };
-        }
-
-        const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
-        const lines = [`**Transactions for ${formatAddress(address)}** (${result.data.length} results, ${orderLabel}${statusNote})`, ''];
-
-        if (transactionDetails === 'signatures') {
           const items = result.data as SignatureResult[];
+          const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
+          const lines = [`**Signatures for ${formatAddress(address)}** (${items.length} results, ${orderLabel}${statusNote})`, ''];
+
           items.forEach((item) => {
             const txStatus = item.err ? '❌' : '✅';
             const time = item.blockTime ? new Date(item.blockTime * 1000).toISOString() : 'N/A';
             lines.push(`${txStatus} ${item.signature}`);
-            lines.push(`   Slot: ${item.slot.toLocaleString()} | Index: ${item.transactionIndex} | Time: ${time}`);
+            lines.push(`   Slot: ${item.slot.toLocaleString()} | Time: ${time}`);
             if (item.memo) {
               lines.push(`   Memo: ${item.memo}`);
             }
           });
-        } else {
-          const items = result.data as FullResult[];
-          items.forEach((item) => {
-            const sig = item.transaction.signatures[0];
-            const txStatus = item.meta.err ? '❌' : '✅';
-            const time = item.blockTime ? new Date(item.blockTime * 1000).toISOString() : 'N/A';
-            const fee = formatSol(item.meta.fee);
 
-            lines.push(`${txStatus} ${sig}`);
-            lines.push(`   Slot: ${item.slot.toLocaleString()} | Index: ${item.transactionIndex} | Time: ${time}`);
-            lines.push(`   Fee: ${fee}`);
+          if (result.paginationToken) {
+            lines.push('', `**Next Page Token:** \`${result.paginationToken}\``);
+          }
 
-            // Show balance changes
-            const balanceChanges: string[] = [];
-            item.meta.preBalances.forEach((pre, idx) => {
-              const post = item.meta.postBalances[idx];
-              const change = post - pre;
-              if (change !== 0) {
-                const changeStr = change > 0 ? `+${formatSol(change)}` : formatSol(change);
-                balanceChanges.push(changeStr);
+          return mcpText(lines.join('\n'));
+        } catch (err) {
+          return handleToolError(err, 'Error fetching signatures');
+        }
+      }
+
+      // ─── RAW MODE ───
+      if (mode === 'raw') {
+        try {
+          const data = await fetchTransactionsForAddress(address, {
+            transactionDetails: transactionDetails! as 'signatures' | 'full',
+            sortOrder,
+            limit,
+            ...(paginationToken && { paginationToken }),
+            ...(Object.keys(filters).length > 0 && { filters })
+          });
+
+          if (data.error) {
+            return mcpText(`**Error**\n\n${data.error.message}`);
+          }
+
+          const result = data.result;
+          if (!result || !result.data || result.data.length === 0) {
+            return mcpText(`**Transactions for ${formatAddress(address)}**\n\nNo transactions found.`);
+          }
+
+          const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
+          const lines = [`**Transactions for ${formatAddress(address)}** (${result.data.length} results, ${orderLabel}${statusNote})`, ''];
+
+          if (transactionDetails === 'signatures') {
+            const items = result.data as SignatureResult[];
+            items.forEach((item) => {
+              const txStatus = item.err ? '❌' : '✅';
+              const time = item.blockTime ? new Date(item.blockTime * 1000).toISOString() : 'N/A';
+              lines.push(`${txStatus} ${item.signature}`);
+              lines.push(`   Slot: ${item.slot.toLocaleString()} | Index: ${item.transactionIndex} | Time: ${time}`);
+              if (item.memo) {
+                lines.push(`   Memo: ${item.memo}`);
               }
             });
-            if (balanceChanges.length > 0) {
-              lines.push(`   Balance changes: ${balanceChanges.slice(0, 3).join(', ')}${balanceChanges.length > 3 ? '...' : ''}`);
-            }
-          });
-        }
+          } else {
+            const items = result.data as FullResult[];
+            items.forEach((item) => {
+              const sig = item.transaction.signatures[0];
+              const txStatus = item.meta.err ? '❌' : '✅';
+              const time = item.blockTime ? new Date(item.blockTime * 1000).toISOString() : 'N/A';
+              const fee = formatSol(item.meta.fee);
 
-        if (result.paginationToken) {
-          lines.push('', `**Next Page Token:** \`${result.paginationToken}\``);
-        }
+              lines.push(`${txStatus} ${sig}`);
+              lines.push(`   Slot: ${item.slot.toLocaleString()} | Index: ${item.transactionIndex} | Time: ${time}`);
+              lines.push(`   Fee: ${fee}`);
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: lines.join('\n')
-          }]
-        };
+              // Show balance changes
+              const balanceChanges: string[] = [];
+              item.meta.preBalances.forEach((pre, idx) => {
+                const post = item.meta.postBalances[idx];
+                const change = post - pre;
+                if (change !== 0) {
+                  const changeStr = change > 0 ? `+${formatSol(change)}` : formatSol(change);
+                  balanceChanges.push(changeStr);
+                }
+              });
+              if (balanceChanges.length > 0) {
+                lines.push(`   Balance changes: ${balanceChanges.slice(0, 3).join(', ')}${balanceChanges.length > 3 ? '...' : ''}`);
+              }
+            });
+          }
+
+          if (result.paginationToken) {
+            lines.push('', `**Next Page Token:** \`${result.paginationToken}\``);
+          }
+
+          return mcpText(lines.join('\n'));
+        } catch (err) {
+          return handleToolError(err, 'Error fetching transactions');
+        }
       }
 
       // ─── PARSED MODE (default) ───
+      try {
       // Step 1: Use getTransactionsForAddress to get sorted signatures in one call
       const sigData = await fetchTransactionsForAddress(address, {
         transactionDetails: 'signatures',
@@ -804,23 +770,13 @@ export function registerTransactionTools(server: McpServer) {
       });
 
       if (sigData.error) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Error**\n\n${sigData.error.message}`
-          }]
-        };
+        return mcpText(`**Error**\n\n${sigData.error.message}`);
       }
 
       type SigItem = { signature: string };
       const sigResult = sigData.result;
       if (!sigResult || !sigResult.data || sigResult.data.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Transaction History for ${formatAddress(address)}**\n\nNo transactions found.`
-          }]
-        };
+        return mcpText(`**Transaction History for ${formatAddress(address)}**\n\nNo transactions found.`);
       }
 
       const sortedSigs = (sigResult.data as SigItem[]).map(item => item.signature);
@@ -839,12 +795,7 @@ export function registerTransactionTools(server: McpServer) {
       }
 
       if (allTransactions.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `**Transaction History for ${formatAddress(address)}**\n\nNo transactions could be enriched.`
-          }]
-        };
+        return mcpText(`**Transaction History for ${formatAddress(address)}**\n\nNo transactions could be enriched.`);
       }
 
       // Re-sort to match original order (Enhanced API may return in different order)
@@ -902,12 +853,10 @@ export function registerTransactionTools(server: McpServer) {
       }
 
       const fullText = lines.join('\n');
-      return {
-        content: [{
-          type: 'text' as const,
-          text: truncateResponse(fullText)
-        }]
-      };
+      return mcpText(truncateResponse(fullText));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching transaction history');
+      }
     }
   );
 }

--- a/helius-mcp/src/tools/wallet.ts
+++ b/helius-mcp/src/tools/wallet.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { hasApiKey, restRequest } from '../utils/helius.js';
 import { formatAddress, formatSol, formatTimestamp, LAMPORTS_PER_SOL } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
+import { mcpText, mcpError, validateEnum, handleToolError, http404Error, addressError } from '../utils/errors.js';
 
 export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Identity ───
@@ -25,13 +26,11 @@ export function registerWalletTools(server: McpServer) {
         if (data.category) lines.push(`**Category:** ${data.category}`);
         if (data.tags && data.tags.length > 0) lines.push(`**Tags:** ${data.tags.join(', ')}`);
 
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        if (errorMsg.includes('404')) {
-          return { content: [{ type: 'text' as const, text: `No identity found for ${formatAddress(address)}` }] };
-        }
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error', [
+          http404Error('', `No identity found for ${formatAddress(address)}`),
+        ]);
       }
     }
   );
@@ -47,35 +46,41 @@ export function registerWalletTools(server: McpServer) {
       if (!hasApiKey()) return noApiKeyResponse();
 
       if (addresses.length > 100) {
-        return { content: [{ type: 'text' as const, text: 'Error: Maximum 100 addresses per batch request.' }], isError: true };
+        return mcpError('Error: Maximum 100 addresses per batch request.');
       }
 
-      const data = await restRequest('/v1/wallet/batch-identity', {
-        method: 'POST',
-        body: JSON.stringify({ addresses })
-      });
+      try {
+        const data = await restRequest('/v1/wallet/batch-identity', {
+          method: 'POST',
+          body: JSON.stringify({ addresses })
+        });
 
-      const results = Array.isArray(data) ? data : [];
-      if (results.length === 0) {
-        return { content: [{ type: 'text' as const, text: `**Batch Identity Lookup** (${addresses.length} addresses)\n\nNo identities found.` }] };
-      }
-
-      const lines = [`**Batch Identity Lookup** (${results.length} results)`, ''];
-
-      for (const entry of results) {
-        const addr = formatAddress(entry.address || '');
-        if (entry.name) {
-          lines.push(`- **${entry.name}** — ${addr}`);
-          const details: string[] = [];
-          if (entry.type) details.push(entry.type);
-          if (entry.category) details.push(entry.category);
-          if (details.length > 0) lines.push(`  ${details.join(' | ')}`);
-        } else {
-          lines.push(`- ${addr} — Unknown`);
+        const results = Array.isArray(data) ? data : [];
+        if (results.length === 0) {
+          return mcpText(`**Batch Identity Lookup** (${addresses.length} addresses)\n\nNo identities found.`);
         }
-      }
 
-      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+        const lines = [`**Batch Identity Lookup** (${results.length} results)`, ''];
+
+        for (const entry of results) {
+          const addr = formatAddress(entry.address || '');
+          if (entry.name) {
+            lines.push(`- **${entry.name}** — ${addr}`);
+            const details: string[] = [];
+            if (entry.type) details.push(entry.type);
+            if (entry.category) details.push(entry.category);
+            if (details.length > 0) lines.push(`  ${details.join(' | ')}`);
+          } else {
+            lines.push(`- ${addr} — Unknown`);
+          }
+        }
+
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching batch identities', [
+          addressError('Batch Identity'),
+        ]);
+      }
     }
   );
 
@@ -101,58 +106,64 @@ export function registerWalletTools(server: McpServer) {
       if (showZeroBalance) params.set('showZeroBalance', 'true');
       if (!showNative) params.set('showNative', 'false');
 
-      const data = await restRequest(`/v1/wallet/${address}/balances?${params.toString()}`);
+      try {
+        const data = await restRequest(`/v1/wallet/${address}/balances?${params.toString()}`);
 
-      const lines = [`**Wallet Balances** (page ${page})`, ''];
+        const lines = [`**Wallet Balances** (page ${page})`, ''];
 
-      if (data.totalUsdValue !== undefined) {
-        lines.push(`**Total Value:** $${Number(data.totalUsdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`, '');
-      }
+        if (data.totalUsdValue !== undefined) {
+          lines.push(`**Total Value:** $${Number(data.totalUsdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`, '');
+        }
 
-      // Native SOL balance
-      if (data.nativeBalance !== undefined) {
-        const solAmount = typeof data.nativeBalance === 'object'
-          ? data.nativeBalance.lamports / LAMPORTS_PER_SOL
-          : data.nativeBalance / LAMPORTS_PER_SOL;
-        const usd = typeof data.nativeBalance === 'object' && data.nativeBalance.totalUsdValue
-          ? ` ($${Number(data.nativeBalance.totalUsdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })})`
-          : '';
-        lines.push(`- **SOL**: ${solAmount.toLocaleString(undefined, { maximumFractionDigits: 9 })}${usd}`);
-      }
+        // Native SOL balance
+        if (data.nativeBalance !== undefined) {
+          const solAmount = typeof data.nativeBalance === 'object'
+            ? data.nativeBalance.lamports / LAMPORTS_PER_SOL
+            : data.nativeBalance / LAMPORTS_PER_SOL;
+          const usd = typeof data.nativeBalance === 'object' && data.nativeBalance.totalUsdValue
+            ? ` ($${Number(data.nativeBalance.totalUsdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })})`
+            : '';
+          lines.push(`- **SOL**: ${solAmount.toLocaleString(undefined, { maximumFractionDigits: 9 })}${usd}`);
+        }
 
-      // Token balances
-      const tokens = data.tokens || [];
-      for (const token of tokens) {
-        const symbol = token.symbol || token.name || formatAddress(token.mint || '');
-        const amount = token.amount !== undefined
-          ? Number(token.amount).toLocaleString(undefined, { maximumFractionDigits: 6 })
-          : '0';
-        const usd = token.usdValue
-          ? ` ($${Number(token.usdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })})`
-          : '';
-        lines.push(`- **${symbol}**: ${amount}${usd}`);
-      }
+        // Token balances
+        const tokens = data.tokens || [];
+        for (const token of tokens) {
+          const symbol = token.symbol || token.name || formatAddress(token.mint || '');
+          const amount = token.amount !== undefined
+            ? Number(token.amount).toLocaleString(undefined, { maximumFractionDigits: 6 })
+            : '0';
+          const usd = token.usdValue
+            ? ` ($${Number(token.usdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })})`
+            : '';
+          lines.push(`- **${symbol}**: ${amount}${usd}`);
+        }
 
-      // NFTs summary
-      if (data.nfts && data.nfts.length > 0) {
-        lines.push('', `**NFTs:** ${data.nfts.length} found`);
-        if (showNfts) {
-          for (const nft of data.nfts.slice(0, 20)) {
-            const name = nft.name || formatAddress(nft.mint || '');
-            lines.push(`- ${name}`);
-          }
-          if (data.nfts.length > 20) {
-            lines.push(`  ... +${data.nfts.length - 20} more`);
+        // NFTs summary
+        if (data.nfts && data.nfts.length > 0) {
+          lines.push('', `**NFTs:** ${data.nfts.length} found`);
+          if (showNfts) {
+            for (const nft of data.nfts.slice(0, 20)) {
+              const name = nft.name || formatAddress(nft.mint || '');
+              lines.push(`- ${name}`);
+            }
+            if (data.nfts.length > 20) {
+              lines.push(`  ... +${data.nfts.length - 20} more`);
+            }
           }
         }
-      }
 
-      // Pagination
-      if (data.pagination?.hasMore) {
-        lines.push('', `*More results available — use page=${page + 1}*`);
-      }
+        // Pagination
+        if (data.pagination?.hasMore) {
+          lines.push('', `*More results available — use page=${page + 1}*`);
+        }
 
-      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching wallet balances', [
+          addressError('Wallet Balances'),
+        ]);
+      }
     }
   );
 
@@ -166,10 +177,13 @@ export function registerWalletTools(server: McpServer) {
       before: z.string().optional().describe('Pagination cursor — pass nextCursor from previous response'),
       after: z.string().optional().describe('Pagination cursor for forward pagination'),
       type: z.string().optional().describe('Filter by transaction type (e.g. SWAP, TRANSFER, NFT_SALE)'),
-      tokenAccounts: z.enum(['none', 'balanceChanged', 'all']).optional().default('balanceChanged').describe('"none" = only direct transactions, "balanceChanged" = include token transfers (default), "all" = all token account activity')
+      tokenAccounts: z.string().optional().default('balanceChanged').describe('"none" = only direct transactions, "balanceChanged" = include token transfers (default), "all" = all token account activity')
     },
     async ({ address, limit, before, after, type, tokenAccounts }) => {
       if (!hasApiKey()) return noApiKeyResponse();
+
+      const err = validateEnum(tokenAccounts, ['none', 'balanceChanged', 'all'], 'Wallet History Error', 'tokenAccounts');
+      if (err) return err;
 
       const params = new URLSearchParams();
       params.set('limit', String(Math.min(limit, 100)));
@@ -178,62 +192,68 @@ export function registerWalletTools(server: McpServer) {
       if (type) params.set('type', type);
       if (tokenAccounts) params.set('tokenAccounts', tokenAccounts);
 
-      const data = await restRequest(`/v1/wallet/${address}/history?${params.toString()}`);
+      try {
+        const data = await restRequest(`/v1/wallet/${address}/history?${params.toString()}`);
 
-      const transactions = data.transactions || data.history || (Array.isArray(data) ? data : []);
+        const transactions = data.transactions || data.history || (Array.isArray(data) ? data : []);
 
-      if (transactions.length === 0) {
-        return { content: [{ type: 'text' as const, text: `**Transaction History for ${formatAddress(address)}**\n\nNo transactions found.` }] };
-      }
-
-      const lines = [`**Transaction History** (${transactions.length} transactions)`, ''];
-
-      transactions.forEach((tx: any, i: number) => {
-        const time = tx.timestamp ? formatTimestamp(tx.timestamp) : 'N/A';
-        const status = tx.transactionError ? 'Failed' : 'Success';
-        const fee = tx.fee ? formatSol(tx.fee) : 'N/A';
-        const txType = tx.type || 'UNKNOWN';
-
-        lines.push(`${i + 1}. ${time} — ${status} — **${txType}** — Fee: ${fee}`);
-        lines.push(`   Signature: \`${tx.signature}\``);
-
-        if (tx.description) {
-          lines.push(`   ${tx.description}`);
+        if (transactions.length === 0) {
+          return mcpText(`**Transaction History for ${formatAddress(address)}**\n\nNo transactions found.`);
         }
 
-        // Balance changes
-        const changes: string[] = [];
-        if (tx.nativeTransfers) {
-          for (const nt of tx.nativeTransfers) {
-            if (nt.amount && nt.amount !== 0) {
-              const dir = nt.toUserAccount === address ? '+' : '-';
-              changes.push(`${dir}${formatSol(Math.abs(nt.amount))}`);
+        const lines = [`**Transaction History** (${transactions.length} transactions)`, ''];
+
+        transactions.forEach((tx: any, i: number) => {
+          const time = tx.timestamp ? formatTimestamp(tx.timestamp) : 'N/A';
+          const status = tx.transactionError ? 'Failed' : 'Success';
+          const fee = tx.fee ? formatSol(tx.fee) : 'N/A';
+          const txType = tx.type || 'UNKNOWN';
+
+          lines.push(`${i + 1}. ${time} — ${status} — **${txType}** — Fee: ${fee}`);
+          lines.push(`   Signature: \`${tx.signature}\``);
+
+          if (tx.description) {
+            lines.push(`   ${tx.description}`);
+          }
+
+          // Balance changes
+          const changes: string[] = [];
+          if (tx.nativeTransfers) {
+            for (const nt of tx.nativeTransfers) {
+              if (nt.amount && nt.amount !== 0) {
+                const dir = nt.toUserAccount === address ? '+' : '-';
+                changes.push(`${dir}${formatSol(Math.abs(nt.amount))}`);
+              }
             }
           }
-        }
-        if (tx.tokenTransfers) {
-          for (const tt of tx.tokenTransfers) {
-            const symbol = tt.symbol || tt.mint ? formatAddress(tt.mint) : 'unknown';
-            const amount = tt.tokenAmount !== undefined ? tt.tokenAmount : 0;
-            const dir = tt.toUserAccount === address ? '+' : '-';
-            changes.push(`${dir}${Math.abs(amount).toLocaleString(undefined, { maximumFractionDigits: 6 })} ${symbol}`);
+          if (tx.tokenTransfers) {
+            for (const tt of tx.tokenTransfers) {
+              const symbol = tt.symbol || tt.mint ? formatAddress(tt.mint) : 'unknown';
+              const amount = tt.tokenAmount !== undefined ? tt.tokenAmount : 0;
+              const dir = tt.toUserAccount === address ? '+' : '-';
+              changes.push(`${dir}${Math.abs(amount).toLocaleString(undefined, { maximumFractionDigits: 6 })} ${symbol}`);
+            }
           }
+
+          if (changes.length > 0) {
+            lines.push(`   Balance Changes: ${changes.join(', ')}`);
+          }
+
+          lines.push('');
+        });
+
+        // Pagination
+        const cursor = data.pagination?.nextCursor || data.nextCursor;
+        if (cursor) {
+          lines.push(`**Next Cursor:** \`${cursor}\``);
         }
 
-        if (changes.length > 0) {
-          lines.push(`   Balance Changes: ${changes.join(', ')}`);
-        }
-
-        lines.push('');
-      });
-
-      // Pagination
-      const cursor = data.pagination?.nextCursor || data.nextCursor;
-      if (cursor) {
-        lines.push(`**Next Cursor:** \`${cursor}\``);
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching wallet history', [
+          addressError('Wallet History'),
+        ]);
       }
-
-      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
     }
   );
 
@@ -253,36 +273,42 @@ export function registerWalletTools(server: McpServer) {
       params.set('limit', String(Math.min(limit, 100)));
       if (cursor) params.set('cursor', cursor);
 
-      const data = await restRequest(`/v1/wallet/${address}/transfers?${params.toString()}`);
+      try {
+        const data = await restRequest(`/v1/wallet/${address}/transfers?${params.toString()}`);
 
-      const transfers = data.transfers || (Array.isArray(data) ? data : []);
+        const transfers = data.transfers || (Array.isArray(data) ? data : []);
 
-      if (transfers.length === 0) {
-        return { content: [{ type: 'text' as const, text: `**Wallet Transfers for ${formatAddress(address)}**\n\nNo transfers found.` }] };
+        if (transfers.length === 0) {
+          return mcpText(`**Wallet Transfers for ${formatAddress(address)}**\n\nNo transfers found.`);
+        }
+
+        const lines = [`**Wallet Transfers** (${transfers.length} transfers)`, ''];
+
+        transfers.forEach((t: any, i: number) => {
+          const direction = t.direction === 'in' ? 'Received' : 'Sent';
+          const time = t.timestamp ? formatTimestamp(t.timestamp) : 'N/A';
+          const symbol = t.symbol || (t.mint ? formatAddress(t.mint) : 'SOL');
+          const amount = t.amount !== undefined ? Number(t.amount).toLocaleString(undefined, { maximumFractionDigits: 6 }) : '?';
+          const counterparty = t.counterparty ? formatAddress(t.counterparty) : 'unknown';
+
+          lines.push(`${i + 1}. **${direction}** — ${time}`);
+          lines.push(`   ${amount} ${symbol} ${t.direction === 'in' ? 'from' : 'to'} ${counterparty}`);
+          if (t.signature) lines.push(`   Signature: \`${t.signature}\``);
+          lines.push('');
+        });
+
+        // Pagination
+        const nextCursor = data.pagination?.cursor || data.cursor || data.nextCursor;
+        if (nextCursor) {
+          lines.push(`**Next Cursor:** \`${nextCursor}\``);
+        }
+
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching wallet transfers', [
+          addressError('Wallet Transfers'),
+        ]);
       }
-
-      const lines = [`**Wallet Transfers** (${transfers.length} transfers)`, ''];
-
-      transfers.forEach((t: any, i: number) => {
-        const direction = t.direction === 'in' ? 'Received' : 'Sent';
-        const time = t.timestamp ? formatTimestamp(t.timestamp) : 'N/A';
-        const symbol = t.symbol || (t.mint ? formatAddress(t.mint) : 'SOL');
-        const amount = t.amount !== undefined ? Number(t.amount).toLocaleString(undefined, { maximumFractionDigits: 6 }) : '?';
-        const counterparty = t.counterparty ? formatAddress(t.counterparty) : 'unknown';
-
-        lines.push(`${i + 1}. **${direction}** — ${time}`);
-        lines.push(`   ${amount} ${symbol} ${t.direction === 'in' ? 'from' : 'to'} ${counterparty}`);
-        if (t.signature) lines.push(`   Signature: \`${t.signature}\``);
-        lines.push('');
-      });
-
-      // Pagination
-      const nextCursor = data.pagination?.cursor || data.cursor || data.nextCursor;
-      if (nextCursor) {
-        lines.push(`**Next Cursor:** \`${nextCursor}\``);
-      }
-
-      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
     }
   );
 
@@ -312,13 +338,11 @@ export function registerWalletTools(server: McpServer) {
         if (data.timestamp) lines.push(`**Date:** ${data.timestamp}`);
         if (data.explorerUrl) lines.push(`**Explorer:** ${data.explorerUrl}`);
 
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        if (errorMsg.includes('404')) {
-          return { content: [{ type: 'text' as const, text: `No funding source found for ${formatAddress(address)}` }] };
-        }
-        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error', [
+          http404Error('', `No funding source found for ${formatAddress(address)}`),
+        ]);
       }
     }
   );

--- a/helius-mcp/src/tools/webhooks.ts
+++ b/helius-mcp/src/tools/webhooks.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { restRequest } from '../utils/helius.js';
 import { formatAddress } from '../utils/formatters.js';
 import { TRANSACTION_TYPES } from '../types/transaction-types.js';
+import { mcpText, mcpError, validateEnum, handleToolError, http404Error, http400Error } from '../utils/errors.js';
 
 export function registerWebhookTools(server: McpServer) {
   server.tool(
@@ -14,9 +15,7 @@ export function registerWebhookTools(server: McpServer) {
         const webhooks = await restRequest('/v0/webhooks');
 
         if (!webhooks || webhooks.length === 0) {
-          return {
-            content: [{ type: 'text' as const, text: '**Webhooks**\n\nNo webhooks configured.' }]
-          };
+          return mcpText('**Webhooks**\n\nNo webhooks configured.');
         }
 
         const lines = [`**Webhooks** (${webhooks.length} total)`, ''];
@@ -30,15 +29,9 @@ export function registerWebhookTools(server: McpServer) {
           lines.push('');
         });
 
-        return {
-          content: [{ type: 'text' as const, text: lines.join('\n') }]
-        };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: 'text' as const, text: `❌ Error: ${errorMsg}` }],
-          isError: true
-        };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error');
       }
     }
   );
@@ -71,15 +64,12 @@ export function registerWebhookTools(server: McpServer) {
           }
         }
 
-        return {
-          content: [{ type: 'text' as const, text: lines.join('\n') }]
-        };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: 'text' as const, text: `❌ Error: ${errorMsg}` }],
-          isError: true
-        };
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching webhook', [
+          http404Error('Webhook Details', `Webhook not found. The ID "${webhookID}" does not exist. Use getAllWebhooks to list your webhooks.`),
+          http400Error('Webhook Details'),
+        ]);
       }
     }
   );
@@ -89,11 +79,19 @@ export function registerWebhookTools(server: McpServer) {
     'Create a webhook to monitor Solana events in real-time with powerful filtering. Use this to track NFT sales, token swaps, staking, and 150+ transaction types. Webhooks send HTTP POST with parsed transaction data to your URL. Enhanced webhooks include human-readable descriptions.',
     {
       webhookURL: z.string().describe('Your webhook URL endpoint'),
-      webhookType: z.enum(['enhanced', 'raw', 'discord']).describe('Webhook type - use "enhanced" for parsed transaction data with descriptions'),
+      webhookType: z.string().describe('Webhook type - use "enhanced" for parsed transaction data with descriptions'),
       accountAddresses: z.array(z.string()).describe('Array of Solana addresses to monitor (up to 100,000 per webhook)'),
-      transactionTypes: z.array(z.enum(TRANSACTION_TYPES as unknown as [string, ...string[]])).describe('Transaction types to monitor - e.g. ["SWAP", "NFT_SALE"]. Use ["ANY"] to receive all types. Common types: NFT_SALE, NFT_MINT, SWAP, TRANSFER, STAKE_TOKEN, UNSTAKE_TOKEN, BUY, SELL, TOKEN_MINT')
+      transactionTypes: z.array(z.string()).optional().describe('Transaction types to monitor - e.g. ["SWAP", "NFT_SALE"]. Use ["ANY"] to receive all types. Common types: NFT_SALE, NFT_MINT, SWAP, TRANSFER, STAKE_TOKEN, UNSTAKE_TOKEN, BUY, SELL, TOKEN_MINT')
     },
     async ({ webhookURL, webhookType, accountAddresses, transactionTypes }) => {
+      const err = validateEnum(webhookType, ['enhanced', 'raw', 'discord'], 'Create Webhook Error', 'webhook type');
+      if (err) return err;
+      if (transactionTypes) {
+        const invalid = transactionTypes.filter(t => !(TRANSACTION_TYPES as readonly string[]).includes(t));
+        if (invalid.length > 0) {
+          return mcpText(`**Create Webhook Error**\n\nInvalid transaction type(s): ${invalid.join(', ')}. See valid types: https://docs.helius.dev/webhooks/transaction-types`);
+        }
+      }
       try {
         const body: any = {
           webhookURL,
@@ -107,18 +105,11 @@ export function registerWebhookTools(server: McpServer) {
           body: JSON.stringify(body)
         });
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `✅ **Webhook Created**\n\n**ID:** ${webhook.webhookID}\n**URL:** ${webhook.webhookURL}\n**Monitoring:** ${accountAddresses.length} address(es)`
-          }]
-        };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: 'text' as const, text: `❌ Error: ${errorMsg}` }],
-          isError: true
-        };
+        return mcpText(`✅ **Webhook Created**\n\n**ID:** ${webhook.webhookID}\n**URL:** ${webhook.webhookURL}\n**Monitoring:** ${accountAddresses.length} address(es)`);
+      } catch (err) {
+        return handleToolError(err, 'Error creating webhook', [
+          http400Error('Create Webhook Error'),
+        ]);
       }
     }
   );
@@ -129,11 +120,21 @@ export function registerWebhookTools(server: McpServer) {
     {
       webhookID: z.string().describe('Webhook ID to update'),
       webhookURL: z.string().optional().describe('New webhook URL'),
-      webhookType: z.enum(['enhanced', 'raw', 'discord']).optional().describe('Webhook type (required by the Helius API for updates)'),
+      webhookType: z.string().optional().describe('Webhook type (required by the Helius API for updates)'),
       accountAddresses: z.array(z.string()).optional().describe('New list of addresses to monitor (replaces existing list)'),
-      transactionTypes: z.array(z.enum(TRANSACTION_TYPES as unknown as [string, ...string[]])).optional().describe('New transaction type filters - e.g. ["SWAP", "NFT_SALE"]. Replaces existing filters.')
+      transactionTypes: z.array(z.string()).optional().describe('New transaction type filters - e.g. ["SWAP", "NFT_SALE"]. Replaces existing filters.')
     },
     async ({ webhookID, webhookURL, webhookType, accountAddresses, transactionTypes }) => {
+      if (webhookType) {
+        const err = validateEnum(webhookType, ['enhanced', 'raw', 'discord'], 'Update Webhook Error', 'webhook type');
+        if (err) return err;
+      }
+      if (transactionTypes) {
+        const invalid = transactionTypes.filter(t => !(TRANSACTION_TYPES as readonly string[]).includes(t));
+        if (invalid.length > 0) {
+          return mcpText(`**Update Webhook Error**\n\nInvalid transaction type(s): ${invalid.join(', ')}. See valid types: https://docs.helius.dev/webhooks/transaction-types`);
+        }
+      }
       try {
         // Helius PUT /v0/webhooks requires the full webhook object.
         // Fetch the existing webhook first so callers only need to supply changed fields.
@@ -154,18 +155,12 @@ export function registerWebhookTools(server: McpServer) {
           body: JSON.stringify(body)
         });
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `✅ **Webhook Updated**\n\n**ID:** ${webhook.webhookID}\n**URL:** ${webhook.webhookURL}`
-          }]
-        };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: 'text' as const, text: `❌ Error: ${errorMsg}` }],
-          isError: true
-        };
+        return mcpText(`✅ **Webhook Updated**\n\n**ID:** ${webhook.webhookID}\n**URL:** ${webhook.webhookURL}`);
+      } catch (err) {
+        return handleToolError(err, 'Error updating webhook', [
+          http404Error('Webhook Update', `Webhook not found. The ID "${webhookID}" does not exist. Use getAllWebhooks to list your webhooks.`),
+          http400Error('Update Webhook Error'),
+        ]);
       }
     }
   );
@@ -182,18 +177,12 @@ export function registerWebhookTools(server: McpServer) {
           method: 'DELETE',
         });
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: `✅ Webhook ${webhookID} deleted successfully.`
-          }]
-        };
-      } catch (err: unknown) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: 'text' as const, text: `❌ Error: ${errorMsg}` }],
-          isError: true
-        };
+        return mcpText(`✅ Webhook ${webhookID} deleted successfully.`);
+      } catch (err) {
+        return handleToolError(err, 'Error deleting webhook', [
+          http404Error('Webhook Delete', `Webhook not found. The ID "${webhookID}" does not exist. Use getAllWebhooks to list your webhooks.`),
+          http400Error('Webhook Delete'),
+        ]);
       }
     }
   );

--- a/helius-mcp/src/types/transaction-types.ts
+++ b/helius-mcp/src/types/transaction-types.ts
@@ -2,6 +2,7 @@
 // https://docs.helius.dev/webhooks/transaction-types
 
 export const TRANSACTION_TYPES = [
+  'ANY',
   'UNKNOWN',
   'NFT_BID',
   'NFT_BID_CANCELLED',

--- a/helius-mcp/src/utils/errors.ts
+++ b/helius-mcp/src/utils/errors.ts
@@ -1,0 +1,186 @@
+// ─── MCP Response Builders ───
+
+type McpToolResponse = {
+  content: [{ type: 'text'; text: string }];
+  isError?: boolean;
+};
+
+export function mcpText(text: string): McpToolResponse {
+  return { content: [{ type: 'text', text }] };
+}
+
+export function mcpError(text: string): McpToolResponse {
+  return { content: [{ type: 'text', text }], isError: true };
+}
+
+// ─── Error Message Extraction ───
+
+export function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ─── Error Classifiers ───
+
+export function isAddressError(msg: string): boolean {
+  return msg.includes('Pubkey Validation Err')
+    || msg.includes('Invalid param')
+    || msg.includes('Invalid pubkey')
+    || msg.includes('Validation Error');
+}
+
+export function isPaginationError(msg: string): boolean {
+  return msg.includes('Pagination Error')
+    || msg.includes('invalid value')
+    || msg.includes('expected u32')
+    || msg.includes('expected u64');
+}
+
+export function isNotFoundError(msg: string): boolean {
+  return msg.includes('RecordNotFound')
+    || msg.includes('Asset Not Found')
+    || msg.includes('Asset Proof Not Found');
+}
+
+export function isHttp404Error(msg: string): boolean {
+  return msg.includes('404')
+    || msg.includes('not found')
+    || msg.includes('Method not found');
+}
+
+export function isHttp400Error(msg: string): boolean {
+  return msg.includes('400');
+}
+
+export function parseHttp400Messages(msg: string): string[] | null {
+  try {
+    const json = JSON.parse(msg.replace(/^HTTP 400:\s*/, ''));
+    const messages = Array.isArray(json.message) ? json.message : [json.message];
+    return messages;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Enum Validation ───
+
+export function validateEnum(
+  value: string,
+  validOptions: readonly string[],
+  context: string,
+  fieldName: string
+): McpToolResponse | null {
+  if (!validOptions.includes(value)) {
+    return mcpText(`**${context}**\n\nInvalid ${fieldName} "${value}". Valid options: ${validOptions.join(', ')}`);
+  }
+  return null;
+}
+
+// ─── Catch-Block Handler Chain ───
+
+type ErrorHandler = {
+  match: (msg: string) => boolean;
+  respond: (msg: string) => McpToolResponse;
+};
+
+export function handleToolError(
+  err: unknown,
+  fallbackPrefix: string,
+  handlers?: ErrorHandler[]
+): McpToolResponse {
+  const msg = getErrorMessage(err);
+  if (handlers) {
+    for (const handler of handlers) {
+      if (handler.match(msg)) return handler.respond(msg);
+    }
+  }
+  return mcpError(`**${fallbackPrefix}:** ${msg}`);
+}
+
+// ─── Pre-built Handler Factories ───
+
+export function addressError(header: string, detail?: string): ErrorHandler {
+  return {
+    match: isAddressError,
+    respond: () => mcpText(`**${header}**\n\n${detail || 'Invalid Solana address. Please provide a valid base58-encoded address.'}`),
+  };
+}
+
+export function paginationError(header: string, detail?: string): ErrorHandler {
+  return {
+    match: isPaginationError,
+    respond: () => mcpText(`**${header}**\n\n${detail || 'Invalid pagination parameters. Page must be at least 1 and limit must be between 1 and 1000.'}`),
+  };
+}
+
+export function notFoundError(header: string, detail?: string): ErrorHandler {
+  return {
+    match: isNotFoundError,
+    respond: () => mcpText(`**${header}**\n\n${detail || 'Asset not found. This mint address does not exist or has not been indexed.'}`),
+  };
+}
+
+export function http404Error(header: string, detail: string): ErrorHandler {
+  return {
+    match: isHttp404Error,
+    respond: () => header ? mcpText(`**${header}**\n\n${detail}`) : mcpText(detail),
+  };
+}
+
+export function http400Error(header: string): ErrorHandler {
+  return {
+    match: isHttp400Error,
+    respond: (msg) => {
+      const messages = parseHttp400Messages(msg);
+      if (messages) {
+        return mcpText(`**${header}**\n\n${messages.map((m: string) => `- ${m}`).join('\n')}`);
+      }
+      return mcpError(`**${header}:** ${msg}`);
+    },
+  };
+}
+
+// ─── Address Format Validation (for config-generation warnings) ───
+
+const SOLANA_ADDRESS_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+export function isValidAddressFormat(address: string): boolean {
+  return SOLANA_ADDRESS_REGEX.test(address);
+}
+
+export function warnInvalidAddresses(paramName: string, addresses: string[]): string[] {
+  const warnings: string[] = [];
+  const empty = addresses.filter(a => !a || !a.trim());
+  if (empty.length > 0) {
+    warnings.push(`${paramName} contains ${empty.length} empty/blank address(es). These will be rejected by the endpoint.`);
+  }
+  const invalid = addresses.filter(a => a && a.trim() && !isValidAddressFormat(a.trim()));
+  if (invalid.length > 0) {
+    warnings.push(`${paramName} contains ${invalid.length} address(es) with invalid format: ${invalid.slice(0, 3).map(a => `"${a}"`).join(', ')}${invalid.length > 3 ? `, ... (${invalid.length} total)` : ''}. Solana addresses are 32-44 base58 characters.`);
+  }
+  return warnings;
+}
+
+export function warnInvalidAddress(paramName: string, address: string): string | null {
+  if (!address || !address.trim()) {
+    return `${paramName} is empty/blank. A valid Solana address is required.`;
+  }
+  if (!isValidAddressFormat(address.trim())) {
+    return `${paramName} "${address}" does not look like a valid Solana address (expected 32-44 base58 characters).`;
+  }
+  return null;
+}
+
+export function warnAddressConflicts(
+  includeName: string, includeAddresses: string[] | undefined,
+  excludeName: string, excludeAddresses: string[] | undefined
+): string | null {
+  if (!includeAddresses || !excludeAddresses) return null;
+  const includeSet = new Set(includeAddresses.map(a => a.trim()));
+  const overlap = excludeAddresses.filter(a => includeSet.has(a.trim()));
+  if (overlap.length > 0) {
+    return `${overlap.length} address(es) appear in both ${includeName} and ${excludeName}: ${overlap.slice(0, 3).map(a => `"${a}"`).join(', ')}${overlap.length > 3 ? `, ... (${overlap.length} total)` : ''}. These addresses will be included and excluded simultaneously, which may cause unexpected behavior.`;
+  }
+  return null;
+}
+
+export type { ErrorHandler, McpToolResponse };


### PR DESCRIPTION
## Summary

  This PR standardizes error handling across helius-mcp tools by introducing shared error utilities and migrating existing tools to use
  them, so failures return consistent, actionable MCP responses.

  ## What Changed

  - Added helius-mcp/src/utils/errors.ts with shared helpers:
  - mcpText, mcpError, getErrorMessage
  - validateEnum
  - handleToolError with reusable handlers for address, pagination, 404, and 400 cases
  - address warning helpers: warnInvalidAddress, warnInvalidAddresses, warnAddressConflicts
  - Refactored tool error paths to use shared handling in:
  - accounts.ts, assets.ts, balance.ts, blocks.ts, config.ts, das-extras.ts, enhanced-websockets.ts, fees.ts, laserstream.ts, network.ts,
    tokens.ts, transactions.ts, wallet.ts, webhooks.ts
  - Added stricter/explicit enum validation in multiple tools before making RPC/API calls.
  - Improved network tool safety by wrapping internal RPC fetch flow in guarded error handling.
  - Added ANY to webhook transaction type support in helius-mcp/src/types/transaction-types.ts.

  ## Why

  - Remove duplicated, inconsistent try/catch logic across tools.
  - Normalize user-facing error responses for common failure modes.
  - Provide clearer validation feedback for invalid addresses, pagination values, and webhook API errors.

  ## Testing

  - Ran cd helius-mcp && npm run build
  - Result: tsc passes

  ## Notes

  - Successful-path behavior is unchanged; this is primarily a failure-path consistency and validation UX improvement.
  - Some error message text changed due to normalization.