### PR TITLE
feat: OpenPay integration for CLI and MCP server

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { signupCommand } from "../src/commands/signup.js";
+import { upgradeCommand } from "../src/commands/upgrade.js";
+import { payCommand } from "../src/commands/pay.js";
 import { loginCommand } from "../src/commands/login.js";
 import { projectsCommand } from "../src/commands/projects.js";
 import { projectCommand } from "../src/commands/project.js";
@@ -73,10 +75,29 @@ program
 
 program
   .command("signup")
-  .description("Pay 1 USDC + create account + project")
+  .description("Create account + project (Developer plan, $49/mo)")
   .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
   .option("--json", "Output in JSON format")
   .action(signupCommand);
+
+program
+  .command("upgrade")
+  .description("Upgrade your Helius plan")
+  .requiredOption("--plan <name>", "Target plan: developer, business, professional")
+  .option("--period <period>", "Billing period: monthly or yearly", "monthly")
+  .option("--coupon <code>", "Coupon code")
+  .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("--json", "Output in JSON format")
+  .action(function(this: any) { upgradeCommand(opts(this)); });
+
+program
+  .command("pay <payment-intent-id>")
+  .description("Pay an existing payment intent (e.g., renewal)")
+  .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("--json", "Output in JSON format")
+  .action(function(this: any, id: string) { payCommand(id, opts(this)); });
 
 program
   .command("login")

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -80,6 +80,9 @@ program
   .option("--plan <plan>", "Plan: basic ($1), developer ($49/mo), business ($499/mo), professional ($999/mo)")
   .option("--period <period>", "Billing period: monthly or yearly (paid plans only)", "monthly")
   .option("--coupon <code>", "Coupon code (paid plans only)")
+  .option("--email <email>", "Email address (required for paid plans)")
+  .option("--first-name <name>", "First name (required for paid plans)")
+  .option("--last-name <name>", "Last name (required for paid plans)")
   .option("--json", "Output in JSON format")
   .action(signupCommand);
 

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -75,8 +75,11 @@ program
 
 program
   .command("signup")
-  .description("Create account + project (Developer plan, $49/mo)")
+  .description("Create a Helius account (default: $1 basic plan, or specify a paid plan)")
   .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
+  .option("--plan <plan>", "Plan: basic ($1), developer ($49/mo), business ($499/mo), professional ($999/mo)")
+  .option("--period <period>", "Billing period: monthly or yearly (paid plans only)", "monthly")
+  .option("--coupon <code>", "Coupon code (paid plans only)")
   .option("--json", "Output in JSON format")
   .action(signupCommand);
 

--- a/helius-cli/src/commands/keygen.ts
+++ b/helius-cli/src/commands/keygen.ts
@@ -5,6 +5,7 @@ import os from "os";
 import { generateKeypair } from "helius-sdk/auth/generateKeypair";
 import { getAddress } from "helius-sdk/auth/getAddress";
 import { loadKeypair } from "helius-sdk/auth/loadKeypair";
+import { PLAN_CATALOG } from "helius-sdk/auth/constants";
 
 const DEFAULT_KEYPAIR_PATH = path.join(os.homedir(), ".helius", "keypair.json");
 
