### PR TITLE
feat: Add MCP usage tracking via User-Agent header

### DIFF
--- a/helius-mcp/.gitignore
+++ b/helius-mcp/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.tgz
+src/version.ts

--- a/helius-mcp/package.json
+++ b/helius-mcp/package.json
@@ -8,6 +8,7 @@
     "helius-mcp": "dist/index.js"
   },
   "scripts": {
+    "prebuild": "node -p \"'export const version = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",

--- a/helius-mcp/src/http.ts
+++ b/helius-mcp/src/http.ts
@@ -1,0 +1,3 @@
+import { version } from './version.js';
+
+export const MCP_USER_AGENT = `helius-mcp/${version}`;

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -1,4 +1,5 @@
 import { createHelius, type HeliusClient } from 'helius-sdk';
+import { MCP_USER_AGENT } from '../http.js';
 
 let sessionApiKey: string | null = null;
 let sessionNetwork: 'mainnet-beta' | 'devnet' = 'mainnet-beta';
@@ -73,7 +74,7 @@ export async function rpcRequest(method: string, params: any[] = []): Promise<an
   const url = getRpcUrl();
   const response = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'User-Agent': MCP_USER_AGENT },
     body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
   });
 
@@ -92,7 +93,7 @@ export async function dasRequest(method: string, params: any = {}): Promise<any>
   const url = getRpcUrl();
   const response = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'User-Agent': MCP_USER_AGENT },
     body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
   });
 
@@ -113,6 +114,7 @@ export async function restRequest(endpoint: string, options: RequestInit = {}): 
   const url = `https://api.helius.xyz${endpoint}${separator}api-key=${apiKey}`;
 
   const headers: Record<string, string> = { ...options.headers as Record<string, string> };
+  headers['User-Agent'] = MCP_USER_AGENT;
   if (options.body) {
     headers['Content-Type'] ??= 'application/json';
   }


### PR DESCRIPTION
## Summary
- All HTTP requests from the MCP server now include `User-Agent: helius-mcp/<version>`
- Covers all three request paths: `rpcRequest`, `dasRequest`, and `restRequest`
- Version is auto-generated from `package.json` via a `prebuild` script, matching the pattern from [helius-sdk#264](https://github.com/helius-labs/helius-sdk/pull/264)

## Example User-Agent
```
helius-mcp/0.3.0
```

## Changes
- Add `prebuild` script to `package.json` that generates `src/version.ts`
- Add `src/version.ts` to `.gitignore` (generated file)
- Create `src/http.ts` with `MCP_USER_AGENT` constant
- Update `rpcRequest`, `dasRequest`, and `restRequest` in `helius.ts` to include the header

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Verified User-Agent header is included in all three request functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)