### PR TITLE
fix: migrate to use sdk

### DIFF
--- a/helius-cli/.gitignore
+++ b/helius-cli/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .DS_Store
+src/version.ts

--- a/helius-cli/package.json
+++ b/helius-cli/package.json
@@ -10,6 +10,7 @@
     "dist"
   ],
   "scripts": {
+    "prebuild": "node -p \"'export const version = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",
     "build": "tsc",
     "dev": "tsx bin/helius.ts",
     "prepublishOnly": "npm run build"

--- a/helius-cli/src/constants.ts
+++ b/helius-cli/src/constants.ts
@@ -1,11 +1,12 @@
 import type { Address } from "@solana/kit";
+import { version } from './version.js';
+import { CLI_USER_AGENT } from './http.js';
 
-export const VERSION = "1.0.1";
+export { CLI_USER_AGENT };
+
+export const VERSION = version;
 
 export const API_URL = "https://dev-api.helius.xyz/v0";
-
-// User agent for API requests
-export const CLI_USER_AGENT = `helius-cli/${VERSION}`;
 
 // Treasury wallet that receives the 1 USDC payment
 export const TREASURY = "CEs84tEowsXpH8u4VBf8rJSVgSRypFMfXw9CpGRtQgb6" as Address;

--- a/helius-cli/src/http.ts
+++ b/helius-cli/src/http.ts
@@ -1,0 +1,3 @@
+import { version } from './version.js';
+
+export const CLI_USER_AGENT = `helius-cli/${version}`;

--- a/helius-mcp/.gitignore
+++ b/helius-mcp/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.tgz
+src/version.ts

--- a/helius-mcp/package.json
+++ b/helius-mcp/package.json
@@ -8,6 +8,7 @@
     "helius-mcp": "dist/index.js"
   },
   "scripts": {
+    "prebuild": "node -p \"'export const version = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",

--- a/helius-mcp/pnpm-lock.yaml
+++ b/helius-mcp/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       helius-sdk:
-        specifier: ^2.0.5
-        version: 2.0.5(typescript@5.9.3)
+        specifier: file:../../helius-sdk
+        version: file:../../helius-sdk(typescript@5.9.3)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -590,8 +590,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  helius-sdk@2.0.5:
-    resolution: {integrity: sha512-c7DnmUAxvT5fjfa8zgD4n3PdoHml54Lxvoorb1QJXYo+xzbHnpksfetjzbGoF7fVOGhQdATcGzmSB4SaVYJoNw==}
+  helius-sdk@file:../../helius-sdk:
+    resolution: {directory: ../../helius-sdk, type: directory}
 
   hono@4.11.4:
     resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
@@ -1465,7 +1465,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  helius-sdk@2.0.5(typescript@5.9.3):
+  helius-sdk@file:../../helius-sdk(typescript@5.9.3):
     dependencies:
       '@solana-program/compute-budget': 0.11.0(@solana/kit@5.4.0(typescript@5.9.3))
       '@solana-program/stake': 0.5.0(@solana/kit@5.4.0(typescript@5.9.3))

--- a/helius-mcp/src/http.ts
+++ b/helius-mcp/src/http.ts
@@ -1,0 +1,3 @@
+import { version } from './version.js';
+
+export const MCP_USER_AGENT = `helius-mcp/${version}`;

--- a/helius-mcp/src/tools/accounts.ts
+++ b/helius-mcp/src/tools/accounts.ts
@@ -1,13 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { getHeliusClient, hasApiKey, getRpcUrl } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatAddress, formatSol } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
 import { mcpText, validateEnum, handleToolError, addressError, paginationError } from '../utils/errors.js';
 
 function formatParsedAccountData(account: {
   data: unknown;
-  lamports: number;
+  lamports: number | bigint;
   owner: string;
   executable: boolean;
   space?: number;
@@ -36,7 +36,7 @@ function formatParsedAccountData(account: {
 }
 
 export function registerAccountTools(server: McpServer) {
-  // Get Account Info (single or batch) — uses direct JSON-RPC
+  // Get Account Info (single or batch) — uses SDK standard Solana RPC (Kit, bigint)
   server.tool(
     'getAccountInfo',
     'Get detailed Solana account information for one or more accounts. For a single account: returns owner program, lamport balance, data size, executable status, and rent epoch. For batch: pass up to 100 addresses in "addresses" for fast bulk lookups. Use jsonParsed encoding (default) on token mint addresses to see Token-2022 extensions, authorities, and supply data. Use this to inspect any on-chain account.',
@@ -51,8 +51,6 @@ export function registerAccountTools(server: McpServer) {
       const err = validateEnum(encoding, ['base58', 'base64', 'jsonParsed'], 'Account Info Error', 'encoding');
       if (err) return err;
 
-      const url = getRpcUrl();
-
       // Validate: must provide exactly one of address or addresses
       if (!address && (!addresses || addresses.length === 0)) {
         return mcpText(`**Error:** Provide either \`address\` (single account) or \`addresses\` (batch of up to 100).`);
@@ -62,61 +60,32 @@ export function registerAccountTools(server: McpServer) {
         return mcpText(`**Error:** Provide either \`address\` or \`addresses\`, not both.`);
       }
 
-      type AccountInfo = {
-        lamports: number;
-        owner: string;
-        data: unknown;
-        executable: boolean;
-        rentEpoch: number;
-        space?: number;
-      };
-
       try {
+        const helius = getHeliusClient();
+
         // --- Batch mode ---
         if (addresses && addresses.length > 0) {
           if (addresses.length > 100) {
             return mcpText(`**Error:** Maximum 100 accounts per request. You provided ${addresses.length}.`);
           }
 
-          const response = await fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              jsonrpc: '2.0',
-              id: 'get-multiple-accounts',
-              method: 'getMultipleAccounts',
-              params: [addresses, { encoding }]
-            })
-          });
-
-          type ApiResponse = {
-            result?: { value: (AccountInfo | null)[] };
-            error?: { message: string };
-          };
-
-          const data = await response.json() as ApiResponse;
-
-          if (data.error) {
-            return mcpText(`**Error**\n\n${data.error.message}`);
-          }
-
-          const accounts = data.result?.value || [];
+          const result = await (helius as any).getMultipleAccounts(addresses, { encoding }).send();
+          const accounts = result?.value || [];
           const lines = [`**Multiple Accounts** (${addresses.length} requested)`, ''];
 
-          addresses.forEach((addr, i) => {
+          addresses.forEach((addr: string, i: number) => {
             const account = accounts[i];
             if (!account) {
               lines.push(`**${formatAddress(addr)}:** Not found`);
             } else {
               lines.push(`**${formatAddress(addr)}**`);
-              lines.push(`  Balance: ${formatSol(account.lamports)}`);
+              lines.push(`  Balance: ${formatSol(Number(account.lamports))}`);
               lines.push(`  Owner: ${account.owner}`);
               lines.push(`  Executable: ${account.executable ? 'Yes' : 'No'}`);
               if (account.space !== undefined) {
-                lines.push(`  Data Size: ${account.space} bytes`);
+                lines.push(`  Data Size: ${Number(account.space)} bytes`);
               }
-              // Show parsed data (Token-2022 extensions, mint info, etc.)
-              const parsedLines = formatParsedAccountData(account);
+              const parsedLines = formatParsedAccountData({ ...account, lamports: Number(account.lamports) });
               lines.push(...parsedLines);
             }
             lines.push('');
@@ -126,48 +95,27 @@ export function registerAccountTools(server: McpServer) {
         }
 
         // --- Single account mode ---
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: 'get-account-info',
-            method: 'getAccountInfo',
-            params: [address, { encoding }]
-          })
-        });
-
-        type ApiResponse = {
-          result?: { value: AccountInfo | null };
-          error?: { message: string };
-        };
-
-        const data = await response.json() as ApiResponse;
-
-        if (data.error) {
-          return mcpText(`**Error**\n\n${data.error.message}`);
-        }
-
-        const account = data.result?.value;
+        const result = await (helius as any).getAccountInfo(address, { encoding }).send();
+        const account = result?.value;
 
         if (!account) {
           return mcpText(`**Account ${formatAddress(address!)}**\n\nAccount not found or has no data.`);
         }
 
+        const lamports = Number(account.lamports);
         const lines = [
           `**Account ${formatAddress(address!)}**`,
           '',
-          `**Balance:** ${formatSol(account.lamports)} (${account.lamports.toLocaleString()} lamports)`,
+          `**Balance:** ${formatSol(lamports)} (${lamports.toLocaleString()} lamports)`,
           `**Owner:** ${account.owner}`,
           `**Executable:** ${account.executable ? 'Yes' : 'No'}`,
         ];
 
         if (account.space !== undefined) {
-          lines.push(`**Data Size:** ${account.space} bytes`);
+          lines.push(`**Data Size:** ${Number(account.space)} bytes`);
         }
 
-        // Show parsed data details when using jsonParsed
-        const parsedLines = formatParsedAccountData(account);
+        const parsedLines = formatParsedAccountData({ ...account, lamports });
         if (parsedLines.length > 0) {
           lines.push('', '**Parsed Data:**');
           lines.push(...parsedLines);
@@ -263,7 +211,7 @@ export function registerAccountTools(server: McpServer) {
     }
   );
 
-  // Get Program Accounts (V2 with pagination)
+  // Get Program Accounts (V2 with pagination) — uses SDK RpcCaller (no bigint)
   server.tool(
     'getProgramAccounts',
     'Get all accounts owned by a specific program. Returns account addresses, balances, and data sizes. Use dataSize to filter by account data length (e.g. 165 for token accounts). Useful for finding all accounts created by a program like a DEX, lending protocol, or custom program.',
@@ -280,8 +228,7 @@ export function registerAccountTools(server: McpServer) {
       const encErr = validateEnum(encoding, ['base58', 'base64', 'jsonParsed'], 'Program Accounts Error', 'encoding');
       if (encErr) return encErr;
 
-      const url = getRpcUrl();
-
+      const helius = getHeliusClient();
       const cappedLimit = Math.min(limit, 10_000);
 
       type Filter = { dataSize: number };
@@ -290,15 +237,7 @@ export function registerAccountTools(server: McpServer) {
         filters.push({ dataSize });
       }
 
-      type RpcParams = {
-        encoding: string;
-        dataSlice: { offset: number; length: number };
-        limit: number;
-        filters?: Filter[];
-        paginationKey?: string;
-      };
-
-      const rpcParams: RpcParams = {
+      const rpcParams: any = {
         encoding,
         dataSlice: { offset: 0, length: 0 },
         limit: cappedLimit
@@ -306,77 +245,41 @@ export function registerAccountTools(server: McpServer) {
       if (filters.length > 0) rpcParams.filters = filters;
       if (paginationKey) rpcParams.paginationKey = paginationKey;
 
-      const requestBody = {
-        jsonrpc: '2.0',
-        id: 'get-program-accounts-v2',
-        method: 'getProgramAccountsV2',
-        params: [programId, rpcParams]
-      };
-
-      type AccountResult = {
-        pubkey: string;
-        account: {
-          lamports: number;
-          owner: string;
-          data: unknown;
-          executable: boolean;
-          rentEpoch: number;
-          space: number;
-        };
-      };
-
-      type ApiResponse = {
-        result?: {
-          accounts: AccountResult[];
-          paginationKey?: string | null;
-          totalResults?: number;
-        };
-        error?: { message: string };
-      };
-
-      let data: ApiResponse;
       try {
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(requestBody)
+        const data = await helius.getProgramAccountsV2([programId, rpcParams]);
+
+        // SDK returns result directly (or may wrap in RpcResponse with context/value)
+        const result = (data as any).value ?? data;
+        const accounts = result?.accounts || [];
+
+        if (accounts.length === 0) {
+          return mcpText(`**Program Accounts for ${formatAddress(programId)}**\n\nNo accounts found.`);
+        }
+
+        const totalLabel = result?.totalResults
+          ? `${result.totalResults.toLocaleString()} total`
+          : `${accounts.length} returned`;
+        const lines = [`**Program Accounts for ${formatAddress(programId)}** (${totalLabel})`, ''];
+
+        accounts.forEach((item: any) => {
+          lines.push(`- **${formatAddress(item.pubkey)}**`);
+          lines.push(`  Balance: ${formatSol(item.account.lamports)}`);
+          if (item.account.space !== undefined) {
+            lines.push(`  Data Size: ${item.account.space} bytes`);
+          }
+          lines.push(`  Executable: ${item.account.executable ? 'Yes' : 'No'}`);
         });
-        data = await response.json() as ApiResponse;
+
+        if (result?.paginationKey) {
+          lines.push('', `**Next Page:** Pass \`paginationKey: "${result.paginationKey}"\` to fetch the next page.`);
+        }
+
+        return mcpText(lines.join('\n'));
       } catch (err) {
         return handleToolError(err, 'Error fetching program accounts', [
           addressError('Program Accounts'),
         ]);
       }
-
-      if (data.error) {
-        return mcpText(`**Error**\n\n${data.error.message}`);
-      }
-
-      const accounts = data.result?.accounts || [];
-
-      if (accounts.length === 0) {
-        return mcpText(`**Program Accounts for ${formatAddress(programId)}**\n\nNo accounts found.`);
-      }
-
-      const totalLabel = data.result?.totalResults
-        ? `${data.result.totalResults.toLocaleString()} total`
-        : `${accounts.length} returned`;
-      const lines = [`**Program Accounts for ${formatAddress(programId)}** (${totalLabel})`, ''];
-
-      accounts.forEach((item) => {
-        lines.push(`- **${formatAddress(item.pubkey)}**`);
-        lines.push(`  Balance: ${formatSol(item.account.lamports)}`);
-        if (item.account.space !== undefined) {
-          lines.push(`  Data Size: ${item.account.space} bytes`);
-        }
-        lines.push(`  Executable: ${item.account.executable ? 'Yes' : 'No'}`);
-      });
-
-      if (data.result?.paginationKey) {
-        lines.push('', `**Next Page:** Pass \`paginationKey: "${data.result.paginationKey}"\` to fetch the next page.`);
-      }
-
-      return mcpText(lines.join('\n'));
     }
   );
 }

--- a/helius-mcp/src/tools/blocks.ts
+++ b/helius-mcp/src/tools/blocks.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { hasApiKey, getRpcUrl } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatSol, formatTimestamp } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
 import { mcpText, validateEnum, handleToolError } from '../utils/errors.js';
@@ -19,78 +19,38 @@ export function registerBlockTools(server: McpServer) {
       const err = validateEnum(transactionDetails, ['none', 'signatures', 'full'], 'Block Error', 'transactionDetails');
       if (err) return err;
 
-      const url = getRpcUrl();
-
       try {
-        const requestBody = {
-          jsonrpc: '2.0',
-          id: 'get-block',
-          method: 'getBlock',
-          params: [
-            slot,
-            {
-              encoding: 'jsonParsed',
-              transactionDetails,
-              maxSupportedTransactionVersion: 0,
-              rewards: true
-            }
-          ]
-        };
+        const helius = getHeliusClient();
 
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(requestBody)
-        });
+        // Kit requires BigInt for slot parameter
+        const block = await (helius as any).getBlock(BigInt(slot), {
+          encoding: 'jsonParsed',
+          transactionDetails,
+          maxSupportedTransactionVersion: 0,
+          rewards: true
+        }).send();
 
-        type Reward = {
-          pubkey: string;
-          lamports: number;
-          postBalance: number;
-          rewardType: string;
-          commission?: number;
-        };
-
-        type BlockResult = {
-          blockhash: string;
-          previousBlockhash: string;
-          parentSlot: number;
-          blockTime: number | null;
-          blockHeight: number | null;
-          transactions?: unknown[];
-          signatures?: string[];
-          rewards?: Reward[];
-        };
-
-        type ApiResponse = {
-          result?: BlockResult;
-          error?: { message: string };
-        };
-
-        const data = await response.json() as ApiResponse;
-
-        if (data.error) {
-          return mcpText(`**Error**\n\n${data.error.message}`);
-        }
-
-        const block = data.result;
         if (!block) {
           return mcpText(`**Block at Slot ${slot.toLocaleString()}**\n\nBlock not found. It may have been skipped or not yet confirmed.`);
         }
+
+        const parentSlot = Number(block.parentSlot);
+        const blockHeight = block.blockHeight != null ? Number(block.blockHeight) : null;
+        const blockTime = block.blockTime != null ? Number(block.blockTime) : null;
 
         const lines = [
           `**Block at Slot ${slot.toLocaleString()}**`,
           '',
           `**Blockhash:** ${block.blockhash}`,
-          `**Parent Slot:** ${block.parentSlot.toLocaleString()}`,
+          `**Parent Slot:** ${parentSlot.toLocaleString()}`,
           `**Previous Blockhash:** ${block.previousBlockhash}`,
         ];
 
-        if (block.blockHeight !== null) {
-          lines.push(`**Block Height:** ${block.blockHeight.toLocaleString()}`);
+        if (blockHeight !== null) {
+          lines.push(`**Block Height:** ${blockHeight.toLocaleString()}`);
         }
-        if (block.blockTime) {
-          lines.push(`**Block Time:** ${formatTimestamp(block.blockTime)}`);
+        if (blockTime) {
+          lines.push(`**Block Time:** ${formatTimestamp(blockTime)}`);
         }
 
         // Transaction count
@@ -102,10 +62,11 @@ export function registerBlockTools(server: McpServer) {
 
         // Rewards summary
         if (block.rewards && block.rewards.length > 0) {
-          const totalRewards = block.rewards.reduce((sum, r) => sum + r.lamports, 0);
+          const totalRewards = block.rewards.reduce((sum: number, r: any) => sum + Number(r.lamports), 0);
           const rewardTypes = new Map<string, number>();
-          block.rewards.forEach((r) => {
-            rewardTypes.set(r.rewardType, (rewardTypes.get(r.rewardType) || 0) + r.lamports);
+          block.rewards.forEach((r: any) => {
+            const lamports = Number(r.lamports);
+            rewardTypes.set(r.rewardType, (rewardTypes.get(r.rewardType) || 0) + lamports);
           });
 
           lines.push('', `**Rewards:** ${formatSol(totalRewards)} total (${block.rewards.length} recipients)`);
@@ -118,7 +79,7 @@ export function registerBlockTools(server: McpServer) {
         if (transactionDetails === 'signatures' && block.signatures && block.signatures.length > 0) {
           const maxShow = 20;
           lines.push('', `**Transaction Signatures** (${block.signatures.length} total):`);
-          block.signatures.slice(0, maxShow).forEach((sig) => {
+          block.signatures.slice(0, maxShow).forEach((sig: string) => {
             lines.push(`- ${sig}`);
           });
           if (block.signatures.length > maxShow) {

--- a/helius-mcp/src/tools/das-extras.ts
+++ b/helius-mcp/src/tools/das-extras.ts
@@ -1,8 +1,9 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { dasRequest } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatAddress } from '../utils/formatters.js';
 import { mcpText, mcpError, handleToolError, addressError, notFoundError, paginationError } from '../utils/errors.js';
+import { noApiKeyResponse } from './shared.js';
 
 export function registerDasExtraTools(server: McpServer) {
   server.tool(
@@ -12,8 +13,10 @@ export function registerDasExtraTools(server: McpServer) {
       id: z.string().describe('Compressed NFT mint address')
     },
     async ({ id }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
       try {
-        const proof = await dasRequest('getAssetProof', { id });
+        const helius = getHeliusClient();
+        const proof = await helius.getAssetProof({ id });
         return mcpText(`**Merkle Proof for ${formatAddress(id)}**\n\n**Root:** ${formatAddress(proof.root)}\n**Leaf:** ${formatAddress(proof.leaf)}\n**Tree ID:** ${formatAddress(proof.tree_id)}\n**Proof Length:** ${proof.proof.length} nodes`);
       } catch (err) {
         const header = `Merkle Proof for ${formatAddress(id)}`;
@@ -32,11 +35,13 @@ export function registerDasExtraTools(server: McpServer) {
       ids: z.array(z.string()).describe('Array of cNFT mint addresses (up to 1000)')
     },
     async ({ ids }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
       try {
         if (ids.length > 1000) {
           return mcpError('Max 1000 proofs per batch');
         }
-        const result = await dasRequest('getAssetProofBatch', { ids });
+        const helius = getHeliusClient();
+        const result = await helius.getAssetProofBatch({ ids });
         const proofsArray = Array.isArray(result) ? result : Object.values(result);
         return mcpText(`**Batch Merkle Proofs** (${proofsArray.length})\n\n${proofsArray.map((p: any, i: number) => `${i + 1}. ${formatAddress(ids[i])}\n   Root: ${formatAddress(p.root)}`).join('\n\n')}`);
       } catch (err) {
@@ -57,8 +62,10 @@ export function registerDasExtraTools(server: McpServer) {
       limit: z.number().optional().default(20)
     },
     async ({ id, page, limit }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
       try {
-        const result = await dasRequest('getSignaturesForAsset', { id, page, limit });
+        const helius = getHeliusClient();
+        const result = await helius.getSignaturesForAsset({ id, page, limit });
         if (!result.items?.length) {
           return mcpText(`**Signatures for ${formatAddress(id)}**\n\nNo transactions found.`);
         }
@@ -88,8 +95,10 @@ export function registerDasExtraTools(server: McpServer) {
       limit: z.number().optional().default(20)
     },
     async ({ mint, page, limit }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
       try {
-        const result = await dasRequest('getNftEditions', { mint, page, limit });
+        const helius = getHeliusClient();
+        const result = await helius.getNftEditions({ mint, page, limit });
         if (!result.editions?.length) {
           return mcpText(`**Editions for ${formatAddress(mint)}**\n\nNo editions found.`);
         }

--- a/helius-mcp/src/tools/fees.ts
+++ b/helius-mcp/src/tools/fees.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { hasApiKey, getRpcUrl } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { noApiKeyResponse } from './shared.js';
 import { mcpText, validateEnum, handleToolError } from '../utils/errors.js';
 
@@ -22,63 +22,16 @@ export function registerFeeTools(server: McpServer) {
         if (err) return err;
       }
 
-      const url = getRpcUrl();
-
-      type PriorityFeeRequest = {
-        jsonrpc: '2.0';
-        id: string;
-        method: 'getPriorityFeeEstimate';
-        params: [{
-          accountKeys?: string[];
-          options?: {
-            priorityLevel?: string;
-            includeAllPriorityFeeLevels?: boolean;
-          };
-        }];
-      };
-
-      type PriorityFeeResponse = {
-        result?: {
-          priorityFeeEstimate?: number;
-          priorityFeeLevels?: {
-            min: number;
-            low: number;
-            medium: number;
-            high: number;
-            veryHigh: number;
-            unsafeMax: number;
-          };
-        };
-        error?: { message: string };
-      };
-
-      const requestBody: PriorityFeeRequest = {
-        jsonrpc: '2.0',
-        id: 'priority-fee-estimate',
-        method: 'getPriorityFeeEstimate',
-        params: [{
+      try {
+        const helius = getHeliusClient();
+        const result = await helius.getPriorityFeeEstimate({
           ...(accountKeys && { accountKeys }),
           options: {
-            ...(priorityLevel && { priorityLevel }),
+            ...(priorityLevel && { priorityLevel: priorityLevel as any }),
             includeAllPriorityFeeLevels: includeAllLevels
           }
-        }]
-      };
-
-      try {
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(requestBody)
         });
 
-        const data = await response.json() as PriorityFeeResponse;
-
-        if (data.error) {
-          return mcpText(`**Priority Fee Estimate Error**\n\n${data.error.message}`);
-        }
-
-        const result = data.result;
         if (!result) {
           return mcpText(`**Priority Fee Estimate**\n\nNo fee data available.`);
         }

--- a/helius-mcp/src/tools/network.ts
+++ b/helius-mcp/src/tools/network.ts
@@ -1,8 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { hasApiKey, getRpcUrl } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatSolCompact } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
-import { getErrorMessage, handleToolError } from '../utils/errors.js';
+import { mcpText, handleToolError } from '../utils/errors.js';
 
 export function registerNetworkTools(server: McpServer) {
   server.tool(
@@ -12,113 +12,55 @@ export function registerNetworkTools(server: McpServer) {
     async () => {
       if (!hasApiKey()) return noApiKeyResponse();
 
-      const url = getRpcUrl();
-
-      const makeRequest = async (method: string, params: unknown[] = []) => {
-        try {
-          const response = await fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              jsonrpc: '2.0',
-              id: method,
-              method,
-              params
-            })
-          });
-          return await response.json();
-        } catch (err) {
-          throw new Error(`RPC ${method} failed: ${getErrorMessage(err)}`);
-        }
-      };
-
-      type EpochInfo = {
-        epoch: number;
-        slotIndex: number;
-        slotsInEpoch: number;
-        absoluteSlot: number;
-        blockHeight: number;
-        transactionCount: number | null;
-      };
-
-      type SupplyResult = {
-        value: {
-          total: number;
-          circulating: number;
-          nonCirculating: number;
-        };
-      };
-
-      type VersionResult = {
-        'solana-core': string;
-        'feature-set': number;
-      };
-
       try {
-        // Fire all requests in parallel
-        const [epochRes, supplyRes, versionRes] = await Promise.all([
-          makeRequest('getEpochInfo'),
-          makeRequest('getSupply'),
-          makeRequest('getVersion')
-        ]) as [
-          { result: EpochInfo; error?: { message: string } },
-          { result: SupplyResult; error?: { message: string } },
-          { result: VersionResult; error?: { message: string } }
-        ];
+        const helius = getHeliusClient();
 
-        // Check for errors
-        const errors: string[] = [];
-        if (epochRes.error) errors.push(`Epoch info: ${epochRes.error.message}`);
-        if (supplyRes.error) errors.push(`Supply: ${supplyRes.error.message}`);
-        if (versionRes.error) errors.push(`Version: ${versionRes.error.message}`);
-
-        if (errors.length === 3) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: `**Network Status Error**\n\n${errors.join('\n')}`
-            }]
-          };
-        }
+        // Fire all requests in parallel — Kit returns bigint for numeric fields
+        const [epochInfo, supplyResult, version] = await Promise.all([
+          (helius as any).getEpochInfo().send(),
+          (helius as any).getSupply().send(),
+          (helius as any).getVersion().send(),
+        ]);
 
         const lines = ['**Solana Network Status**', ''];
 
-        // Epoch info
-        if (epochRes.result) {
-          const epoch = epochRes.result;
-          const epochProgress = ((epoch.slotIndex / epoch.slotsInEpoch) * 100).toFixed(1);
+        // Epoch info — all fields are bigint from Kit
+        if (epochInfo) {
+          const epoch = Number(epochInfo.epoch);
+          const slotIndex = Number(epochInfo.slotIndex);
+          const slotsInEpoch = Number(epochInfo.slotsInEpoch);
+          const absoluteSlot = Number(epochInfo.absoluteSlot);
+          const blockHeight = Number(epochInfo.blockHeight);
+          const transactionCount = epochInfo.transactionCount != null ? Number(epochInfo.transactionCount) : null;
+
+          const epochProgress = ((slotIndex / slotsInEpoch) * 100).toFixed(1);
           lines.push('**Epoch:**');
-          lines.push(`- Current Epoch: ${epoch.epoch}`);
-          lines.push(`- Progress: ${epochProgress}% (slot ${epoch.slotIndex.toLocaleString()} / ${epoch.slotsInEpoch.toLocaleString()})`);
-          lines.push(`- Absolute Slot: ${epoch.absoluteSlot.toLocaleString()}`);
-          lines.push(`- Block Height: ${epoch.blockHeight.toLocaleString()}`);
-          if (epoch.transactionCount !== null) {
-            lines.push(`- Transaction Count: ${epoch.transactionCount.toLocaleString()}`);
+          lines.push(`- Current Epoch: ${epoch}`);
+          lines.push(`- Progress: ${epochProgress}% (slot ${slotIndex.toLocaleString()} / ${slotsInEpoch.toLocaleString()})`);
+          lines.push(`- Absolute Slot: ${absoluteSlot.toLocaleString()}`);
+          lines.push(`- Block Height: ${blockHeight.toLocaleString()}`);
+          if (transactionCount !== null) {
+            lines.push(`- Transaction Count: ${transactionCount.toLocaleString()}`);
           }
           lines.push('');
         }
 
-        // Supply
-        if (supplyRes.result) {
-          const supply = supplyRes.result.value;
+        // Supply — value fields are bigint from Kit
+        if (supplyResult?.value) {
+          const supply = supplyResult.value;
           lines.push('**SOL Supply:**');
-          lines.push(`- Total: ${formatSolCompact(supply.total)}`);
-          lines.push(`- Circulating: ${formatSolCompact(supply.circulating)}`);
-          lines.push(`- Non-Circulating: ${formatSolCompact(supply.nonCirculating)}`);
+          lines.push(`- Total: ${formatSolCompact(Number(supply.total))}`);
+          lines.push(`- Circulating: ${formatSolCompact(Number(supply.circulating))}`);
+          lines.push(`- Non-Circulating: ${formatSolCompact(Number(supply.nonCirculating))}`);
           lines.push('');
         }
 
-        // Version
-        if (versionRes.result) {
-          lines.push(`**Cluster Version:** ${versionRes.result['solana-core']}`);
+        // Version — no bigint issues
+        if (version) {
+          lines.push(`**Cluster Version:** ${version['solana-core']}`);
         }
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: lines.join('\n')
-          }]
-        };
+        return mcpText(lines.join('\n'));
       } catch (err) {
         return handleToolError(err, 'Error fetching network status');
       }

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { getHeliusClient, hasApiKey, getRpcUrl } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatSol, formatAddress, formatTimestamp, LAMPORTS_PER_SOL } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
 import { mcpText, getErrorMessage, validateEnum, handleToolError, http400Error } from '../utils/errors.js';
@@ -112,8 +112,9 @@ function decodeComputeBudget(dataBase58: string): string | null {
   }
 }
 
-// Shared helper: call getTransactionsForAddress (Helius JSON-RPC) — supports native sortOrder asc/desc
+// Shared helper: call getTransactionsForAddress via SDK (Helius custom RPC method)
 async function fetchTransactionsForAddress(
+  helius: ReturnType<typeof getHeliusClient>,
   address: string,
   params: {
     transactionDetails: 'signatures' | 'full';
@@ -123,18 +124,7 @@ async function fetchTransactionsForAddress(
     filters?: Record<string, unknown>;
   }
 ) {
-  const url = getRpcUrl();
-
-  type RequestParams = {
-    transactionDetails: string;
-    sortOrder: string;
-    limit: number;
-    maxSupportedTransactionVersion: number;
-    paginationToken?: string;
-    filters?: Record<string, unknown>;
-  };
-
-  const reqParams: RequestParams = {
+  const reqParams: any = {
     transactionDetails: params.transactionDetails,
     sortOrder: params.sortOrder,
     limit: params.limit,
@@ -144,26 +134,8 @@ async function fetchTransactionsForAddress(
   if (params.paginationToken) reqParams.paginationToken = params.paginationToken;
   if (params.filters && Object.keys(params.filters).length > 0) reqParams.filters = params.filters;
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 'get-transactions-for-address',
-      method: 'getTransactionsForAddress',
-      params: [address, reqParams]
-    })
-  });
-
-  type ApiResponse = {
-    result?: {
-      data: SignatureResult[] | FullResult[];
-      paginationToken?: string;
-    };
-    error?: { message: string };
-  };
-
-  return await response.json() as ApiResponse;
+  // SDK returns { data, paginationToken } directly
+  return await helius.getTransactionsForAddress([address, reqParams]);
 }
 
 const BASE58_REGEX = /^[1-9A-HJ-NP-Za-km-z]{86,88}$/;
@@ -541,6 +513,7 @@ export function registerTransactionTools(server: McpServer) {
     },
     async ({ address, mode, limit, sortOrder, before, until, paginationToken, transactionDetails, status, tokenAccounts, blockTimeGte, blockTimeLte, slotGte, slotLte }) => {
       if (!hasApiKey()) return noApiKeyResponse();
+      const helius = getHeliusClient();
 
       let err;
       err = validateEnum(mode, ['parsed', 'signatures', 'raw'], 'Transaction History Error', 'mode');
@@ -588,50 +561,26 @@ export function registerTransactionTools(server: McpServer) {
         // Fast path: getSignaturesForAddress — cheap RPC call for latest sigs (desc only, no filters)
         if (useQuickPath) {
           try {
-            const url = getRpcUrl();
-
             type QuickSigParams = { limit: number; before?: string; until?: string };
             const rpcParams: QuickSigParams = { limit };
             if (before) rpcParams.before = before;
             if (until) rpcParams.until = until;
 
-            type SignatureInfo = {
-              signature: string;
-              slot: number;
-              err: unknown;
-              memo: string | null;
-              blockTime: number | null;
-            };
+            // Kit returns bigint for slot/blockTime fields
+            const sigs = await (helius as any).getSignaturesForAddress(address, rpcParams).send();
 
-            const response = await fetch(url, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                jsonrpc: '2.0',
-                id: 'get-signatures-for-address',
-                method: 'getSignaturesForAddress',
-                params: [address, rpcParams]
-              })
-            });
-
-            const json = await response.json() as { result?: SignatureInfo[]; error?: { message: string } };
-            if (json.error) {
-              return mcpText(`Error fetching signatures: ${json.error.message}`);
-            }
-
-            const sigs = json.result || [];
-
-            if (sigs.length === 0) {
+            if (!sigs || sigs.length === 0) {
               return mcpText(`**Signatures for ${formatAddress(address)}**\n\nNo signatures found.`);
             }
 
             const lines = [`**Signatures for ${formatAddress(address)}** (${sigs.length} results, newest first${statusNote})`, ''];
 
-            sigs.forEach((sig) => {
+            sigs.forEach((sig: any) => {
               const sigStatus = sig.err ? '❌' : '✅';
-              const time = sig.blockTime ? new Date(sig.blockTime * 1000).toISOString() : 'N/A';
+              const blockTime = sig.blockTime != null ? Number(sig.blockTime) : null;
+              const time = blockTime ? new Date(blockTime * 1000).toISOString() : 'N/A';
               lines.push(`${sigStatus} ${sig.signature}`);
-              lines.push(`   Slot: ${sig.slot.toLocaleString()} | Time: ${time}`);
+              lines.push(`   Slot: ${Number(sig.slot).toLocaleString()} | Time: ${time}`);
               if (sig.memo) {
                 lines.push(`   Memo: ${sig.memo}`);
               }
@@ -645,7 +594,7 @@ export function registerTransactionTools(server: McpServer) {
 
         // Full path: getTransactionsForAddress — needed for asc sort, filters, or paginationToken
         try {
-          const data = await fetchTransactionsForAddress(address, {
+          const result = await fetchTransactionsForAddress(helius, address, {
             transactionDetails: 'signatures',
             sortOrder,
             limit,
@@ -653,16 +602,11 @@ export function registerTransactionTools(server: McpServer) {
             ...(Object.keys(filters).length > 0 && { filters })
           });
 
-          if (data.error) {
-            return mcpText(`**Error**\n\n${data.error.message}`);
-          }
-
-          const result = data.result;
           if (!result || !result.data || result.data.length === 0) {
             return mcpText(`**Signatures for ${formatAddress(address)}**\n\nNo signatures found.`);
           }
 
-          const items = result.data as SignatureResult[];
+          const items = result.data as unknown as SignatureResult[];
           const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
           const lines = [`**Signatures for ${formatAddress(address)}** (${items.length} results, ${orderLabel}${statusNote})`, ''];
 
@@ -689,7 +633,7 @@ export function registerTransactionTools(server: McpServer) {
       // ─── RAW MODE ───
       if (mode === 'raw') {
         try {
-          const data = await fetchTransactionsForAddress(address, {
+          const result = await fetchTransactionsForAddress(helius, address, {
             transactionDetails: transactionDetails! as 'signatures' | 'full',
             sortOrder,
             limit,
@@ -697,11 +641,6 @@ export function registerTransactionTools(server: McpServer) {
             ...(Object.keys(filters).length > 0 && { filters })
           });
 
-          if (data.error) {
-            return mcpText(`**Error**\n\n${data.error.message}`);
-          }
-
-          const result = data.result;
           if (!result || !result.data || result.data.length === 0) {
             return mcpText(`**Transactions for ${formatAddress(address)}**\n\nNo transactions found.`);
           }
@@ -710,7 +649,7 @@ export function registerTransactionTools(server: McpServer) {
           const lines = [`**Transactions for ${formatAddress(address)}** (${result.data.length} results, ${orderLabel}${statusNote})`, ''];
 
           if (transactionDetails === 'signatures') {
-            const items = result.data as SignatureResult[];
+            const items = result.data as unknown as SignatureResult[];
             items.forEach((item) => {
               const txStatus = item.err ? '❌' : '✅';
               const time = item.blockTime ? new Date(item.blockTime * 1000).toISOString() : 'N/A';
@@ -721,7 +660,7 @@ export function registerTransactionTools(server: McpServer) {
               }
             });
           } else {
-            const items = result.data as FullResult[];
+            const items = result.data as unknown as FullResult[];
             items.forEach((item) => {
               const sig = item.transaction.signatures[0];
               const txStatus = item.meta.err ? '❌' : '✅';
@@ -760,100 +699,93 @@ export function registerTransactionTools(server: McpServer) {
 
       // ─── PARSED MODE (default) ───
       try {
-      // Step 1: Use getTransactionsForAddress to get sorted signatures in one call
-      const sigData = await fetchTransactionsForAddress(address, {
-        transactionDetails: 'signatures',
-        sortOrder,
-        limit: Math.min(limit, 100),
-        ...(paginationToken && { paginationToken }),
-        ...(Object.keys(filters).length > 0 && { filters })
-      });
+        // Step 1: Use getTransactionsForAddress to get sorted signatures in one call
+        const sigResult = await fetchTransactionsForAddress(helius, address, {
+          transactionDetails: 'signatures',
+          sortOrder,
+          limit: Math.min(limit, 100),
+          ...(paginationToken && { paginationToken }),
+          ...(Object.keys(filters).length > 0 && { filters })
+        });
 
-      if (sigData.error) {
-        return mcpText(`**Error**\n\n${sigData.error.message}`);
-      }
-
-      type SigItem = { signature: string };
-      const sigResult = sigData.result;
-      if (!sigResult || !sigResult.data || sigResult.data.length === 0) {
-        return mcpText(`**Transaction History for ${formatAddress(address)}**\n\nNo transactions found.`);
-      }
-
-      const sortedSigs = (sigResult.data as SigItem[]).map(item => item.signature);
-
-      // Step 2: Send sorted signatures to Enhanced API for rich data
-      const helius = getHeliusClient();
-
-      // Batch in chunks of 100 (Enhanced API limit)
-      const allTransactions: EnrichedTransaction[] = [];
-      for (let i = 0; i < sortedSigs.length; i += 100) {
-        const batch = sortedSigs.slice(i, i + 100);
-        const enriched = await helius.enhanced.getTransactions({
-          transactions: batch
-        }) as EnrichedTransaction[];
-        if (enriched) allTransactions.push(...enriched);
-      }
-
-      if (allTransactions.length === 0) {
-        return mcpText(`**Transaction History for ${formatAddress(address)}**\n\nNo transactions could be enriched.`);
-      }
-
-      // Re-sort to match original order (Enhanced API may return in different order)
-      const sigOrder = new Map(sortedSigs.map((sig, idx) => [sig, idx]));
-      allTransactions.sort((a, b) => (sigOrder.get(a.signature) ?? 999) - (sigOrder.get(b.signature) ?? 999));
-
-      const tokenMetadata = await fetchTokenMetadata(helius, collectMints(allTransactions));
-
-      const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
-      const lines = [`**Transaction History for ${formatAddress(address)}** (${allTransactions.length} transactions, ${orderLabel}${statusNote})`, ''];
-
-      allTransactions.forEach((tx) => {
-        const time = tx.timestamp ? formatTimestamp(tx.timestamp) : 'N/A';
-        const txStatus = tx.transactionError ? '❌' : '✅';
-        const type = tx.type || 'UNKNOWN';
-        const source = tx.source || '';
-
-        lines.push(`${txStatus} **${type}**${source ? ` (${source})` : ''} - ${time}`);
-        lines.push(`   Sig: \`${tx.signature}\``);
-
-        if (tx.description) {
-          lines.push(`   ${tx.description}`);
+        if (!sigResult || !sigResult.data || sigResult.data.length === 0) {
+          return mcpText(`**Transaction History for ${formatAddress(address)}**\n\nNo transactions found.`);
         }
 
-        // Swap summary
-        if (tx.events?.swap) {
-          const swapSummary = formatSwapSummary(tx.events.swap, tokenMetadata);
-          if (swapSummary) {
-            lines.push(`   Swap: ${swapSummary}`);
+        type SigItem = { signature: string };
+        const sortedSigs = (sigResult.data as unknown as SigItem[]).map(item => item.signature);
+
+        // Step 2: Send sorted signatures to Enhanced API for rich data
+        // Batch in chunks of 100 (Enhanced API limit)
+        const allTransactions: EnrichedTransaction[] = [];
+        for (let i = 0; i < sortedSigs.length; i += 100) {
+          const batch = sortedSigs.slice(i, i + 100);
+          const enriched = await helius.enhanced.getTransactions({
+            transactions: batch
+          }) as EnrichedTransaction[];
+          if (enriched) allTransactions.push(...enriched);
+        }
+
+        if (allTransactions.length === 0) {
+          return mcpText(`**Transaction History for ${formatAddress(address)}**\n\nNo transactions could be enriched.`);
+        }
+
+        // Re-sort to match original order (Enhanced API may return in different order)
+        const sigOrder = new Map(sortedSigs.map((sig, idx) => [sig, idx]));
+        allTransactions.sort((a, b) => (sigOrder.get(a.signature) ?? 999) - (sigOrder.get(b.signature) ?? 999));
+
+        const tokenMetadata = await fetchTokenMetadata(helius, collectMints(allTransactions));
+
+        const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
+        const lines = [`**Transaction History for ${formatAddress(address)}** (${allTransactions.length} transactions, ${orderLabel}${statusNote})`, ''];
+
+        allTransactions.forEach((tx) => {
+          const time = tx.timestamp ? formatTimestamp(tx.timestamp) : 'N/A';
+          const txStatus = tx.transactionError ? '❌' : '✅';
+          const type = tx.type || 'UNKNOWN';
+          const source = tx.source || '';
+
+          lines.push(`${txStatus} **${type}**${source ? ` (${source})` : ''} - ${time}`);
+          lines.push(`   Sig: \`${tx.signature}\``);
+
+          if (tx.description) {
+            lines.push(`   ${tx.description}`);
           }
+
+          // Swap summary
+          if (tx.events?.swap) {
+            const swapSummary = formatSwapSummary(tx.events.swap, tokenMetadata);
+            if (swapSummary) {
+              lines.push(`   Swap: ${swapSummary}`);
+            }
+          }
+
+          // Compact token transfer summary (for non-swap transactions)
+          if (!tx.events?.swap && tx.tokenTransfers && tx.tokenTransfers.length > 0) {
+            const transferParts = tx.tokenTransfers.slice(0, 3).map((t) => {
+              const asset = tokenMetadata.get(t.mint);
+              const symbol = asset?.token_info?.symbol || asset?.content?.metadata?.symbol || asset?.content?.metadata?.name || formatAddress(t.mint);
+              const decimals = asset?.token_info?.decimals ?? t.decimals ?? 0;
+              const amount = t.tokenAmount.toLocaleString(undefined, { maximumFractionDigits: Math.min(decimals || 4, 4) });
+              return `${amount} ${symbol}`;
+            });
+            const moreCount = tx.tokenTransfers.length > 3 ? ` +${tx.tokenTransfers.length - 3} more` : '';
+            lines.push(`   Transfers: ${transferParts.join(', ')}${moreCount}`);
+          }
+
+          if (tx.fee) {
+            lines.push(`   Fee: ${formatSol(tx.fee)}`);
+          }
+
+          lines.push('');
+        });
+
+        if (sigResult.paginationToken) {
+          lines.push(`**Next Page Token:** \`${sigResult.paginationToken}\``);
         }
 
-        // Compact token transfer summary (for non-swap transactions)
-        if (!tx.events?.swap && tx.tokenTransfers && tx.tokenTransfers.length > 0) {
-          const transferParts = tx.tokenTransfers.slice(0, 3).map((t) => {
-            const asset = tokenMetadata.get(t.mint);
-            const symbol = asset?.token_info?.symbol || asset?.content?.metadata?.symbol || asset?.content?.metadata?.name || formatAddress(t.mint);
-            const decimals = asset?.token_info?.decimals ?? t.decimals ?? 0;
-            const amount = t.tokenAmount.toLocaleString(undefined, { maximumFractionDigits: Math.min(decimals || 4, 4) });
-            return `${amount} ${symbol}`;
-          });
-          const moreCount = tx.tokenTransfers.length > 3 ? ` +${tx.tokenTransfers.length - 3} more` : '';
-          lines.push(`   Transfers: ${transferParts.join(', ')}${moreCount}`);
-        }
-
-        if (tx.fee) {
-          lines.push(`   Fee: ${formatSol(tx.fee)}`);
-        }
-
-        lines.push('');
-      });
-
-      if (sigResult.paginationToken) {
-        lines.push(`**Next Page Token:** \`${sigResult.paginationToken}\``);
-      }
-
-      const fullText = lines.join('\n');
-      return mcpText(truncateResponse(fullText));
+        const fullText = lines.join('\n');
+        return mcpText(truncateResponse(fullText));
       } catch (err) {
         return handleToolError(err, 'Error fetching transaction history');
       }

--- a/helius-mcp/src/tools/wallet.ts
+++ b/helius-mcp/src/tools/wallet.ts
@@ -1,7 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { hasApiKey, restRequest } from '../utils/helius.js';
-import { formatAddress, formatSol, formatTimestamp, LAMPORTS_PER_SOL } from '../utils/formatters.js';
+import type { HistoryTransaction, Transfer } from 'helius-sdk/wallet/types';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
+import { formatAddress, formatSol, formatTimestamp } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
 import { mcpText, mcpError, validateEnum, handleToolError, http404Error, addressError } from '../utils/errors.js';
 
@@ -17,7 +18,8 @@ export function registerWalletTools(server: McpServer) {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
-        const data = await restRequest(`/v1/wallet/${address}/identity`);
+        const client = getHeliusClient();
+        const data = await client.wallet.getIdentity({ wallet: address });
 
         const lines = ['**Wallet Identity**', ''];
         lines.push(`**Address:** ${formatAddress(address)}`);
@@ -50,12 +52,9 @@ export function registerWalletTools(server: McpServer) {
       }
 
       try {
-        const data = await restRequest('/v1/wallet/batch-identity', {
-          method: 'POST',
-          body: JSON.stringify({ addresses })
-        });
+        const client = getHeliusClient();
+        const results = await client.wallet.getBatchIdentity({ addresses });
 
-        const results = Array.isArray(data) ? data : [];
         if (results.length === 0) {
           return mcpText(`**Batch Identity Lookup** (${addresses.length} addresses)\n\nNo identities found.`);
         }
@@ -99,15 +98,16 @@ export function registerWalletTools(server: McpServer) {
     async ({ address, page, limit, showNfts, showZeroBalance, showNative }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
-      const params = new URLSearchParams();
-      params.set('page', String(page));
-      params.set('limit', String(Math.min(limit, 100)));
-      if (showNfts) params.set('showNfts', 'true');
-      if (showZeroBalance) params.set('showZeroBalance', 'true');
-      if (!showNative) params.set('showNative', 'false');
-
       try {
-        const data = await restRequest(`/v1/wallet/${address}/balances?${params.toString()}`);
+        const client = getHeliusClient();
+        const data = await client.wallet.getBalances({
+          wallet: address,
+          page,
+          limit: Math.min(limit, 100),
+          showNfts,
+          showZeroBalance,
+          showNative,
+        });
 
         const lines = [`**Wallet Balances** (page ${page})`, ''];
 
@@ -115,23 +115,11 @@ export function registerWalletTools(server: McpServer) {
           lines.push(`**Total Value:** $${Number(data.totalUsdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`, '');
         }
 
-        // Native SOL balance
-        if (data.nativeBalance !== undefined) {
-          const solAmount = typeof data.nativeBalance === 'object'
-            ? data.nativeBalance.lamports / LAMPORTS_PER_SOL
-            : data.nativeBalance / LAMPORTS_PER_SOL;
-          const usd = typeof data.nativeBalance === 'object' && data.nativeBalance.totalUsdValue
-            ? ` ($${Number(data.nativeBalance.totalUsdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })})`
-            : '';
-          lines.push(`- **SOL**: ${solAmount.toLocaleString(undefined, { maximumFractionDigits: 9 })}${usd}`);
-        }
-
-        // Token balances
-        const tokens = data.tokens || [];
-        for (const token of tokens) {
+        // Token balances (includes native SOL when showNative=true)
+        for (const token of data.balances) {
           const symbol = token.symbol || token.name || formatAddress(token.mint || '');
-          const amount = token.amount !== undefined
-            ? Number(token.amount).toLocaleString(undefined, { maximumFractionDigits: 6 })
+          const amount = token.balance !== undefined
+            ? Number(token.balance).toLocaleString(undefined, { maximumFractionDigits: 9 })
             : '0';
           const usd = token.usdValue
             ? ` ($${Number(token.usdValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })})`
@@ -185,17 +173,18 @@ export function registerWalletTools(server: McpServer) {
       const err = validateEnum(tokenAccounts, ['none', 'balanceChanged', 'all'], 'Wallet History Error', 'tokenAccounts');
       if (err) return err;
 
-      const params = new URLSearchParams();
-      params.set('limit', String(Math.min(limit, 100)));
-      if (before) params.set('before', before);
-      if (after) params.set('after', after);
-      if (type) params.set('type', type);
-      if (tokenAccounts) params.set('tokenAccounts', tokenAccounts);
-
       try {
-        const data = await restRequest(`/v1/wallet/${address}/history?${params.toString()}`);
+        const client = getHeliusClient();
+        const data = await client.wallet.getHistory({
+          wallet: address,
+          limit: Math.min(limit, 100),
+          before,
+          after,
+          type,
+          tokenAccounts,
+        });
 
-        const transactions = data.transactions || data.history || (Array.isArray(data) ? data : []);
+        const transactions = data.data;
 
         if (transactions.length === 0) {
           return mcpText(`**Transaction History for ${formatAddress(address)}**\n\nNo transactions found.`);
@@ -203,39 +192,21 @@ export function registerWalletTools(server: McpServer) {
 
         const lines = [`**Transaction History** (${transactions.length} transactions)`, ''];
 
-        transactions.forEach((tx: any, i: number) => {
+        transactions.forEach((tx: HistoryTransaction, i: number) => {
           const time = tx.timestamp ? formatTimestamp(tx.timestamp) : 'N/A';
-          const status = tx.transactionError ? 'Failed' : 'Success';
+          const status = tx.error ? 'Failed' : 'Success';
           const fee = tx.fee ? formatSol(tx.fee) : 'N/A';
-          const txType = tx.type || 'UNKNOWN';
 
-          lines.push(`${i + 1}. ${time} — ${status} — **${txType}** — Fee: ${fee}`);
+          lines.push(`${i + 1}. ${time} — ${status} — Fee: ${fee}`);
           lines.push(`   Signature: \`${tx.signature}\``);
 
-          if (tx.description) {
-            lines.push(`   ${tx.description}`);
-          }
-
           // Balance changes
-          const changes: string[] = [];
-          if (tx.nativeTransfers) {
-            for (const nt of tx.nativeTransfers) {
-              if (nt.amount && nt.amount !== 0) {
-                const dir = nt.toUserAccount === address ? '+' : '-';
-                changes.push(`${dir}${formatSol(Math.abs(nt.amount))}`);
-              }
-            }
-          }
-          if (tx.tokenTransfers) {
-            for (const tt of tx.tokenTransfers) {
-              const symbol = tt.symbol || tt.mint ? formatAddress(tt.mint) : 'unknown';
-              const amount = tt.tokenAmount !== undefined ? tt.tokenAmount : 0;
-              const dir = tt.toUserAccount === address ? '+' : '-';
-              changes.push(`${dir}${Math.abs(amount).toLocaleString(undefined, { maximumFractionDigits: 6 })} ${symbol}`);
-            }
-          }
-
-          if (changes.length > 0) {
+          if (tx.balanceChanges && tx.balanceChanges.length > 0) {
+            const changes = tx.balanceChanges.map((bc: { mint: string; amount: number; decimals: number }) => {
+              const sign = bc.amount >= 0 ? '+' : '';
+              const symbol = bc.mint === 'SOL' ? 'SOL' : formatAddress(bc.mint);
+              return `${sign}${Number(bc.amount).toLocaleString(undefined, { maximumFractionDigits: 9 })} ${symbol}`;
+            });
             lines.push(`   Balance Changes: ${changes.join(', ')}`);
           }
 
@@ -243,7 +214,7 @@ export function registerWalletTools(server: McpServer) {
         });
 
         // Pagination
-        const cursor = data.pagination?.nextCursor || data.nextCursor;
+        const cursor = data.pagination?.nextCursor;
         if (cursor) {
           lines.push(`**Next Cursor:** \`${cursor}\``);
         }
@@ -269,14 +240,15 @@ export function registerWalletTools(server: McpServer) {
     async ({ address, limit, cursor }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
-      const params = new URLSearchParams();
-      params.set('limit', String(Math.min(limit, 100)));
-      if (cursor) params.set('cursor', cursor);
-
       try {
-        const data = await restRequest(`/v1/wallet/${address}/transfers?${params.toString()}`);
+        const client = getHeliusClient();
+        const data = await client.wallet.getTransfers({
+          wallet: address,
+          limit: Math.min(limit, 100),
+          cursor,
+        });
 
-        const transfers = data.transfers || (Array.isArray(data) ? data : []);
+        const transfers = data.data;
 
         if (transfers.length === 0) {
           return mcpText(`**Wallet Transfers for ${formatAddress(address)}**\n\nNo transfers found.`);
@@ -284,7 +256,7 @@ export function registerWalletTools(server: McpServer) {
 
         const lines = [`**Wallet Transfers** (${transfers.length} transfers)`, ''];
 
-        transfers.forEach((t: any, i: number) => {
+        transfers.forEach((t: Transfer, i: number) => {
           const direction = t.direction === 'in' ? 'Received' : 'Sent';
           const time = t.timestamp ? formatTimestamp(t.timestamp) : 'N/A';
           const symbol = t.symbol || (t.mint ? formatAddress(t.mint) : 'SOL');
@@ -298,7 +270,7 @@ export function registerWalletTools(server: McpServer) {
         });
 
         // Pagination
-        const nextCursor = data.pagination?.cursor || data.cursor || data.nextCursor;
+        const nextCursor = data.pagination?.nextCursor;
         if (nextCursor) {
           lines.push(`**Next Cursor:** \`${nextCursor}\``);
         }
@@ -323,7 +295,8 @@ export function registerWalletTools(server: McpServer) {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
-        const data = await restRequest(`/v1/wallet/${address}/funded-by`);
+        const client = getHeliusClient();
+        const data = await client.wallet.getFundedBy({ wallet: address });
 
         const lines = ['**Wallet Funding Source**', ''];
 
@@ -335,7 +308,7 @@ export function registerWalletTools(server: McpServer) {
         if (data.amount !== undefined) {
           lines.push(`**Amount:** ${formatSol(data.amount)}`);
         }
-        if (data.timestamp) lines.push(`**Date:** ${data.timestamp}`);
+        if (data.date) lines.push(`**Date:** ${data.date}`);
         if (data.explorerUrl) lines.push(`**Explorer:** ${data.explorerUrl}`);
 
         return mcpText(lines.join('\n'));

--- a/helius-mcp/src/tools/webhooks.ts
+++ b/helius-mcp/src/tools/webhooks.ts
@@ -1,7 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { restRequest } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatAddress } from '../utils/formatters.js';
+import { noApiKeyResponse } from './shared.js';
 import { TRANSACTION_TYPES } from '../types/transaction-types.js';
 import { mcpText, mcpError, validateEnum, handleToolError, http404Error, http400Error } from '../utils/errors.js';
 
@@ -11,8 +12,10 @@ export function registerWebhookTools(server: McpServer) {
     'List all active webhooks for your Helius account. Shows webhook IDs, URLs, and monitored addresses.',
     {},
     async () => {
+      if (!hasApiKey()) return noApiKeyResponse();
       try {
-        const webhooks = await restRequest('/v0/webhooks');
+        const helius = getHeliusClient();
+        const webhooks = await helius.webhooks.getAll();
 
         if (!webhooks || webhooks.length === 0) {
           return mcpText('**Webhooks**\n\nNo webhooks configured.');
@@ -43,8 +46,10 @@ export function registerWebhookTools(server: McpServer) {
       webhookID: z.string().describe('Webhook ID')
     },
     async ({ webhookID }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
       try {
-        const webhook = await restRequest(`/v0/webhooks/${webhookID}`);
+        const helius = getHeliusClient();
+        const webhook = await helius.webhooks.get(webhookID);
 
         const lines = [
           `**Webhook Details**`,
@@ -84,6 +89,7 @@ export function registerWebhookTools(server: McpServer) {
       transactionTypes: z.array(z.string()).optional().describe('Transaction types to monitor - e.g. ["SWAP", "NFT_SALE"]. Use ["ANY"] to receive all types. Common types: NFT_SALE, NFT_MINT, SWAP, TRANSFER, STAKE_TOKEN, UNSTAKE_TOKEN, BUY, SELL, TOKEN_MINT')
     },
     async ({ webhookURL, webhookType, accountAddresses, transactionTypes }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
       const err = validateEnum(webhookType, ['enhanced', 'raw', 'discord'], 'Create Webhook Error', 'webhook type');
       if (err) return err;
       if (transactionTypes) {
@@ -93,16 +99,12 @@ export function registerWebhookTools(server: McpServer) {
         }
       }
       try {
-        const body: any = {
+        const helius = getHeliusClient();
+        const webhook = await helius.webhooks.create({
           webhookURL,
           webhookType,
           accountAddresses,
           transactionTypes
-        };
-
-        const webhook = await restRequest('/v0/webhooks', {
-          method: 'POST',
-          body: JSON.stringify(body)
         });
 
         return mcpText(`✅ **Webhook Created**\n\n**ID:** ${webhook.webhookID}\n**URL:** ${webhook.webhookURL}\n**Monitoring:** ${accountAddresses.length} address(es)`);
@@ -125,6 +127,7 @@ export function registerWebhookTools(server: McpServer) {
       transactionTypes: z.array(z.string()).optional().describe('New transaction type filters - e.g. ["SWAP", "NFT_SALE"]. Replaces existing filters.')
     },
     async ({ webhookID, webhookURL, webhookType, accountAddresses, transactionTypes }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
       if (webhookType) {
         const err = validateEnum(webhookType, ['enhanced', 'raw', 'discord'], 'Update Webhook Error', 'webhook type');
         if (err) return err;
@@ -136,24 +139,22 @@ export function registerWebhookTools(server: McpServer) {
         }
       }
       try {
+        const helius = getHeliusClient();
         // Helius PUT /v0/webhooks requires the full webhook object.
         // Fetch the existing webhook first so callers only need to supply changed fields.
-        const existing = await restRequest(`/v0/webhooks/${webhookID}`);
-        const body: any = {
+        const existing = await helius.webhooks.get(webhookID);
+        const mergedParams: any = {
           webhookURL: webhookURL ?? existing.webhookURL,
           webhookType: webhookType ?? existing.webhookType,
           accountAddresses: accountAddresses ?? existing.accountAddresses,
         };
         if (transactionTypes) {
-          body.transactionTypes = transactionTypes;
+          mergedParams.transactionTypes = transactionTypes;
         } else if (existing.transactionTypes) {
-          body.transactionTypes = existing.transactionTypes;
+          mergedParams.transactionTypes = existing.transactionTypes;
         }
 
-        const webhook = await restRequest(`/v0/webhooks/${webhookID}`, {
-          method: 'PUT',
-          body: JSON.stringify(body)
-        });
+        const webhook = await helius.webhooks.update(webhookID, mergedParams);
 
         return mcpText(`✅ **Webhook Updated**\n\n**ID:** ${webhook.webhookID}\n**URL:** ${webhook.webhookURL}`);
       } catch (err) {
@@ -172,10 +173,10 @@ export function registerWebhookTools(server: McpServer) {
       webhookID: z.string().describe('Webhook ID to delete')
     },
     async ({ webhookID }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
       try {
-        await restRequest(`/v0/webhooks/${webhookID}`, {
-          method: 'DELETE',
-        });
+        const helius = getHeliusClient();
+        await helius.webhooks.delete(webhookID);
 
         return mcpText(`✅ Webhook ${webhookID} deleted successfully.`);
       } catch (err) {

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -1,4 +1,5 @@
 import { createHelius, type HeliusClient } from 'helius-sdk';
+import { MCP_USER_AGENT } from '../http.js';
 
 let sessionApiKey: string | null = null;
 let sessionNetwork: 'mainnet-beta' | 'devnet' = 'mainnet-beta';
@@ -24,7 +25,7 @@ export function hasApiKey(): boolean {
 export function getHeliusClient(): HeliusClient {
   if (!heliusClient) {
     const apiKey = getApiKey();
-    heliusClient = createHelius({ apiKey });
+    heliusClient = createHelius({ apiKey, userAgent: MCP_USER_AGENT });
   }
   return heliusClient;
 }
@@ -66,6 +67,7 @@ export async function restRequest(endpoint: string, options: RequestInit = {}): 
   const url = `https://api.helius.xyz${endpoint}${separator}api-key=${apiKey}`;
 
   const headers: Record<string, string> = { ...options.headers as Record<string, string> };
+  headers['User-Agent'] = MCP_USER_AGENT;
   if (options.body) {
     headers['Content-Type'] ??= 'application/json';
   }

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -41,15 +41,6 @@ export function getNetwork(): 'mainnet-beta' | 'devnet' {
   return sessionNetwork;
 }
 
-export function getRpcUrl(): string {
-  const apiKey = getApiKey();
-  const network = getNetwork();
-  if (network === 'devnet') {
-    return `https://devnet.helius-rpc.com/?api-key=${apiKey}`;
-  }
-  return `https://mainnet.helius-rpc.com/?api-key=${apiKey}`;
-}
-
 export function getEnhancedWebSocketUrl(): string {
   const apiKey = getApiKey();
   const network = getNetwork();
@@ -67,44 +58,6 @@ export function getLaserstreamUrl(region?: 'ewr' | 'pitt' | 'slc' | 'lax' | 'lon
   }
   const selectedRegion = region || 'ewr';
   return `https://laserstream-mainnet-${selectedRegion}.helius-rpc.com`;
-}
-
-export async function rpcRequest(method: string, params: any[] = []): Promise<any> {
-  const url = getRpcUrl();
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-  }
-
-  const data = await response.json();
-  if (data.error) {
-    throw new Error(`RPC Error: ${data.error.message || JSON.stringify(data.error)}`);
-  }
-  return data.result;
-}
-
-export async function dasRequest(method: string, params: any = {}): Promise<any> {
-  const url = getRpcUrl();
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-  }
-
-  const data = await response.json();
-  if (data.error) {
-    throw new Error(`DAS Error: ${data.error.message || JSON.stringify(data.error)}`);
-  }
-  return data.result;
 }
 
 export async function restRequest(endpoint: string, options: RequestInit = {}): Promise<any> {


### PR DESCRIPTION
 Migrate MCP tools from raw RPC/DAS calls to Helius SDK
                                                                                                                                                                 
  Summary         

  - Replace manual fetch-based JSON-RPC and DAS API calls with the Helius SDK client across all tool modules
  - Remove now-unused getRpcUrl(), rpcRequest(), and dasRequest() utility functions from helius.ts
  - Handle SDK's bigint return types (e.g. lamports) by converting to Number where needed for formatting

  Changed files

  - tools/accounts.ts — use SDK for getAccountInfo / getMultipleAccounts / getProgramAccounts / getTokenAccounts
  - tools/blocks.ts — use SDK for getBlock
  - tools/das-extras.ts — use SDK for DAS calls (editions, proofs)
  - tools/fees.ts — use SDK for priority fee estimates
  - tools/network.ts — use SDK for epoch info, supply, version, block height
  - tools/transactions.ts — use SDK for transaction history, parsing, and signatures
  - tools/webhooks.ts — minor cleanup aligned with SDK usage
  - utils/helius.ts — remove getRpcUrl, rpcRequest, dasRequest (-47 lines)

  Impact

  -315 net lines — removes boilerplate HTTP/JSON-RPC plumbing in favor of typed SDK methods, improving maintainability and consistency across the codebase.

  Test plan

  - Verify each MCP tool still returns correct output (accounts, transactions, blocks, fees, network, DAS, webhooks)
  - Confirm bigint → Number conversions don't lose precision for typical balances
  - Test on both mainnet and devnet networks