@@ -48,7 +49,19 @@ export async function keygenCommand(options: KeygenOptions): Promise<void> {
   console.log("");
   console.log(chalk.yellow("To use this wallet, fund it with:"));
   console.log(`  • ${chalk.cyan("~0.01 SOL")} for transaction fees`);
-  console.log(`  • ${chalk.cyan("49 USDC")} for Helius Developer plan`);
+  console.log(`  • USDC for your chosen plan:`);
+  console.log(`      ${"basic".padEnd(15)}${chalk.cyan("$1")} (one-time)`);
+  for (const [key, plan] of Object.entries(PLAN_CATALOG)) {
+    const price = `$${plan.monthlyPrice / 100}`;
+    console.log(`      ${key.padEnd(15)}${chalk.cyan(price)}/mo`);
+  }
+  console.log("");
+  console.log(`Then run: ${chalk.green("helius signup")}`);
+  console.log(
+    chalk.gray(
+      "  Options: --plan <plan> --email <email> --first-name <name> --last-name <name> --coupon <code>",
+    ),
+  );
 }
 
 export function getDefaultKeypairPath(): string {

--- a/helius-cli/src/commands/keygen.ts
+++ b/helius-cli/src/commands/keygen.ts
@@ -31,7 +31,7 @@ export async function keygenCommand(options: KeygenOptions): Promise<void> {
   }
 
   // Generate keypair
-  const keypair = generateKeypair();
+  const keypair = await generateKeypair();
 
   // Save in Solana CLI format (64-byte array)
   const secretKeyArray = Array.from(keypair.secretKey);
@@ -47,8 +47,8 @@ export async function keygenCommand(options: KeygenOptions): Promise<void> {
   console.log(`Address: ${chalk.cyan(address)}`);
   console.log("");
   console.log(chalk.yellow("To use this wallet, fund it with:"));
-  console.log(`  • ${chalk.cyan("~0.001 SOL")} for transaction fees`);
-  console.log(`  • ${chalk.cyan("1 USDC")} for Helius signup`);
+  console.log(`  • ${chalk.cyan("~0.01 SOL")} for transaction fees`);
+  console.log(`  • ${chalk.cyan("49 USDC")} for Helius Developer plan`);
 }
 
 export function getDefaultKeypairPath(): string {

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -32,7 +32,7 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
 
     // Sign auth message
     spinner?.start("Signing authentication message...");
-    const { message, signature } = signAuthMessage(keypair.secretKey);
+    const { message, signature } = await signAuthMessage(keypair.secretKey);
     spinner?.succeed("Message signed");
 
     // Call login API

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -1,0 +1,123 @@
+import chalk from "chalk";
+import ora from "ora";
+import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
+import { signup } from "../lib/api.js";
+import { getPaymentIntent, executeRenewal } from "../lib/checkout.js";
+import { setJwt } from "../lib/config.js";
+import { keypairExists } from "./keygen.js";
+import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import readline from "readline";
+
+interface PayOptions extends OutputOptions {
+  keypair: string;
+  yes?: boolean;
+}
+
+function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
+}
+
+export async function payCommand(paymentIntentId: string, options: PayOptions): Promise<void> {
+  const spinner = options.json ? null : ora();
+
+  try {
+    // Check keypair exists
+    if (!keypairExists(options.keypair)) {
+      if (options.json) {
+        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, true);
+      }
+      console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
+      console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));
+      process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+    }
+
+    // 1. Load keypair and authenticate
+    spinner?.start("Loading keypair...");
+    const keypair = await loadKeypairFromFile(options.keypair);
+    const walletAddress = await getAddress(keypair);
+    spinner?.succeed(`Wallet: ${chalk.cyan(walletAddress)}`);
+
+    spinner?.start("Authenticating...");
+    const { message, signature } = await signAuthMessage(keypair.secretKey);
+    const authResult = await signup(message, signature, walletAddress);
+    setJwt(authResult.token);
+    spinner?.succeed("Authenticated");
+
+    // 2. Fetch payment intent details
+    spinner?.start("Fetching payment intent...");
+    const intent = await getPaymentIntent(authResult.token, paymentIntentId);
+    spinner?.succeed("Payment intent loaded");
+
+    const amountUsdc = intent.amount / 100;
+    const expiresAt = new Date(intent.expiresAt).toLocaleString();
+
+    if (!options.json) {
+      console.log("");
+      console.log(`  Payment ID:  ${chalk.cyan(intent.id)}`);
+      console.log(`  Amount:      ${chalk.bold(`$${amountUsdc.toFixed(2)} USDC`)}`);
+      console.log(`  Status:      ${intent.status}`);
+      console.log(`  Expires:     ${expiresAt}`);
+      console.log("");
+    }
+
+    if (intent.status !== "pending") {
+      if (options.json) {
+        exitWithError("PAYMENT_FAILED", `Payment intent is ${intent.status}, cannot pay`, { intentId: intent.id }, true);
+      }
+      spinner?.fail(`Payment intent is ${intent.status} — cannot pay`);
+      process.exit(ExitCode.PAYMENT_FAILED);
+    }
+
+    if (!options.yes) {
+      const ok = await confirm(`  Pay $${amountUsdc.toFixed(2)} USDC? (y/N) `);
+      if (!ok) {
+        console.log(chalk.gray("  Cancelled."));
+        return;
+      }
+    }
+
+    // 3. Execute renewal payment
+    spinner?.start("Processing payment...");
+    const result = await executeRenewal(
+      keypair.secretKey,
+      authResult.token,
+      paymentIntentId,
+    );
+
+    if (result.status !== "completed") {
+      throw new Error(
+        `Payment ${result.status}${result.txSignature ? `. TX: ${result.txSignature}` : ""}`
+      );
+    }
+    spinner?.succeed("Payment complete");
+
+    if (options.json) {
+      outputJson({
+        status: "SUCCESS",
+        paymentIntentId: intent.id,
+        amount: intent.amount,
+        transaction: result.txSignature,
+      });
+      return;
+    }
+
+    console.log("\n" + chalk.green("✓ Payment complete!"));
+    if (result.txSignature) {
+      console.log(`\nView transaction: ${chalk.blue(`https://solscan.io/tx/${result.txSignature}`)}`);
+    }
+  } catch (error) {
+    if (options.json) {
+      exitWithError("PAYMENT_FAILED", error instanceof Error ? error.message : String(error), undefined, true);
+    }
+    spinner?.fail(
+      `Error: ${error instanceof Error ? error.message : String(error)}`
+    );
+    process.exit(ExitCode.GENERAL_ERROR);
+  }
+}

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -109,7 +109,7 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
 
     console.log("\n" + chalk.green("✓ Payment complete!"));
     if (result.txSignature) {
-      console.log(`\nView transaction: ${chalk.blue(`https://solscan.io/tx/${result.txSignature}`)}`);
+      console.log(`\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`);
     }
   } catch (error) {
     if (options.json) {

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -2,10 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
 import { signup, listProjects, getProject } from "../lib/api.js";
-import { checkSolBalance, MIN_SOL_FOR_TX } from "../lib/payment.js";
-import { checkUsdcBalance } from "../lib/payment.js";
-import { initializeCheckout, pollCheckoutCompletion } from "../lib/checkout.js";
-import { payWithMemo } from "../lib/checkout.js";
+import { executeCheckout, DEFAULT_DEVELOPER_MONTHLY_PRICE_ID } from "../lib/checkout.js";
 import { setJwt, setApiKey, setSharedApiKey, SHARED_CONFIG_PATH } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
@@ -13,8 +10,6 @@ import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/
 interface SignupOptions extends OutputOptions {
   keypair: string;
 }
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export async function signupCommand(options: SignupOptions): Promise<void> {
   const spinner = options.json ? null : ora();
@@ -38,7 +33,7 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
 
     // 2. Authenticate first (no payment yet)
     spinner?.start("Signing authentication message...");
-    const { message, signature } = signAuthMessage(keypair.secretKey);
+    const { message, signature } = await signAuthMessage(keypair.secretKey);
     spinner?.succeed("Message signed");
 
     spinner?.start("Authenticating...");
@@ -97,93 +92,52 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
 
     spinner?.succeed("No existing projects");
 
-    // 4. Initialize checkout
-    spinner?.start("Initializing checkout...");
-    const intent = await initializeCheckout(authResult.token, { paymentType: "subscription" });
-    spinner?.succeed("Checkout initialized");
+    // 4. Execute checkout (SDK handles init → balance check → pay → poll → project)
+    spinner?.start("Processing signup payment...");
+    const checkoutResult = await executeCheckout(
+      keypair.secretKey,
+      authResult.token,
+      { priceId: DEFAULT_DEVELOPER_MONTHLY_PRICE_ID, refId: authResult.refId },
+    );
 
-    // 5. Check balances against intent amount
-    const amountRaw = BigInt(Math.round(intent.amount * 1_000_000));
-
-    spinner?.start("Checking SOL balance...");
-    const solBalance = await checkSolBalance(walletAddress);
-    if (solBalance < MIN_SOL_FOR_TX) {
-      if (options.json) {
-        exitWithError("INSUFFICIENT_SOL", "Insufficient SOL for transaction fees", {
-          have: Number(solBalance) / 1_000_000_000,
-          need: 0.001,
-          fundAddress: walletAddress,
-        }, true);
-      }
-      spinner?.fail(`Insufficient SOL for transaction fees`);
-      console.error(chalk.red(`Have: ${(Number(solBalance) / 1_000_000_000).toFixed(6)} SOL`));
-      console.error(chalk.red(`Need: ~0.001 SOL`));
-      console.error(chalk.gray(`\nSend SOL to: ${walletAddress}`));
-      process.exit(ExitCode.INSUFFICIENT_SOL);
-    }
-    spinner?.succeed(`SOL balance: ${chalk.green((Number(solBalance) / 1_000_000_000).toFixed(4))} SOL`);
-
-    spinner?.start("Checking USDC balance...");
-    const usdcBalance = await checkUsdcBalance(walletAddress);
-    if (usdcBalance < amountRaw) {
-      if (options.json) {
-        exitWithError("INSUFFICIENT_USDC", "Insufficient USDC", {
-          have: Number(usdcBalance) / 1_000_000,
-          need: intent.amount,
-          fundAddress: walletAddress,
-        }, true);
-      }
-      spinner?.fail(`Insufficient USDC`);
-      console.error(chalk.red(`Have: ${(Number(usdcBalance) / 1_000_000).toFixed(2)} USDC`));
-      console.error(chalk.red(`Need: ${intent.amount} USDC`));
-      console.error(chalk.gray(`\nSend USDC to: ${walletAddress}`));
-      process.exit(ExitCode.INSUFFICIENT_USDC);
-    }
-    spinner?.succeed(`USDC balance: ${chalk.green((Number(usdcBalance) / 1_000_000).toFixed(2))} USDC`);
-
-    // 6. Send payment with memo
-    spinner?.start(`Sending ${intent.amount} USDC payment...`);
-    const txSignature = await payWithMemo(keypair.secretKey, intent.treasuryWallet, amountRaw, intent.memo);
-    spinner?.succeed(`Payment sent: ${chalk.cyan(txSignature)}`);
-
-    // 7. Wait for payment confirmation
-    spinner?.start("Waiting for payment confirmation...");
-    const status = await pollCheckoutCompletion(authResult.token, intent.paymentIntentId);
-    if (status.status !== "completed") {
-      throw new Error(`Payment ${status.status}. TX: ${txSignature}`);
+    if (checkoutResult.status !== "completed") {
+      throw new Error(
+        `Checkout ${checkoutResult.status}${checkoutResult.txSignature ? `. TX: ${checkoutResult.txSignature}` : ""}`
+      );
     }
     spinner?.succeed("Payment confirmed");
 
-    // 8. Wait for project creation
-    spinner?.start("Setting up project...");
-    let project = null;
-    let apiKey: string | null = null;
-    for (let i = 0; i < 15; i++) {
-      const projects = await listProjects(authResult.token);
-      if (projects.length > 0) {
-        project = projects[0];
-        const details = await getProject(authResult.token, project.id);
-        apiKey = details.apiKeys?.[0]?.keyId || null;
-        break;
-      }
-      await sleep(2000);
-    }
-    if (!project) {
-      throw new Error("Project creation timed out. Payment successful — contact support.");
-    }
-    spinner?.succeed("Project created");
+    const projectId = checkoutResult.projectId;
+    const apiKey = checkoutResult.apiKey || null;
+    const txSignature = checkoutResult.txSignature;
 
     if (apiKey) {
       setApiKey(apiKey);
       setSharedApiKey(apiKey);
     }
 
+    // Fetch project for display details
+    let projectName: string | undefined;
+    let dnsRecords: Array<{ dns: string; network: string; usageType: string }> = [];
+    if (projectId) {
+      try {
+        const projects = await listProjects(authResult.token);
+        const proj = projects.find(p => p.id === projectId);
+        if (proj) {
+          projectName = proj.name;
+          dnsRecords = proj.dnsRecords || [];
+        }
+      } catch {
+        // Non-critical — display proceeds without project name
+      }
+    }
+
     if (options.json) {
       outputJson({
         status: "SUCCESS",
         wallet: walletAddress,
-        projectId: project.id,
-        projectName: project.name,
+        projectId,
+        projectName: projectName || null,
         apiKey,
         configPath: apiKey ? SHARED_CONFIG_PATH : null,
         endpoints: apiKey ? {
@@ -197,25 +151,29 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     }
 
     console.log("\n" + chalk.green("✓ Signup complete!"));
-    console.log(`\nProject ID: ${chalk.cyan(project.id)}`);
+    if (projectId) {
+      console.log(`\nProject ID: ${chalk.cyan(projectId)}`);
+    }
     if (apiKey) {
       console.log(`API Key: ${chalk.cyan(apiKey)}`);
       console.log(chalk.green(`API key saved to ${SHARED_CONFIG_PATH}`));
     }
 
     // Show RPC endpoints if available
-    if (project.dnsRecords && project.dnsRecords.length > 0) {
+    if (dnsRecords.length > 0) {
       console.log(chalk.bold("\nRPC Endpoints:"));
-      for (const record of project.dnsRecords) {
+      for (const record of dnsRecords) {
         if (record.usageType === "rpc") {
           console.log(`  ${record.network}: ${chalk.blue("https://" + record.dns)}`);
         }
       }
     }
 
-    console.log(
-      `\nView transaction: ${chalk.blue(`https://solscan.io/tx/${txSignature}`)}`
-    );
+    if (txSignature) {
+      console.log(
+        `\nView transaction: ${chalk.blue(`https://solscan.io/tx/${txSignature}`)}`
+      );
+    }
   } catch (error) {
     if (options.json) {
       exitWithError("SIGNUP_FAILED", error instanceof Error ? error.message : String(error), undefined, true);

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -1,10 +1,12 @@
 import chalk from "chalk";
 import ora from "ora";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
-import { signup, createProject, listProjects, getProject, type Project } from "../lib/api.js";
-import { payUSDC, checkUsdcBalance, checkSolBalance, MIN_SOL_FOR_TX } from "../lib/payment.js";
+import { signup, listProjects, getProject } from "../lib/api.js";
+import { checkSolBalance, MIN_SOL_FOR_TX } from "../lib/payment.js";
+import { checkUsdcBalance } from "../lib/payment.js";
+import { initializeCheckout, pollCheckoutCompletion } from "../lib/checkout.js";
+import { payWithMemo } from "../lib/checkout.js";
 import { setJwt, setApiKey, setSharedApiKey, SHARED_CONFIG_PATH } from "../lib/config.js";
-import { PAYMENT_AMOUNT } from "../constants.js";
 import { keypairExists } from "./keygen.js";
 import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
 
@@ -13,27 +15,6 @@ interface SignupOptions extends OutputOptions {
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-async function createProjectWithRetry(
-  jwt: string,
-  maxRetries = 3,
-  delayMs = 2000
-): Promise<Project> {
-  let lastError: Error | null = null;
-
-  for (let i = 0; i < maxRetries; i++) {
-    try {
-      return await createProject(jwt);
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      if (i < maxRetries - 1) {
-        await sleep(delayMs);
-      }
-    }
-  }
-
-  throw lastError;
-}
 
 export async function signupCommand(options: SignupOptions): Promise<void> {
   const spinner = options.json ? null : ora();
@@ -116,7 +97,14 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
 
     spinner?.succeed("No existing projects");
 
-    // 4. Check SOL balance for transaction fees
+    // 4. Initialize checkout
+    spinner?.start("Initializing checkout...");
+    const intent = await initializeCheckout(authResult.token, { paymentType: "subscription" });
+    spinner?.succeed("Checkout initialized");
+
+    // 5. Check balances against intent amount
+    const amountRaw = BigInt(Math.round(intent.amount * 1_000_000));
+
     spinner?.start("Checking SOL balance...");
     const solBalance = await checkSolBalance(walletAddress);
     if (solBalance < MIN_SOL_FOR_TX) {
@@ -135,37 +123,55 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     }
     spinner?.succeed(`SOL balance: ${chalk.green((Number(solBalance) / 1_000_000_000).toFixed(4))} SOL`);
 
-    // 5. Check USDC balance
     spinner?.start("Checking USDC balance...");
     const usdcBalance = await checkUsdcBalance(walletAddress);
-    if (usdcBalance < PAYMENT_AMOUNT) {
+    if (usdcBalance < amountRaw) {
       if (options.json) {
         exitWithError("INSUFFICIENT_USDC", "Insufficient USDC", {
           have: Number(usdcBalance) / 1_000_000,
-          need: 1,
+          need: intent.amount,
           fundAddress: walletAddress,
         }, true);
       }
       spinner?.fail(`Insufficient USDC`);
       console.error(chalk.red(`Have: ${(Number(usdcBalance) / 1_000_000).toFixed(2)} USDC`));
-      console.error(chalk.red(`Need: 1 USDC`));
+      console.error(chalk.red(`Need: ${intent.amount} USDC`));
       console.error(chalk.gray(`\nSend USDC to: ${walletAddress}`));
       process.exit(ExitCode.INSUFFICIENT_USDC);
     }
     spinner?.succeed(`USDC balance: ${chalk.green((Number(usdcBalance) / 1_000_000).toFixed(2))} USDC`);
 
-    spinner?.start("Sending 1 USDC payment...");
-    const txSignature = await payUSDC(keypair.secretKey);
+    // 6. Send payment with memo
+    spinner?.start(`Sending ${intent.amount} USDC payment...`);
+    const txSignature = await payWithMemo(keypair.secretKey, intent.treasuryWallet, amountRaw, intent.memo);
     spinner?.succeed(`Payment sent: ${chalk.cyan(txSignature)}`);
 
-    // 6. Create project (with retry - backend needs time to verify payment)
-    spinner?.start("Creating project...");
-    const project = await createProjectWithRetry(authResult.token, 3, 2000);
-    spinner?.succeed("Project created");
+    // 7. Wait for payment confirmation
+    spinner?.start("Waiting for payment confirmation...");
+    const status = await pollCheckoutCompletion(authResult.token, intent.paymentIntentId);
+    if (status.status !== "completed") {
+      throw new Error(`Payment ${status.status}. TX: ${txSignature}`);
+    }
+    spinner?.succeed("Payment confirmed");
 
-    // Get full project details for comprehensive output
-    const projectDetails = await getProject(authResult.token, project.id);
-    const apiKey = projectDetails.apiKeys?.[0]?.keyId || project.apiKeys?.[0]?.keyId || null;
+    // 8. Wait for project creation
+    spinner?.start("Setting up project...");
+    let project = null;
+    let apiKey: string | null = null;
+    for (let i = 0; i < 15; i++) {
+      const projects = await listProjects(authResult.token);
+      if (projects.length > 0) {
+        project = projects[0];
+        const details = await getProject(authResult.token, project.id);
+        apiKey = details.apiKeys?.[0]?.keyId || null;
+        break;
+      }
+      await sleep(2000);
+    }
+    if (!project) {
+      throw new Error("Project creation timed out. Payment successful — contact support.");
+    }
+    spinner?.succeed("Project created");
 
     if (apiKey) {
       setApiKey(apiKey);
@@ -184,7 +190,7 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
           mainnet: `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
           devnet: `https://devnet.helius-rpc.com/?api-key=${apiKey}`,
         } : null,
-        credits: projectDetails.creditsUsage?.remainingCredits || 1000000,
+        credits: null,
         transaction: txSignature,
       });
       return;

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -11,6 +11,9 @@ interface SignupOptions extends OutputOptions {
   plan?: string;
   period?: string;
   coupon?: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
 }
 
 function mapErrorToExitCode(message: string): number {
@@ -52,6 +55,9 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
       plan: options.plan,
       period: (options.period as "monthly" | "yearly") || undefined,
       couponCode: options.coupon,
+      email: options.email,
+      firstName: options.firstName,
+      lastName: options.lastName,
     });
 
     spinner?.succeed("Signup complete");

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -1,14 +1,27 @@
 import chalk from "chalk";
 import ora from "ora";
-import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
-import { signup, listProjects, getProject } from "../lib/api.js";
-import { executeCheckout } from "../lib/checkout.js";
+import { loadKeypairFromFile } from "../lib/wallet.js";
+import { agenticSignup, listProjects } from "../lib/api.js";
 import { setJwt, setApiKey, setSharedApiKey, SHARED_CONFIG_PATH } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
 
 interface SignupOptions extends OutputOptions {
   keypair: string;
+  plan?: string;
+  period?: string;
+  coupon?: string;
+}
+
+function mapErrorToExitCode(message: string): number {
+  if (message.includes("Insufficient SOL")) return ExitCode.INSUFFICIENT_SOL;
+  if (message.includes("Insufficient USDC")) return ExitCode.INSUFFICIENT_USDC;
+  if (
+    message.includes("Checkout failed") ||
+    message.includes("Checkout expired") ||
+    message.includes("Checkout timeout")
+  ) return ExitCode.PAYMENT_FAILED;
+  return ExitCode.GENERAL_ERROR;
 }
 
 export async function signupCommand(options: SignupOptions): Promise<void> {
@@ -25,162 +38,128 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
       process.exit(ExitCode.KEYPAIR_NOT_FOUND);
     }
 
-    // 1. Load keypair
+    // Load keypair
     spinner?.start("Loading keypair...");
     const keypair = await loadKeypairFromFile(options.keypair);
-    const walletAddress = await getAddress(keypair);
-    spinner?.succeed(`Wallet: ${chalk.cyan(walletAddress)}`);
+    spinner?.succeed("Wallet loaded");
 
-    // 2. Authenticate first (no payment yet)
-    spinner?.start("Signing authentication message...");
-    const { message, signature } = await signAuthMessage(keypair.secretKey);
-    spinner?.succeed("Message signed");
+    // Run agenticSignup (handles all plan paths)
+    const planLabel = options.plan || "basic";
+    spinner?.start(`Signing up (${planLabel} plan)...`);
 
-    spinner?.start("Authenticating...");
-    const authResult = await signup(message, signature, walletAddress);
-    setJwt(authResult.token);
-    spinner?.succeed(authResult.newUser ? "Account created" : "Authenticated");
+    const result = await agenticSignup({
+      secretKey: keypair.secretKey,
+      plan: options.plan,
+      period: (options.period as "monthly" | "yearly") || undefined,
+      couponCode: options.coupon,
+    });
 
-    // 3. Check existing projects BEFORE payment
-    spinner?.start("Checking existing projects...");
-    const existingProjects = await listProjects(authResult.token);
+    spinner?.succeed("Signup complete");
 
-    if (existingProjects.length > 0) {
-      // User already has projects - no payment needed
-      spinner?.succeed("Found existing project(s)");
+    // Save config
+    if (result.jwt) {
+      setJwt(result.jwt);
+    }
+    if (result.apiKey) {
+      setApiKey(result.apiKey);
+      setSharedApiKey(result.apiKey);
+    }
 
-      // Fetch full details to get API key
-      const project = existingProjects[0];
-      const projectDetails = await getProject(authResult.token, project.id);
-      const apiKey = projectDetails.apiKeys?.[0]?.keyId || null;
-
-      if (apiKey) {
-        setApiKey(apiKey);
-        setSharedApiKey(apiKey);
-      }
+    // Handle result statuses
+    if (result.status === "existing_project") {
+      // Show all projects for existing users
+      const allProjects = await listProjects(result.jwt);
 
       if (options.json) {
         outputJson({
           status: "EXISTING_PROJECT",
-          wallet: walletAddress,
-          projectId: project.id,
-          projectName: project.name,
-          apiKey,
-          configPath: apiKey ? SHARED_CONFIG_PATH : null,
-          endpoints: apiKey ? {
-            mainnet: `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
-            devnet: `https://devnet.helius-rpc.com/?api-key=${apiKey}`,
-          } : null,
-          credits: projectDetails.creditsUsage?.remainingCredits || null,
+          wallet: result.walletAddress,
+          projectId: result.projectId,
+          apiKey: result.apiKey,
+          configPath: result.apiKey ? SHARED_CONFIG_PATH : null,
+          endpoints: result.endpoints,
+          credits: result.credits,
+          projects: allProjects.map((p) => ({ id: p.id, name: p.name })),
         });
         return;
       }
 
       console.log("\n" + chalk.yellow("You already have project(s):"));
-      for (const p of existingProjects) {
+      for (const p of allProjects) {
         console.log(`  ${chalk.cyan(p.id)} - ${p.name}`);
         if (p.subscription) {
           console.log(`    Plan: ${p.subscription.plan}`);
         }
       }
-      if (apiKey) {
+      if (result.apiKey) {
         console.log(chalk.green(`\nAPI key saved to ${SHARED_CONFIG_PATH}`));
       }
       console.log(chalk.gray("\nNo payment required. Use `helius projects` to view details."));
       return;
     }
 
-    spinner?.succeed("No existing projects");
-
-    // 4. Execute checkout (SDK handles init → balance check → pay → poll → project)
-    spinner?.start("Processing signup payment...");
-    const checkoutResult = await executeCheckout(
-      keypair.secretKey,
-      authResult.token,
-      { plan: "developer", period: "monthly", refId: authResult.refId },
-    );
-
-    if (checkoutResult.status !== "completed") {
-      throw new Error(
-        `Checkout ${checkoutResult.status}${checkoutResult.txSignature ? `. TX: ${checkoutResult.txSignature}` : ""}`
-      );
-    }
-    spinner?.succeed("Payment confirmed");
-
-    const projectId = checkoutResult.projectId;
-    const apiKey = checkoutResult.apiKey || null;
-    const txSignature = checkoutResult.txSignature;
-
-    if (apiKey) {
-      setApiKey(apiKey);
-      setSharedApiKey(apiKey);
-    }
-
-    // Fetch project for display details
-    let projectName: string | undefined;
-    let dnsRecords: Array<{ dns: string; network: string; usageType: string }> = [];
-    if (projectId) {
-      try {
-        const projects = await listProjects(authResult.token);
-        const proj = projects.find(p => p.id === projectId);
-        if (proj) {
-          projectName = proj.name;
-          dnsRecords = proj.dnsRecords || [];
-        }
-      } catch {
-        // Non-critical — display proceeds without project name
+    if (result.status === "upgraded") {
+      if (options.json) {
+        outputJson({
+          status: "UPGRADED",
+          wallet: result.walletAddress,
+          projectId: result.projectId,
+          apiKey: result.apiKey,
+          plan: planLabel,
+          transaction: result.txSignature || null,
+        });
+        return;
       }
+
+      console.log("\n" + chalk.green(`Plan upgraded to ${planLabel}!`));
+      console.log(`\nProject ID: ${chalk.cyan(result.projectId)}`);
+      if (result.txSignature) {
+        console.log(
+          `Transaction: ${chalk.blue(`https://solscan.io/tx/${result.txSignature}`)}`
+        );
+      }
+      return;
     }
 
+    // status === "success"
     if (options.json) {
       outputJson({
         status: "SUCCESS",
-        wallet: walletAddress,
-        projectId,
-        projectName: projectName || null,
-        apiKey,
-        configPath: apiKey ? SHARED_CONFIG_PATH : null,
-        endpoints: apiKey ? {
-          mainnet: `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
-          devnet: `https://devnet.helius-rpc.com/?api-key=${apiKey}`,
-        } : null,
-        credits: null,
-        transaction: txSignature,
+        wallet: result.walletAddress,
+        projectId: result.projectId,
+        apiKey: result.apiKey,
+        configPath: result.apiKey ? SHARED_CONFIG_PATH : null,
+        endpoints: result.endpoints,
+        credits: result.credits,
+        transaction: result.txSignature || null,
       });
       return;
     }
 
-    console.log("\n" + chalk.green("✓ Signup complete!"));
-    if (projectId) {
-      console.log(`\nProject ID: ${chalk.cyan(projectId)}`);
-    }
-    if (apiKey) {
-      console.log(`API Key: ${chalk.cyan(apiKey)}`);
+    console.log("\n" + chalk.green("Signup complete!"));
+    console.log(`\nProject ID: ${chalk.cyan(result.projectId)}`);
+    if (result.apiKey) {
+      console.log(`API Key: ${chalk.cyan(result.apiKey)}`);
       console.log(chalk.green(`API key saved to ${SHARED_CONFIG_PATH}`));
     }
-
-    // Show RPC endpoints if available
-    if (dnsRecords.length > 0) {
+    if (result.endpoints) {
       console.log(chalk.bold("\nRPC Endpoints:"));
-      for (const record of dnsRecords) {
-        if (record.usageType === "rpc") {
-          console.log(`  ${record.network}: ${chalk.blue("https://" + record.dns)}`);
-        }
-      }
+      console.log(`  Mainnet: ${chalk.blue(result.endpoints.mainnet)}`);
+      console.log(`  Devnet:  ${chalk.blue(result.endpoints.devnet)}`);
     }
-
-    if (txSignature) {
+    if (result.txSignature) {
       console.log(
-        `\nView transaction: ${chalk.blue(`https://solscan.io/tx/${txSignature}`)}`
+        `\nView transaction: ${chalk.blue(`https://solscan.io/tx/${result.txSignature}`)}`
       );
     }
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const exitCode = mapErrorToExitCode(message);
+
     if (options.json) {
-      exitWithError("SIGNUP_FAILED", error instanceof Error ? error.message : String(error), undefined, true);
+      exitWithError("SIGNUP_FAILED", message, undefined, true);
     }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.GENERAL_ERROR);
+    spinner?.fail(`Error: ${message}`);
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -121,7 +121,7 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
       console.log(`\nProject ID: ${chalk.cyan(result.projectId)}`);
       if (result.txSignature) {
         console.log(
-          `Transaction: ${chalk.blue(`https://solscan.io/tx/${result.txSignature}`)}`
+          `Transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`
         );
       }
       return;
@@ -155,7 +155,7 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     }
     if (result.txSignature) {
       console.log(
-        `\nView transaction: ${chalk.blue(`https://solscan.io/tx/${result.txSignature}`)}`
+        `\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`
       );
     }
   } catch (error) {

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
 import { signup, listProjects, getProject } from "../lib/api.js";
-import { executeCheckout, DEFAULT_DEVELOPER_MONTHLY_PRICE_ID } from "../lib/checkout.js";
+import { executeCheckout } from "../lib/checkout.js";
 import { setJwt, setApiKey, setSharedApiKey, SHARED_CONFIG_PATH } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
@@ -97,7 +97,7 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     const checkoutResult = await executeCheckout(
       keypair.secretKey,
       authResult.token,
-      { priceId: DEFAULT_DEVELOPER_MONTHLY_PRICE_ID, refId: authResult.refId },
+      { plan: "developer", period: "monthly", refId: authResult.refId },
     );
 
     if (checkoutResult.status !== "completed") {

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -166,7 +166,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
 
     console.log("\n" + chalk.green(`✓ Upgraded to ${preview.planName}!`));
     if (result.txSignature) {
-      console.log(`\nView transaction: ${chalk.blue(`https://solscan.io/tx/${result.txSignature}`)}`);
+      console.log(`\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`);
     }
   } catch (error) {
     if (options.json) {

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -1,0 +1,181 @@
+import chalk from "chalk";
+import ora from "ora";
+import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
+import { signup, listProjects, getProject } from "../lib/api.js";
+import { getCheckoutPreview, executeUpgrade, resolvePriceId, PLAN_CATALOG } from "../lib/checkout.js";
+import { setJwt } from "../lib/config.js";
+import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
+import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import readline from "readline";
+
+interface UpgradeOptions extends OutputOptions {
+  keypair: string;
+  plan: string;
+  period: "monthly" | "yearly";
+  coupon?: string;
+  yes?: boolean;
+}
+
+function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
+}
+
+export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
+  const spinner = options.json ? null : ora();
+
+  try {
+    // Validate plan name
+    const planKey = options.plan.toLowerCase();
+    if (!PLAN_CATALOG[planKey]) {
+      const available = Object.keys(PLAN_CATALOG).join(", ");
+      if (options.json) {
+        exitWithError("API_ERROR", `Unknown plan: ${options.plan}. Available: ${available}`, undefined, true);
+      }
+      console.error(chalk.red(`Unknown plan: ${options.plan}`));
+      console.error(chalk.gray(`Available plans: ${available}`));
+      process.exit(ExitCode.GENERAL_ERROR);
+    }
+
+    const priceId = resolvePriceId(planKey, options.period);
+
+    // Check keypair exists
+    if (!keypairExists(options.keypair)) {
+      if (options.json) {
+        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, true);
+      }
+      console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
+      console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));
+      process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+    }
+
+    // 1. Load keypair and authenticate
+    spinner?.start("Loading keypair...");
+    const keypair = await loadKeypairFromFile(options.keypair);
+    const walletAddress = await getAddress(keypair);
+    spinner?.succeed(`Wallet: ${chalk.cyan(walletAddress)}`);
+
+    spinner?.start("Authenticating...");
+    const { message, signature } = await signAuthMessage(keypair.secretKey);
+    const authResult = await signup(message, signature, walletAddress);
+    setJwt(authResult.token);
+    spinner?.succeed("Authenticated");
+
+    // 2. Get project
+    spinner?.start("Fetching project...");
+    const projects = await listProjects(authResult.token);
+    if (projects.length === 0) {
+      if (options.json) {
+        exitWithError("NO_PROJECTS", "No projects found. Run `helius signup` first.", undefined, true);
+      }
+      spinner?.fail("No projects found");
+      console.error(chalk.gray("Run `helius signup` to create an account first."));
+      process.exit(ExitCode.NO_PROJECTS);
+    }
+    const project = projects[0];
+    const projectDetails = await getProject(authResult.token, project.id);
+    const currentPlan = projectDetails.subscriptionPlanDetails?.currentPlan || "unknown";
+    spinner?.succeed(`Project: ${chalk.cyan(project.id)}`);
+
+    // 3. Preview pricing
+    spinner?.start("Fetching upgrade pricing...");
+    const preview = await getCheckoutPreview(authResult.token, priceId, project.id, options.coupon);
+    spinner?.succeed("Pricing loaded");
+
+    if (options.json && !options.yes) {
+      outputJson({
+        action: "preview",
+        currentPlan,
+        targetPlan: preview.planName,
+        period: preview.period,
+        baseAmount: preview.baseAmount,
+        subtotal: preview.subtotal,
+        appliedCredits: preview.appliedCredits,
+        proratedCredits: preview.proratedCredits,
+        discounts: preview.discounts,
+        dueToday: preview.dueToday,
+        coupon: preview.coupon,
+      });
+      return;
+    }
+
+    // 4. Show pricing and confirm
+    if (!options.json) {
+      console.log("");
+      console.log(`  Current plan:     ${chalk.yellow(currentPlan)}`);
+      console.log(`  Upgrade to:       ${chalk.green(preview.planName)} (${preview.period})`);
+      console.log("");
+      console.log(`  Subtotal:         $${(preview.subtotal / 100).toFixed(2)}`);
+      if (preview.proratedCredits > 0) {
+        console.log(`  Prorated credit:  ${chalk.green(`-$${(preview.proratedCredits / 100).toFixed(2)}`)}`);
+      }
+      if (preview.appliedCredits > 0) {
+        console.log(`  Applied credits:  ${chalk.green(`-$${(preview.appliedCredits / 100).toFixed(2)}`)}`);
+      }
+      if (preview.discounts > 0) {
+        console.log(`  Discounts:        ${chalk.green(`-$${(preview.discounts / 100).toFixed(2)}`)}`);
+      }
+      if (preview.coupon?.valid) {
+        console.log(`  Coupon:           ${chalk.green(preview.coupon.description || preview.coupon.code)}`);
+      }
+      console.log(`  ${chalk.bold(`Due today:        $${(preview.dueToday / 100).toFixed(2)}`)}`);
+      console.log("");
+    }
+
+    if (!options.yes) {
+      const ok = await confirm("  Proceed with upgrade? (y/N) ");
+      if (!ok) {
+        console.log(chalk.gray("  Cancelled."));
+        return;
+      }
+    }
+
+    // 5. Execute upgrade
+    spinner?.start("Processing upgrade payment...");
+    const result = await executeUpgrade(
+      keypair.secretKey,
+      authResult.token,
+      priceId,
+      project.id,
+      options.coupon,
+    );
+
+    if (result.status !== "completed") {
+      throw new Error(
+        `Upgrade ${result.status}${result.txSignature ? `. TX: ${result.txSignature}` : ""}`
+      );
+    }
+    spinner?.succeed("Upgrade complete");
+
+    if (options.json) {
+      outputJson({
+        status: "SUCCESS",
+        previousPlan: currentPlan,
+        newPlan: preview.planName,
+        period: preview.period,
+        amountPaid: preview.dueToday,
+        transaction: result.txSignature,
+        projectId: project.id,
+      });
+      return;
+    }
+
+    console.log("\n" + chalk.green(`✓ Upgraded to ${preview.planName}!`));
+    if (result.txSignature) {
+      console.log(`\nView transaction: ${chalk.blue(`https://solscan.io/tx/${result.txSignature}`)}`);
+    }
+  } catch (error) {
+    if (options.json) {
+      exitWithError("PAYMENT_FAILED", error instanceof Error ? error.message : String(error), undefined, true);
+    }
+    spinner?.fail(
+      `Error: ${error instanceof Error ? error.message : String(error)}`
+    );
+    process.exit(ExitCode.GENERAL_ERROR);
+  }
+}

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
 import { signup, listProjects, getProject } from "../lib/api.js";
-import { getCheckoutPreview, executeUpgrade, resolvePriceId, PLAN_CATALOG } from "../lib/checkout.js";
+import { getCheckoutPreview, executeUpgrade, PLAN_CATALOG } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
 import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
@@ -41,8 +41,6 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
       console.error(chalk.gray(`Available plans: ${available}`));
       process.exit(ExitCode.GENERAL_ERROR);
     }
-
-    const priceId = resolvePriceId(planKey, options.period);
 
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
@@ -84,7 +82,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
 
     // 3. Preview pricing
     spinner?.start("Fetching upgrade pricing...");
-    const preview = await getCheckoutPreview(authResult.token, priceId, project.id, options.coupon);
+    const preview = await getCheckoutPreview(authResult.token, planKey, options.period, project.id, options.coupon);
     spinner?.succeed("Pricing loaded");
 
     if (options.json && !options.yes) {
@@ -140,7 +138,8 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     const result = await executeUpgrade(
       keypair.secretKey,
       authResult.token,
-      priceId,
+      planKey,
+      options.period,
       project.id,
       options.coupon,
     );

--- a/helius-cli/src/constants.ts
+++ b/helius-cli/src/constants.ts
@@ -4,6 +4,3 @@ import { CLI_USER_AGENT } from './http.js';
 export { CLI_USER_AGENT };
 
 export const VERSION = version;
-
-// Re-export auth constants from SDK for any remaining local usage
-export { PAYMENT_AMOUNT } from "helius-sdk/auth/constants";

--- a/helius-cli/src/lib/api.ts
+++ b/helius-cli/src/lib/api.ts
@@ -5,12 +5,15 @@ import { createProject as sdkCreateProject } from "helius-sdk/auth/createProject
 import { listProjects as sdkListProjects } from "helius-sdk/auth/listProjects";
 import { getProject as sdkGetProject } from "helius-sdk/auth/getProject";
 import { createApiKey as sdkCreateApiKey } from "helius-sdk/auth/createApiKey";
+import { agenticSignup as sdkAgenticSignup } from "helius-sdk/auth/agenticSignup";
 import type {
   SignupResponse,
   Project,
   ProjectListItem,
   ProjectDetails,
   ApiKey,
+  AgenticSignupOptions,
+  AgenticSignupResult,
 } from "helius-sdk/auth/types";
 
 // Wrap SDK functions to pass CLI user agent
@@ -42,11 +45,18 @@ export async function createApiKey(
   return sdkCreateApiKey(jwt, projectId, walletAddress, CLI_USER_AGENT);
 }
 
+export async function agenticSignup(
+  options: Omit<AgenticSignupOptions, "userAgent">,
+): Promise<AgenticSignupResult> {
+  return sdkAgenticSignup({ ...options, userAgent: CLI_USER_AGENT });
+}
+
 export type {
   Project,
   ProjectListItem,
   ProjectDetails,
   ApiKey,
+  AgenticSignupResult,
   CreditsUsage,
   DnsRecord,
   Subscription,

--- a/helius-cli/src/lib/checkout.ts
+++ b/helius-cli/src/lib/checkout.ts
@@ -13,6 +13,7 @@ import type {
   CheckoutStatusResponse,
   CheckoutPreviewResponse,
   CheckoutResult,
+  CheckoutRequest,
 } from "helius-sdk/auth/types";
 
 export async function initializeCheckout(
@@ -33,18 +34,19 @@ export async function pollCheckoutCompletion(
 export async function executeCheckout(
   secretKey: Uint8Array,
   jwt: string,
-  request: CheckoutInitializeRequest,
+  request: CheckoutRequest,
 ): Promise<CheckoutResult> {
   return sdkExecuteCheckout(secretKey, jwt, request, CLI_USER_AGENT);
 }
 
 export async function getCheckoutPreview(
   jwt: string,
-  priceId: string,
+  plan: string,
+  period: "monthly" | "yearly",
   refId: string,
   couponCode?: string,
 ): Promise<CheckoutPreviewResponse> {
-  return sdkGetCheckoutPreview(jwt, priceId, refId, couponCode, CLI_USER_AGENT);
+  return sdkGetCheckoutPreview(jwt, plan, period, refId, couponCode, CLI_USER_AGENT);
 }
 
 export async function getPaymentIntent(
@@ -57,11 +59,12 @@ export async function getPaymentIntent(
 export async function executeUpgrade(
   secretKey: Uint8Array,
   jwt: string,
-  priceId: string,
+  plan: string,
+  period: "monthly" | "yearly",
   projectId: string,
   couponCode?: string,
 ): Promise<CheckoutResult> {
-  return sdkExecuteUpgrade(secretKey, jwt, priceId, projectId, couponCode, CLI_USER_AGENT);
+  return sdkExecuteUpgrade(secretKey, jwt, plan, period, projectId, couponCode, CLI_USER_AGENT);
 }
 
 export async function executeRenewal(
@@ -74,7 +77,7 @@ export async function executeRenewal(
 
 export { payWithMemo } from "helius-sdk/auth/payWithMemo";
 export { payPaymentIntent } from "helius-sdk/auth/checkout";
-export { PLAN_CATALOG, resolvePriceId, DEFAULT_DEVELOPER_MONTHLY_PRICE_ID } from "helius-sdk/auth/constants";
+export { PLAN_CATALOG } from "helius-sdk/auth/constants";
 
 export type {
   CheckoutInitializeRequest,
@@ -82,4 +85,5 @@ export type {
   CheckoutStatusResponse,
   CheckoutPreviewResponse,
   CheckoutResult,
+  CheckoutRequest,
 } from "helius-sdk/auth/types";

--- a/helius-cli/src/lib/checkout.ts
+++ b/helius-cli/src/lib/checkout.ts
@@ -1,0 +1,32 @@
+// Re-export checkout and payment functions from helius-sdk
+import { CLI_USER_AGENT } from "../constants.js";
+import { initializeCheckout as sdkInitializeCheckout } from "helius-sdk/auth/checkout";
+import { pollCheckoutCompletion as sdkPollCheckoutCompletion } from "helius-sdk/auth/checkout";
+import type {
+  CheckoutInitializeRequest,
+  CheckoutInitializeResponse,
+  CheckoutStatusResponse,
+} from "helius-sdk/auth/types";
+
+export async function initializeCheckout(
+  jwt: string,
+  request: CheckoutInitializeRequest,
+): Promise<CheckoutInitializeResponse> {
+  return sdkInitializeCheckout(jwt, request, CLI_USER_AGENT);
+}
+
+export async function pollCheckoutCompletion(
+  jwt: string,
+  paymentIntentId: string,
+  options?: { timeoutMs?: number; intervalMs?: number },
+): Promise<CheckoutStatusResponse> {
+  return sdkPollCheckoutCompletion(jwt, paymentIntentId, CLI_USER_AGENT, options);
+}
+
+export { payWithMemo } from "helius-sdk/auth/payWithMemo";
+
+export type {
+  CheckoutInitializeRequest,
+  CheckoutInitializeResponse,
+  CheckoutStatusResponse,
+} from "helius-sdk/auth/types";

--- a/helius-cli/src/lib/checkout.ts
+++ b/helius-cli/src/lib/checkout.ts
@@ -2,10 +2,17 @@
 import { CLI_USER_AGENT } from "../constants.js";
 import { initializeCheckout as sdkInitializeCheckout } from "helius-sdk/auth/checkout";
 import { pollCheckoutCompletion as sdkPollCheckoutCompletion } from "helius-sdk/auth/checkout";
+import { executeCheckout as sdkExecuteCheckout } from "helius-sdk/auth/checkout";
+import { getCheckoutPreview as sdkGetCheckoutPreview } from "helius-sdk/auth/checkout";
+import { getPaymentIntent as sdkGetPaymentIntent } from "helius-sdk/auth/checkout";
+import { executeUpgrade as sdkExecuteUpgrade } from "helius-sdk/auth/checkout";
+import { executeRenewal as sdkExecuteRenewal } from "helius-sdk/auth/checkout";
 import type {
   CheckoutInitializeRequest,
   CheckoutInitializeResponse,
   CheckoutStatusResponse,
+  CheckoutPreviewResponse,
+  CheckoutResult,
 } from "helius-sdk/auth/types";
 
 export async function initializeCheckout(
@@ -23,10 +30,56 @@ export async function pollCheckoutCompletion(
   return sdkPollCheckoutCompletion(jwt, paymentIntentId, CLI_USER_AGENT, options);
 }
 
+export async function executeCheckout(
+  secretKey: Uint8Array,
+  jwt: string,
+  request: CheckoutInitializeRequest,
+): Promise<CheckoutResult> {
+  return sdkExecuteCheckout(secretKey, jwt, request, CLI_USER_AGENT);
+}
+
+export async function getCheckoutPreview(
+  jwt: string,
+  priceId: string,
+  refId: string,
+  couponCode?: string,
+): Promise<CheckoutPreviewResponse> {
+  return sdkGetCheckoutPreview(jwt, priceId, refId, couponCode, CLI_USER_AGENT);
+}
+
+export async function getPaymentIntent(
+  jwt: string,
+  paymentIntentId: string,
+): Promise<CheckoutInitializeResponse> {
+  return sdkGetPaymentIntent(jwt, paymentIntentId, CLI_USER_AGENT);
+}
+
+export async function executeUpgrade(
+  secretKey: Uint8Array,
+  jwt: string,
+  priceId: string,
+  projectId: string,
+  couponCode?: string,
+): Promise<CheckoutResult> {
+  return sdkExecuteUpgrade(secretKey, jwt, priceId, projectId, couponCode, CLI_USER_AGENT);
+}
+
+export async function executeRenewal(
+  secretKey: Uint8Array,
+  jwt: string,
+  paymentIntentId: string,
+): Promise<CheckoutResult> {
+  return sdkExecuteRenewal(secretKey, jwt, paymentIntentId, CLI_USER_AGENT);
+}
+
 export { payWithMemo } from "helius-sdk/auth/payWithMemo";
+export { payPaymentIntent } from "helius-sdk/auth/checkout";
+export { PLAN_CATALOG, resolvePriceId, DEFAULT_DEVELOPER_MONTHLY_PRICE_ID } from "helius-sdk/auth/constants";
 
 export type {
   CheckoutInitializeRequest,
   CheckoutInitializeResponse,
   CheckoutStatusResponse,
+  CheckoutPreviewResponse,
+  CheckoutResult,
 } from "helius-sdk/auth/types";

--- a/helius-cli/src/lib/payment.ts
+++ b/helius-cli/src/lib/payment.ts
@@ -1,4 +1,3 @@
 // Re-export payment and balance functions from helius-sdk
-export { payUSDC } from "helius-sdk/auth/payUSDC";
 export { checkSolBalance, checkUsdcBalance } from "helius-sdk/auth/checkBalances";
 export { MIN_SOL_FOR_TX } from "helius-sdk/auth/constants";

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -20,12 +20,10 @@ import {
 import { mcpText, mcpError, handleToolError } from '../utils/errors.js';
 import { setSharedApiKey, setJwt, getJwt, SHARED_CONFIG_PATH, KEYPAIR_PATH, loadKeypairFromDisk, saveKeypairToDisk } from '../utils/config.js';
 
-const DEVELOPER_PRICE_USDC = PLAN_CATALOG.developer.monthlyPrice / 100;
-
 export function registerAuthTools(server: McpServer) {
   server.tool(
     'generateKeypair',
-    `Generate a new Solana keypair for Helius account signup. Returns the wallet address. The user must fund this wallet with ~0.01 SOL + ${DEVELOPER_PRICE_USDC} USDC (Developer plan) before calling agenticSignup.`,
+    'Generate a new Solana keypair for Helius account signup. Returns the wallet address. The user must fund this wallet with ~0.001 SOL + 1 USDC (basic plan) or more USDC (for paid plans) before calling agenticSignup.',
     {},
     async () => {
       try {
@@ -42,8 +40,8 @@ export function registerAuthTools(server: McpServer) {
             `**Existing Keypair Loaded** from \`${KEYPAIR_PATH}\`\n\n` +
             `**Wallet Address:** \`${address}\`\n\n` +
             `To create a Helius account, fund this wallet with:\n` +
-            `- **~0.01 SOL** for transaction fees\n` +
-            `- **${DEVELOPER_PRICE_USDC} USDC** for Helius Developer plan\n\n` +
+            `- **~0.001 SOL** for transaction fees\n` +
+            `- **1 USDC** for basic plan (or more for paid plans)\n\n` +
             `Then call \`agenticSignup\` to complete account creation.`
           );
         }
@@ -62,8 +60,8 @@ export function registerAuthTools(server: McpServer) {
           `**Wallet Address:** \`${address}\`\n` +
           `**Saved to:** \`${KEYPAIR_PATH}\`\n\n` +
           `To create a Helius account, fund this wallet with:\n` +
-          `- **~0.01 SOL** for transaction fees\n` +
-          `- **${DEVELOPER_PRICE_USDC} USDC** for Helius Developer plan\n\n` +
+          `- **~0.001 SOL** for transaction fees\n` +
+          `- **1 USDC** for basic plan (or more for paid plans)\n\n` +
           `Then call \`agenticSignup\` to complete account creation.`
         );
       } catch (err) {
@@ -74,7 +72,7 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'checkSignupBalance',
-    'Check if the signup wallet has sufficient SOL and USDC balance for Helius account creation.',
+    'Check if the signup wallet has sufficient SOL and USDC balance for Helius basic plan ($1 USDC). Paid plans (developer/business/professional) require more USDC — the exact amount depends on the plan and is checked during checkout.',
     {},
     async () => {
       try {
@@ -102,24 +100,22 @@ export function registerAuthTools(server: McpServer) {
         const usdcAmount = Number(usdcBalance) / 1_000_000;
 
         const solOk = solBalance >= 1_000_000n;
-        // Check against actual Developer plan price
-        const requiredUsdc = BigInt(PLAN_CATALOG.developer.monthlyPrice) * 10_000n;
-        const usdcOk = usdcBalance >= requiredUsdc;
+        const usdcOk = usdcBalance >= 1_000_000n; // 1 USDC for basic plan
 
         let status: string;
         if (solOk && usdcOk) {
-          status = 'Ready for signup';
+          status = 'Ready for signup (basic plan). For paid plans, ensure sufficient USDC for the plan price.';
         } else {
           const missing: string[] = [];
-          if (!solOk) missing.push(`~0.01 SOL (have ${solAmount.toFixed(6)})`);
-          if (!usdcOk) missing.push(`${DEVELOPER_PRICE_USDC} USDC (have ${usdcAmount.toFixed(2)})`);
+          if (!solOk) missing.push(`~0.001 SOL (have ${solAmount.toFixed(6)})`);
+          if (!usdcOk) missing.push(`1 USDC (have ${usdcAmount.toFixed(2)})`);
           status = `Need more funds: ${missing.join(', ')}`;
         }
 
         return mcpText(
           `**Signup Wallet Balance** (\`${address}\`)\n\n` +
-          `- **SOL:** ${solAmount.toFixed(6)} ${solOk ? '(sufficient)' : '(insufficient — need ~0.01)'}\n` +
-          `- **USDC:** ${usdcAmount.toFixed(2)} ${usdcOk ? '(sufficient)' : `(insufficient — need ${DEVELOPER_PRICE_USDC})`}\n\n` +
+          `- **SOL:** ${solAmount.toFixed(6)} ${solOk ? '(sufficient)' : '(insufficient)'}\n` +
+          `- **USDC:** ${usdcAmount.toFixed(2)} ${usdcOk ? '(sufficient for basic)' : '(insufficient)'}\n\n` +
           `**Status:** ${status}`
         );
       } catch (err) {
@@ -130,11 +126,14 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'agenticSignup',
-    `Create a Helius account using the generated keypair. Requires the wallet to be funded with ~0.01 SOL + ${DEVELOPER_PRICE_USDC} USDC. On success, automatically configures the API key for this session so all other Helius tools work immediately.`,
+    'Create a Helius account using the generated keypair. Default: basic plan ($1 USDC). For paid plans, specify plan: developer ($49/mo), business ($499/mo), or professional ($999/mo). On success, automatically configures the API key for this session.',
     {
+      plan: z.string().optional().describe('Plan to sign up for: "basic" ($1, default), "developer", "business", or "professional"'),
+      period: z.enum(["monthly", "yearly"]).optional().describe('Billing period for paid plans (default: monthly)'),
       email: z.string().email().optional().describe('Contact email for the account (may be required for new signups)'),
+      couponCode: z.string().optional().describe('Coupon code for paid plans'),
     },
-    async ({ email }) => {
+    async ({ plan, period, email, couponCode }) => {
       try {
         let secretKey = getSessionSecretKey();
 
@@ -156,7 +155,10 @@ export function registerAuthTools(server: McpServer) {
         const result = await agenticSignup({
           secretKey,
           userAgent: MCP_USER_AGENT,
+          plan,
+          period,
           email,
+          couponCode,
         });
 
         // Configure API key for this session and persist to shared config
@@ -184,6 +186,17 @@ export function registerAuthTools(server: McpServer) {
             (result.endpoints ? `- **Mainnet RPC:** \`${result.endpoints.mainnet}\`\n` : '') +
             (result.endpoints ? `- **Devnet RPC:** \`${result.endpoints.devnet}\`\n` : '') +
             (result.credits !== null ? `- **Credits:** ${result.credits.toLocaleString()}\n` : '') +
+            saveNote
+          );
+        }
+
+        if (result.status === 'upgraded') {
+          return mcpText(
+            `**Plan Upgraded to ${plan || 'paid plan'}**\n\n` +
+            `- **Wallet:** \`${result.walletAddress}\`\n` +
+            `- **Project ID:** \`${result.projectId}\`\n` +
+            (result.apiKey ? `- **API Key:** \`${result.apiKey}\`\n` : '') +
+            (result.txSignature ? `- **Payment TX:** \`${result.txSignature}\`\n` : '') +
             saveNote
           );
         }

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -5,6 +5,10 @@ import { loadKeypair } from 'helius-sdk/auth/loadKeypair';
 import { getAddress } from 'helius-sdk/auth/getAddress';
 import { checkSolBalance, checkUsdcBalance } from 'helius-sdk/auth/checkBalances';
 import { agenticSignup } from 'helius-sdk/auth/agenticSignup';
+import { getCheckoutPreview, executeUpgrade, executeRenewal } from 'helius-sdk/auth/checkout';
+import { listProjects } from 'helius-sdk/auth/listProjects';
+import { getProject } from 'helius-sdk/auth/getProject';
+import { PLAN_CATALOG, resolvePriceId } from 'helius-sdk/auth/constants';
 import { MCP_USER_AGENT } from '../http.js';
 import {
   setApiKey,
@@ -14,12 +18,14 @@ import {
   getSessionWalletAddress,
 } from '../utils/helius.js';
 import { mcpText, mcpError, handleToolError } from '../utils/errors.js';
-import { setSharedApiKey, setJwt, SHARED_CONFIG_PATH, KEYPAIR_PATH, loadKeypairFromDisk, saveKeypairToDisk } from '../utils/config.js';
+import { setSharedApiKey, setJwt, getJwt, SHARED_CONFIG_PATH, KEYPAIR_PATH, loadKeypairFromDisk, saveKeypairToDisk } from '../utils/config.js';
+
+const DEVELOPER_PRICE_USDC = PLAN_CATALOG.developer.monthlyPrice / 100;
 
 export function registerAuthTools(server: McpServer) {
   server.tool(
     'generateKeypair',
-    'Generate a new Solana keypair for Helius account signup. Returns the wallet address. The user must fund this wallet with ~0.001 SOL + 1 USDC before calling agenticSignup.',
+    `Generate a new Solana keypair for Helius account signup. Returns the wallet address. The user must fund this wallet with ~0.01 SOL + ${DEVELOPER_PRICE_USDC} USDC (Developer plan) before calling agenticSignup.`,
     {},
     async () => {
       try {
@@ -36,14 +42,14 @@ export function registerAuthTools(server: McpServer) {
             `**Existing Keypair Loaded** from \`${KEYPAIR_PATH}\`\n\n` +
             `**Wallet Address:** \`${address}\`\n\n` +
             `To create a Helius account, fund this wallet with:\n` +
-            `- **~0.001 SOL** for transaction fees\n` +
-            `- **1 USDC** for Helius signup\n\n` +
+            `- **~0.01 SOL** for transaction fees\n` +
+            `- **${DEVELOPER_PRICE_USDC} USDC** for Helius Developer plan\n\n` +
             `Then call \`agenticSignup\` to complete account creation.`
           );
         }
 
         // Generate new keypair and persist to disk
-        const keypair = generateKeypair();
+        const keypair = await generateKeypair();
         const walletKeypair = loadKeypair(keypair.secretKey);
         const address = await getAddress(walletKeypair);
 
@@ -56,8 +62,8 @@ export function registerAuthTools(server: McpServer) {
           `**Wallet Address:** \`${address}\`\n` +
           `**Saved to:** \`${KEYPAIR_PATH}\`\n\n` +
           `To create a Helius account, fund this wallet with:\n` +
-          `- **~0.001 SOL** for transaction fees\n` +
-          `- **1 USDC** for Helius signup\n\n` +
+          `- **~0.01 SOL** for transaction fees\n` +
+          `- **${DEVELOPER_PRICE_USDC} USDC** for Helius Developer plan\n\n` +
           `Then call \`agenticSignup\` to complete account creation.`
         );
       } catch (err) {
@@ -96,22 +102,24 @@ export function registerAuthTools(server: McpServer) {
         const usdcAmount = Number(usdcBalance) / 1_000_000;
 
         const solOk = solBalance >= 1_000_000n;
-        const usdcOk = usdcBalance >= 1_000_000n;
+        // Check against actual Developer plan price
+        const requiredUsdc = BigInt(PLAN_CATALOG.developer.monthlyPrice) * 10_000n;
+        const usdcOk = usdcBalance >= requiredUsdc;
 
         let status: string;
         if (solOk && usdcOk) {
           status = 'Ready for signup';
         } else {
           const missing: string[] = [];
-          if (!solOk) missing.push(`~0.001 SOL (have ${solAmount.toFixed(6)})`);
-          if (!usdcOk) missing.push(`1 USDC (have ${usdcAmount.toFixed(2)})`);
+          if (!solOk) missing.push(`~0.01 SOL (have ${solAmount.toFixed(6)})`);
+          if (!usdcOk) missing.push(`${DEVELOPER_PRICE_USDC} USDC (have ${usdcAmount.toFixed(2)})`);
           status = `Need more funds: ${missing.join(', ')}`;
         }
 
         return mcpText(
           `**Signup Wallet Balance** (\`${address}\`)\n\n` +
-          `- **SOL:** ${solAmount.toFixed(6)} ${solOk ? '(sufficient)' : '(insufficient)'}\n` +
-          `- **USDC:** ${usdcAmount.toFixed(2)} ${usdcOk ? '(sufficient)' : '(insufficient)'}\n\n` +
+          `- **SOL:** ${solAmount.toFixed(6)} ${solOk ? '(sufficient)' : '(insufficient — need ~0.01)'}\n` +
+          `- **USDC:** ${usdcAmount.toFixed(2)} ${usdcOk ? '(sufficient)' : `(insufficient — need ${DEVELOPER_PRICE_USDC})`}\n\n` +
           `**Status:** ${status}`
         );
       } catch (err) {
@@ -122,9 +130,11 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'agenticSignup',
-    'Create a Helius account using the generated keypair. Requires the wallet to be funded with ~0.001 SOL + 1 USDC. On success, automatically configures the API key for this session so all other Helius tools work immediately.',
-    {},
-    async () => {
+    `Create a Helius account using the generated keypair. Requires the wallet to be funded with ~0.01 SOL + ${DEVELOPER_PRICE_USDC} USDC. On success, automatically configures the API key for this session so all other Helius tools work immediately.`,
+    {
+      email: z.string().email().optional().describe('Contact email for the account (may be required for new signups)'),
+    },
+    async ({ email }) => {
       try {
         let secretKey = getSessionSecretKey();
 
@@ -146,6 +156,7 @@ export function registerAuthTools(server: McpServer) {
         const result = await agenticSignup({
           secretKey,
           userAgent: MCP_USER_AGENT,
+          email,
         });
 
         // Configure API key for this session and persist to shared config
@@ -190,6 +201,184 @@ export function registerAuthTools(server: McpServer) {
         );
       } catch (err) {
         return handleToolError(err, 'Error during signup');
+      }
+    }
+  );
+
+  // ── Upgrade, Preview, Renewal Tools ──
+
+  server.tool(
+    'previewUpgrade',
+    'Preview pricing for a plan upgrade with proration details. Shows current plan, new plan cost, prorated credits, and amount due today.',
+    {
+      plan: z.enum(['developer', 'business', 'professional']).describe('Target plan name'),
+      period: z.enum(['monthly', 'yearly']).default('monthly').describe('Billing period'),
+      couponCode: z.string().optional().describe('Optional coupon code'),
+    },
+    async ({ plan, period, couponCode }) => {
+      try {
+        const jwt = getJwt();
+        if (!jwt) {
+          return mcpError('Not authenticated. Call `agenticSignup` or authenticate first.');
+        }
+
+        const projects = await listProjects(jwt, MCP_USER_AGENT);
+        if (projects.length === 0) {
+          return mcpError('No projects found. Call `agenticSignup` to create an account first.');
+        }
+
+        const projectId = projects[0].id;
+        const projectDetails = await getProject(jwt, projectId, MCP_USER_AGENT);
+        const currentPlan = projectDetails.subscriptionPlanDetails?.currentPlan || 'unknown';
+
+        const priceId = resolvePriceId(plan, period);
+        const preview = await getCheckoutPreview(jwt, priceId, projectId, couponCode, MCP_USER_AGENT);
+
+        let text =
+          `**Upgrade Preview**\n\n` +
+          `- **Current Plan:** ${currentPlan}\n` +
+          `- **Target Plan:** ${preview.planName} (${preview.period})\n\n` +
+          `**Pricing Breakdown:**\n` +
+          `- Subtotal: $${(preview.subtotal / 100).toFixed(2)}\n`;
+
+        if (preview.proratedCredits > 0) {
+          text += `- Prorated credit: -$${(preview.proratedCredits / 100).toFixed(2)}\n`;
+        }
+        if (preview.appliedCredits > 0) {
+          text += `- Applied credits: -$${(preview.appliedCredits / 100).toFixed(2)}\n`;
+        }
+        if (preview.discounts > 0) {
+          text += `- Discounts: -$${(preview.discounts / 100).toFixed(2)}\n`;
+        }
+        if (preview.coupon?.valid) {
+          text += `- Coupon (${preview.coupon.code}): ${preview.coupon.description || 'Applied'}\n`;
+        } else if (preview.coupon && !preview.coupon.valid) {
+          text += `- Coupon (${preview.coupon.code}): **Invalid** — ${preview.coupon.invalidReason || 'not applicable'}\n`;
+        }
+
+        text += `\n**Due Today: $${(preview.dueToday / 100).toFixed(2)}**\n`;
+
+        if (preview.note) {
+          text += `\n_${preview.note}_\n`;
+        }
+
+        text += `\nTo proceed, use the \`upgradePlan\` tool with plan: '${plan}'.`;
+
+        return mcpText(text);
+      } catch (err) {
+        return handleToolError(err, 'Error previewing upgrade');
+      }
+    }
+  );
+
+  server.tool(
+    'upgradePlan',
+    'Upgrade your Helius plan. Processes USDC payment with proration. Call previewUpgrade first to see pricing.',
+    {
+      plan: z.enum(['developer', 'business', 'professional']).describe('Target plan name'),
+      period: z.enum(['monthly', 'yearly']).default('monthly').describe('Billing period'),
+      couponCode: z.string().optional().describe('Optional coupon code'),
+    },
+    async ({ plan, period, couponCode }) => {
+      try {
+        let secretKey = getSessionSecretKey();
+        if (!secretKey) {
+          secretKey = loadKeypairFromDisk();
+          if (secretKey) {
+            const walletKeypair = loadKeypair(secretKey);
+            const address = await getAddress(walletKeypair);
+            setSessionSecretKey(secretKey);
+            setSessionWalletAddress(address);
+          }
+        }
+        if (!secretKey) {
+          return mcpError('No keypair found. Call `generateKeypair` first.');
+        }
+
+        const jwt = getJwt();
+        if (!jwt) {
+          return mcpError('Not authenticated. Call `agenticSignup` or authenticate first.');
+        }
+
+        const projects = await listProjects(jwt, MCP_USER_AGENT);
+        if (projects.length === 0) {
+          return mcpError('No projects found. Call `agenticSignup` to create an account first.');
+        }
+
+        const projectId = projects[0].id;
+        const priceId = resolvePriceId(plan, period);
+
+        const result = await executeUpgrade(secretKey, jwt, priceId, projectId, couponCode, MCP_USER_AGENT);
+
+        if (result.status !== 'completed') {
+          return mcpError(
+            `**Upgrade ${result.status}**\n\n` +
+            (result.error ? `Error: ${result.error}\n` : '') +
+            (result.txSignature ? `TX: \`${result.txSignature}\`\n` : '') +
+            `\nIf you need help, contact support with the payment intent ID: \`${result.paymentIntentId}\``
+          );
+        }
+
+        const planInfo = PLAN_CATALOG[plan];
+        return mcpText(
+          `**Plan Upgraded Successfully**\n\n` +
+          `- **New Plan:** ${planInfo.name} (${period})\n` +
+          `- **Project ID:** \`${projectId}\`\n` +
+          (result.txSignature ? `- **Payment TX:** \`${result.txSignature}\`\n` : '') +
+          `\nYour new plan is now active with ${(planInfo.credits / 1_000_000).toFixed(0)}M credits and ${planInfo.requestsPerSecond} RPS.`
+        );
+      } catch (err) {
+        return handleToolError(err, 'Error upgrading plan');
+      }
+    }
+  );
+
+  server.tool(
+    'payRenewal',
+    'Pay an existing payment intent (e.g., from a renewal notification). Fetches intent details, validates, and processes USDC payment.',
+    {
+      paymentIntentId: z.string().describe('Payment intent ID from renewal notification'),
+    },
+    async ({ paymentIntentId }) => {
+      try {
+        let secretKey = getSessionSecretKey();
+        if (!secretKey) {
+          secretKey = loadKeypairFromDisk();
+          if (secretKey) {
+            const walletKeypair = loadKeypair(secretKey);
+            const address = await getAddress(walletKeypair);
+            setSessionSecretKey(secretKey);
+            setSessionWalletAddress(address);
+          }
+        }
+        if (!secretKey) {
+          return mcpError('No keypair found. Call `generateKeypair` first.');
+        }
+
+        const jwt = getJwt();
+        if (!jwt) {
+          return mcpError('Not authenticated. Call `agenticSignup` or authenticate first.');
+        }
+
+        const result = await executeRenewal(secretKey, jwt, paymentIntentId, MCP_USER_AGENT);
+
+        if (result.status !== 'completed') {
+          return mcpError(
+            `**Payment ${result.status}**\n\n` +
+            (result.error ? `Error: ${result.error}\n` : '') +
+            (result.txSignature ? `TX: \`${result.txSignature}\`\n` : '') +
+            `\nIf you need help, contact support with the payment intent ID: \`${result.paymentIntentId}\``
+          );
+        }
+
+        return mcpText(
+          `**Payment Complete**\n\n` +
+          `- **Payment Intent:** \`${result.paymentIntentId}\`\n` +
+          (result.txSignature ? `- **TX:** \`${result.txSignature}\`\n` : '') +
+          `\nYour subscription has been renewed successfully.`
+        );
+      } catch (err) {
+        return handleToolError(err, 'Error processing renewal payment');
       }
     }
   );

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -130,10 +130,12 @@ export function registerAuthTools(server: McpServer) {
     {
       plan: z.string().optional().describe('Plan to sign up for: "basic" ($1, default), "developer", "business", or "professional"'),
       period: z.enum(["monthly", "yearly"]).optional().describe('Billing period for paid plans (default: monthly)'),
-      email: z.string().email().optional().describe('Contact email for the account (may be required for new signups)'),
+      email: z.string().email().optional().describe('Email address (required for paid plans)'),
+      firstName: z.string().optional().describe('First name (required for paid plans)'),
+      lastName: z.string().optional().describe('Last name (required for paid plans)'),
       couponCode: z.string().optional().describe('Coupon code for paid plans'),
     },
-    async ({ plan, period, email, couponCode }) => {
+    async ({ plan, period, email, firstName, lastName, couponCode }) => {
       try {
         let secretKey = getSessionSecretKey();
 
@@ -158,6 +160,8 @@ export function registerAuthTools(server: McpServer) {
           plan,
           period,
           email,
+          firstName,
+          lastName,
           couponCode,
         });
 

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -8,7 +8,7 @@ import { agenticSignup } from 'helius-sdk/auth/agenticSignup';
 import { getCheckoutPreview, executeUpgrade, executeRenewal } from 'helius-sdk/auth/checkout';
 import { listProjects } from 'helius-sdk/auth/listProjects';
 import { getProject } from 'helius-sdk/auth/getProject';
-import { PLAN_CATALOG, resolvePriceId } from 'helius-sdk/auth/constants';
+import { PLAN_CATALOG } from 'helius-sdk/auth/constants';
 import { MCP_USER_AGENT } from '../http.js';
 import {
   setApiKey,
@@ -231,8 +231,7 @@ export function registerAuthTools(server: McpServer) {
         const projectDetails = await getProject(jwt, projectId, MCP_USER_AGENT);
         const currentPlan = projectDetails.subscriptionPlanDetails?.currentPlan || 'unknown';
 
-        const priceId = resolvePriceId(plan, period);
-        const preview = await getCheckoutPreview(jwt, priceId, projectId, couponCode, MCP_USER_AGENT);
+        const preview = await getCheckoutPreview(jwt, plan, period, projectId, couponCode, MCP_USER_AGENT);
 
         let text =
           `**Upgrade Preview**\n\n` +
@@ -306,9 +305,7 @@ export function registerAuthTools(server: McpServer) {
         }
 
         const projectId = projects[0].id;
-        const priceId = resolvePriceId(plan, period);
-
-        const result = await executeUpgrade(secretKey, jwt, priceId, projectId, couponCode, MCP_USER_AGENT);
+        const result = await executeUpgrade(secretKey, jwt, plan, period, projectId, couponCode, MCP_USER_AGENT);
 
         if (result.status !== 'completed') {
           return mcpError(

--- a/helius-mcp/src/tools/index.ts
+++ b/helius-mcp/src/tools/index.ts
@@ -14,10 +14,12 @@ import { registerWebhookTools } from './webhooks.js';
 import { registerEnhancedWebSocketTools } from './enhanced-websockets.js';
 import { registerLaserstreamTools } from './laserstream.js';
 import { registerWalletTools } from './wallet.js';
+import { registerPlanTools } from './plans.js';
 
 export function registerTools(server: McpServer) {
   registerAuthTools(server);
   registerConfigTools(server);
+  registerPlanTools(server);
   registerBalanceTools(server);
   registerTransactionTools(server);
   registerAssetTools(server);

--- a/helius-mcp/src/tools/plans.ts
+++ b/helius-mcp/src/tools/plans.ts
@@ -1,14 +1,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { PLAN_CATALOG } from 'helius-sdk/auth/constants';
 
-// Full plan details including display-only info not in PLAN_CATALOG
+// Full plan details for display
 const HELIUS_PLANS: Record<string, {
   name: string;
   price: string;
   credits: string;
   additionalCredits: string;
-  priceIds?: { monthly: string; yearly: string };
   rateLimit: { rpc: string; sendTransaction: string; getProgramAccounts: string; das: string };
   connections: { websocket: number; enhancedWebsocket: number };
   features: Record<string, boolean | string>;
@@ -31,7 +29,6 @@ const HELIUS_PLANS: Record<string, {
     price: '$49/month',
     credits: '10M/month',
     additionalCredits: '$5 per million',
-    priceIds: PLAN_CATALOG.developer.priceIds,
     rateLimit: { rpc: '50 RPS', sendTransaction: '5/sec', getProgramAccounts: '25/sec', das: '10/sec' },
     connections: { websocket: 150, enhancedWebsocket: 0 },
     features: { webhooks: true, standardWebSockets: true, enhancedWebSockets: false, laserstream: 'Devnet only', stakedConnections: true, archivalData: true },
@@ -43,7 +40,6 @@ const HELIUS_PLANS: Record<string, {
     price: '$499/month',
     credits: '100M/month',
     additionalCredits: '$5 per million',
-    priceIds: PLAN_CATALOG.business.priceIds,
     rateLimit: { rpc: '200 RPS', sendTransaction: '50/sec', getProgramAccounts: '50/sec', das: '50/sec' },
     connections: { websocket: 250, enhancedWebsocket: 100 },
     features: { webhooks: true, standardWebSockets: true, enhancedWebSockets: true, laserstream: 'Devnet only', stakedConnections: true, archivalData: true },
@@ -55,7 +51,6 @@ const HELIUS_PLANS: Record<string, {
     price: '$999/month',
     credits: '200M/month',
     additionalCredits: '$5 per million',
-    priceIds: PLAN_CATALOG.professional.priceIds,
     rateLimit: { rpc: '500 RPS (+100 RPS for $100/mo)', sendTransaction: '100/sec', getProgramAccounts: '75/sec', das: '100/sec' },
     connections: { websocket: 250, enhancedWebsocket: 100 },
     features: { webhooks: true, standardWebSockets: true, enhancedWebSockets: true, laserstream: 'Full access (mainnet + devnet, data add-ons $500+/mo)', stakedConnections: true, archivalData: true },
@@ -73,10 +68,6 @@ function formatPlanDetails(planKey: string): string {
     `**Credits:** ${plan.credits}`,
     `**Additional Credits:** ${plan.additionalCredits}`,
   ];
-
-  if (plan.priceIds) {
-    lines.push(`**Price IDs:** monthly: \`${plan.priceIds.monthly}\`, yearly: \`${plan.priceIds.yearly}\``);
-  }
 
   lines.push(
     '',

--- a/helius-mcp/src/tools/plans.ts
+++ b/helius-mcp/src/tools/plans.ts
@@ -1,0 +1,255 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { PLAN_CATALOG } from 'helius-sdk/auth/constants';
+
+// Full plan details including display-only info not in PLAN_CATALOG
+const HELIUS_PLANS: Record<string, {
+  name: string;
+  price: string;
+  credits: string;
+  additionalCredits: string;
+  priceIds?: { monthly: string; yearly: string };
+  rateLimit: { rpc: string; sendTransaction: string; getProgramAccounts: string; das: string };
+  connections: { websocket: number; enhancedWebsocket: number };
+  features: Record<string, boolean | string>;
+  support: string;
+  sla: string;
+}> = {
+  free: {
+    name: 'Free',
+    price: '$0/month',
+    credits: '1M/month',
+    additionalCredits: 'N/A',
+    rateLimit: { rpc: '10 RPS', sendTransaction: '1/sec', getProgramAccounts: '5/sec', das: '2/sec' },
+    connections: { websocket: 5, enhancedWebsocket: 0 },
+    features: { webhooks: true, standardWebSockets: true, enhancedWebSockets: false, laserstream: false, stakedConnections: true, archivalData: true },
+    support: 'Community (Discord)',
+    sla: 'N/A',
+  },
+  developer: {
+    name: 'Developer',
+    price: '$49/month',
+    credits: '10M/month',
+    additionalCredits: '$5 per million',
+    priceIds: PLAN_CATALOG.developer.priceIds,
+    rateLimit: { rpc: '50 RPS', sendTransaction: '5/sec', getProgramAccounts: '25/sec', das: '10/sec' },
+    connections: { websocket: 150, enhancedWebsocket: 0 },
+    features: { webhooks: true, standardWebSockets: true, enhancedWebSockets: false, laserstream: 'Devnet only', stakedConnections: true, archivalData: true },
+    support: 'Chat support',
+    sla: '24-hour response',
+  },
+  business: {
+    name: 'Business',
+    price: '$499/month',
+    credits: '100M/month',
+    additionalCredits: '$5 per million',
+    priceIds: PLAN_CATALOG.business.priceIds,
+    rateLimit: { rpc: '200 RPS', sendTransaction: '50/sec', getProgramAccounts: '50/sec', das: '50/sec' },
+    connections: { websocket: 250, enhancedWebsocket: 100 },
+    features: { webhooks: true, standardWebSockets: true, enhancedWebSockets: true, laserstream: 'Devnet only', stakedConnections: true, archivalData: true },
+    support: 'Priority chat',
+    sla: '12-hour response',
+  },
+  professional: {
+    name: 'Professional',
+    price: '$999/month',
+    credits: '200M/month',
+    additionalCredits: '$5 per million',
+    priceIds: PLAN_CATALOG.professional.priceIds,
+    rateLimit: { rpc: '500 RPS (+100 RPS for $100/mo)', sendTransaction: '100/sec', getProgramAccounts: '75/sec', das: '100/sec' },
+    connections: { websocket: 250, enhancedWebsocket: 100 },
+    features: { webhooks: true, standardWebSockets: true, enhancedWebSockets: true, laserstream: 'Full access (mainnet + devnet, data add-ons $500+/mo)', stakedConnections: true, archivalData: true },
+    support: 'Dedicated Slack + Telegram',
+    sla: '8-hour response',
+  },
+};
+
+function formatPlanDetails(planKey: string): string {
+  const plan = HELIUS_PLANS[planKey];
+  const lines: string[] = [
+    `## ${plan.name} Plan`,
+    '',
+    `**Price:** ${plan.price}`,
+    `**Credits:** ${plan.credits}`,
+    `**Additional Credits:** ${plan.additionalCredits}`,
+  ];
+
+  if (plan.priceIds) {
+    lines.push(`**Price IDs:** monthly: \`${plan.priceIds.monthly}\`, yearly: \`${plan.priceIds.yearly}\``);
+  }
+
+  lines.push(
+    '',
+    '### Rate Limits',
+    `- RPC Requests: ${plan.rateLimit.rpc}`,
+    `- sendTransaction: ${plan.rateLimit.sendTransaction}`,
+    `- getProgramAccounts: ${plan.rateLimit.getProgramAccounts}`,
+    `- DAS Requests: ${plan.rateLimit.das}`,
+    '',
+    '### Connection Limits',
+    `- Standard WebSocket Connections: ${plan.connections.websocket}`,
+    `- Enhanced WebSocket Connections: ${plan.connections.enhancedWebsocket}`,
+    '',
+    '### Features',
+    `- Webhooks: ${plan.features.webhooks ? 'Yes' : 'No'}`,
+    `- Standard WebSockets: ${plan.features.standardWebSockets ? 'Yes' : 'No'}`,
+    `- Enhanced WebSockets: ${typeof plan.features.enhancedWebSockets === 'string' ? plan.features.enhancedWebSockets : plan.features.enhancedWebSockets ? 'Yes' : 'No'}`,
+    `- Laserstream: ${typeof plan.features.laserstream === 'string' ? plan.features.laserstream : plan.features.laserstream ? 'Yes' : 'No'}`,
+    `- Staked Connections: ${plan.features.stakedConnections ? 'Yes' : 'No'}`,
+    `- Archival Data: ${plan.features.archivalData ? 'Yes' : 'No'}`,
+  );
+
+  lines.push('', '### Support');
+  lines.push(`- Channel: ${plan.support}`);
+  lines.push(`- SLA: ${plan.sla}`);
+
+  if (planKey !== 'free') {
+    lines.push('', `_To upgrade to ${plan.name}, use the \`upgradePlan\` tool with plan: '${planKey}'._`);
+  }
+
+  return lines.join('\n');
+}
+
+export function registerPlanTools(server: McpServer) {
+  server.tool(
+    'getHeliusPlanInfo',
+    'Get detailed Helius plan information including pricing, credits, rate limits, and feature availability. Shows what features are available on each tier (Free, Developer, Business, Professional). Useful for understanding WebSocket limits, Laserstream access, and API rate limits per plan.',
+    {
+      plan: z.enum(['free', 'developer', 'business', 'professional', 'all']).optional().default('all').describe('Specific plan to show details for, or "all" for comparison'),
+    },
+    async ({ plan }) => {
+      try {
+        if (plan === 'all') {
+          const lines = [
+            '# Helius Plans Overview',
+            '',
+            '| Feature | Free | Developer | Business | Professional |',
+            '|---------|------|-----------|----------|--------------|',
+            '| **Price** | $0/mo | $49/mo | $499/mo | $999/mo |',
+            '| **Credits** | 1M | 10M | 100M | 200M |',
+            '| **RPC RPS** | 10 | 50 | 200 | 500 |',
+            '| **sendTransaction** | 1/s | 5/s | 50/s | 100/s |',
+            '| **DAS Requests** | 2/s | 10/s | 50/s | 100/s |',
+            '| **WS Connections** | 5 | 150 | 250 | 250 |',
+            '| **Enhanced WS** | No | No | Yes (100) | Yes (100) |',
+            '| **Laserstream** | No | Devnet | Devnet | Full |',
+            '| **Support SLA** | — | 24hr | 12hr | 8hr |',
+            '',
+            '---',
+            '',
+            '## Actions',
+            '',
+            '- To upgrade, use the `upgradePlan` tool with a plan name (developer, business, professional)',
+            '- To preview pricing before upgrading, use the `previewUpgrade` tool',
+            '',
+            '---',
+            '',
+            '## Key Differences',
+            '',
+            '### WebSocket Connection Limits',
+            '- **Free:** 5 simultaneous connections',
+            '- **Developer:** 150 connections',
+            '- **Business/Professional:** 250 standard, 100 enhanced each',
+            '',
+            '### Enhanced WebSockets',
+            '- **Available on:** Business, Professional',
+            '- **Connection limit:** 100 (Business/Pro)',
+            '- **Speed:** 1.5-2x faster than standard WebSockets',
+            '- **Filtering:** Up to 50,000 addresses per filter',
+            '',
+            '### Laserstream (gRPC)',
+            '- **Developer/Business:** Devnet only',
+            '- **Professional:** Full access (mainnet + devnet)',
+            '- **Data add-ons:** Starting at $500/mo for Professional',
+            '',
+            '### Credit Costs (from docs)',
+            '- **0 credits**: Helius Sender',
+            '- **1 credit**: Standard RPC, sendTransaction, Priority Fee API, webhook events',
+            '- **3 credits**: per 0.1 MB streamed (LaserStream, Enhanced WS)',
+            '- **10 credits**: getProgramAccounts, historical data, DAS API',
+            '- **100 credits**: Enhanced Transactions, Wallet API, webhook management',
+            '- **Additional credits**: $5 per million (all paid plans)',
+            '',
+            '**Docs:** https://www.helius.dev/pricing',
+          ];
+          return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+        }
+
+        const planDetails = formatPlanDetails(plan);
+        return { content: [{ type: 'text' as const, text: planDetails }] };
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text' as const, text: `Error: ${errorMsg}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    'compareHeliusPlans',
+    'Compare specific Helius plans side-by-side for a specific feature category (rate limits, features, connections, or pricing).',
+    {
+      category: z.enum(['rates', 'features', 'connections', 'pricing', 'support']).describe('Category to compare'),
+      plans: z.array(z.enum(['free', 'developer', 'business', 'professional'])).optional().describe('Plans to compare (default: all)'),
+    },
+    async ({ category, plans }) => {
+      const plansToCompare = plans || ['free', 'developer', 'business', 'professional'];
+      const lines: string[] = [];
+
+      switch (category) {
+        case 'rates':
+          lines.push('# Rate Limits Comparison', '');
+          lines.push('| Plan | RPC RPS | sendTx | getProgramAccounts | DAS |');
+          lines.push('|------|---------|--------|-------------------|-----|');
+          for (const p of plansToCompare) {
+            const plan = HELIUS_PLANS[p];
+            lines.push(`| ${plan.name} | ${plan.rateLimit.rpc} | ${plan.rateLimit.sendTransaction} | ${plan.rateLimit.getProgramAccounts} | ${plan.rateLimit.das} |`);
+          }
+          break;
+        case 'features':
+          lines.push('# Features Comparison', '');
+          lines.push('| Plan | Enhanced WS | Laserstream | Staked | Archival |');
+          lines.push('|------|-------------|-------------|--------|----------|');
+          for (const p of plansToCompare) {
+            const plan = HELIUS_PLANS[p];
+            const ews = typeof plan.features.enhancedWebSockets === 'string' ? plan.features.enhancedWebSockets : plan.features.enhancedWebSockets ? 'Yes' : 'No';
+            const ls = typeof plan.features.laserstream === 'string' ? plan.features.laserstream : plan.features.laserstream ? 'Yes' : 'No';
+            lines.push(`| ${plan.name} | ${ews} | ${ls} | Yes | Yes |`);
+          }
+          break;
+        case 'connections':
+          lines.push('# Connection Limits Comparison', '');
+          lines.push('| Plan | Standard WS | Enhanced WS |');
+          lines.push('|------|-------------|-------------|');
+          for (const p of plansToCompare) {
+            const plan = HELIUS_PLANS[p];
+            lines.push(`| ${plan.name} | ${plan.connections.websocket} | ${plan.connections.enhancedWebsocket} |`);
+          }
+          lines.push('', '**Notes:**');
+          lines.push('- Enhanced WS requires Business+ plan');
+          lines.push('- Opening a connection costs 1 credit');
+          lines.push('- Enhanced WS data: 3 credits per 0.1 MB streamed');
+          break;
+        case 'pricing':
+          lines.push('# Pricing Comparison', '');
+          lines.push('| Plan | Price | Credits | Extra Credits |');
+          lines.push('|------|-------|---------|---------------|');
+          for (const p of plansToCompare) {
+            const plan = HELIUS_PLANS[p];
+            lines.push(`| ${plan.name} | ${plan.price} | ${plan.credits} | ${plan.additionalCredits} |`);
+          }
+          break;
+        case 'support':
+          lines.push('# Support Comparison', '');
+          lines.push('| Plan | Channel | SLA |');
+          lines.push('|------|---------|-----|');
+          for (const p of plansToCompare) {
+            const plan = HELIUS_PLANS[p];
+            lines.push(`| ${plan.name} | ${plan.support} | ${plan.sla} |`);
+          }
+          break;
+      }
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- Integrates the helius-sdk OpenPay auth module into both the Helius CLI and MCP server, enabling agentic signup, plan upgrades, and renewal payments
- Refactors CLI signup to support dual-path flow: basic plan ($1 USDC) and paid plans (developer/business/professional) via OpenPay checkout
- Adds MCP server tools for auth (signup, upgrade, preview, pay renewal) and plan info (plan details, plan comparison)
- Consolidates config and keypair storage to `~/.helius/`

## What changed
### CLI (`helius-cli/`)
- **`src/commands/signup.ts`** — Rewritten to use SDK's agentic signup with dual-path basic/paid plan flow, coupon support, and name/email collection
- **`src/commands/upgrade.ts`** — New command for previewing and executing plan upgrades with proration
- **`src/commands/pay.ts`** — New command for paying renewal invoices/payment intents
- **`src/commands/keygen.ts`** — Updated to use SDK keypair generation
- **`src/lib/checkout.ts`** — New checkout helper using SDK's checkout module
- **`src/lib/api.ts`** — Simplified, delegates to SDK auth functions
- **`src/lib/wallet.ts`** — Updated to use consolidated `~/.helius/` storage
- **`src/lib/config.ts`** — Updated config path to `~/.helius/config.json`
- Removed `src/constants.ts` (moved to SDK)

### MCP Server (`helius-mcp/`)
- **`src/tools/auth.ts`** — New auth tools: `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `setHeliusApiKey`
- **`src/tools/plans.ts`** — New plan info tools: `getHeliusPlanInfo`, `compareHeliusPlans`
- **`src/utils/config.ts`** — New config utility for persistent API key and keypair storage
- **`src/tools/index.ts`** — Registers new auth and plan tools
- **`src/index.ts`** — Wires up config initialization

## Test plan
- [ ] Run `helius signup` and verify basic plan ($1) flow works end-to-end
- [ ] Run `helius signup --plan developer` and verify paid plan checkout flow
- [ ] Run `helius upgrade` and verify plan upgrade with proration preview
- [ ] Run `helius pay <intent-id>` and verify renewal payment
- [ ] Test MCP tools via Claude Code: `generateKeypair` → `checkSignupBalance` → `agenticSignup` → `upgradePlan`
- [ ] Verify `~/.helius/` consolidation works for both CLI and MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)