### PR TITLE
feat(cli): Better Errors

### DIFF
--- a/helius-cli/CLAUDE.md
+++ b/helius-cli/CLAUDE.md
@@ -27,10 +27,10 @@ src/
     projects.ts        # list projects (existing)
     ...
   lib/
-    helius.ts          # SDK client wrapper — resolveApiKey(), getClient(), restRequest()
+    helius.ts          # SDK client wrapper — resolveApiKey(), getClient(), restRequest(), HeliusHttpError
     formatters.ts      # formatSol(), formatAddress(), formatTimestamp(), formatTable()
     config.ts          # ~/.helius-cli/config.json — jwt, apiKey, network, projectId
-    output.ts          # ExitCode enum, outputJson(), exitWithError()
+    output.ts          # ExitCode enum, classifyError(), outputJson(), exitWithError()
     api.ts             # Helius management API (signup, projects, API keys)
     payment.ts         # USDC payment for signup
     wallet.ts          # Keypair loading
@@ -45,7 +45,24 @@ All data commands follow this pattern:
 3. Get SDK client via `getClient(apiKey, network)`
 4. Call SDK method
 5. Output: formatted terminal (chalk) or `outputJson()` for `--json`
-6. Error: `process.exit(ExitCode.SDK_ERROR)`
+6. Error: call `classifyError(error)`, emit `outputJson({ error, message, retryable })` in JSON mode, show spinner hint in terminal mode, exit with the classified exit code
+
+Standard catch block template (all commands except `ws.ts`):
+```ts
+} catch (error) {
+  const { exitCode, errorCode, retryable } = classifyError(error);
+  const message = error instanceof Error ? error.message : String(error);
+  if (options.json) {
+    outputJson({ error: errorCode, message, retryable });
+  } else {
+    const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+    spinner?.fail(`${message}${hint}`);
+  }
+  process.exit(exitCode);
+}
+```
+
+WebSocket commands (`ws.ts`) use a variant that preserves the AbortError early-return and uses `console.error` instead of spinner.
 
 ## API Key Resolution Chain
 
@@ -58,11 +75,34 @@ All data commands follow this pattern:
 
 - 0: success
 - 1: general error
-- 10-19: auth errors
-- 20-29: balance/payment errors
-- 30-39: project errors
-- 40-49: API errors
-- 50-59: SDK/data errors (NO_API_KEY=50, SDK_ERROR=51, INVALID_ADDRESS=52, NETWORK_ERROR=53)
+- 10-19: auth errors (NOT_LOGGED_IN=10, KEYPAIR_NOT_FOUND=11, AUTH_FAILED=12)
+- 20-29: balance/payment errors (INSUFFICIENT_SOL=20, INSUFFICIENT_USDC=21, PAYMENT_FAILED=22)
+- 30-39: project errors (NO_PROJECTS=30, PROJECT_NOT_FOUND=31, MULTIPLE_PROJECTS=32, PROJECT_EXISTS=33)
+- 40-49: API errors (API_ERROR=40, NO_API_KEYS=41)
+- 50-59: SDK/data errors:
+  - 50 `NO_API_KEY` — resolveApiKey() found nothing; permanent, fix config
+  - 51 `SDK_ERROR` — unclassified SDK error
+  - 52 `INVALID_ADDRESS` — bad base58/pubkey format; permanent
+  - 53 `INVALID_INPUT` — bad parameters or HTTP 400; permanent
+  - 54 `INVALID_API_KEY` — HTTP 401/403 or "invalid api key"; permanent, fix the key
+  - 55 `NOT_FOUND` — HTTP 404 or resource not found; permanent
+  - 56 `RATE_LIMITED` — HTTP 429 or rate limit message; **transient, safe to retry**
+  - 57 `SERVER_ERROR` — HTTP 5xx or server error message; **transient, safe to retry**
+  - 58 `NETWORK_ERROR` — ECONNREFUSED/ETIMEDOUT/fetch failed; **transient, safe to retry**
+
+The `retryable` field in `--json` error output reflects this directly.
+
+## Error Classification
+
+`classifyError(error)` in `src/lib/output.ts` returns `{ exitCode, errorCode, retryable }` using three tiers:
+
+1. **`HeliusHttpError`** (from `restRequest()` — wallet.ts REST path): exact `status` property → precise code
+2. **Status in message** (enhanced TX: `"Helius HTTP 429: ..."`, webhooks: `"HTTP error! status: 429 - ..."`): regex extracts status → same mapping
+3. **Keyword matching** (RPC caller path — DAS, ZK, staking, raw): matches phrases like `"invalid api key"`, `"rate limit"`, `"not found"`, `"ECONNREFUSED"`, `SyntaxError`, etc.
+
+`restRequest()` throws `HeliusHttpError` (defined in `src/lib/helius.ts`) so the REST path always hits Tier 1. The SDK paths hit Tier 2 or 3 depending on the client.
+
+`exitWithError()` (used by auth/project commands) also includes `retryable` in JSON output automatically.
 
 ## SDK vs REST
 
@@ -83,5 +123,6 @@ node dist/bin/helius.js --help
 1. Create `src/commands/mycommand.ts` exporting async handler(s)
 2. Use `resolveApiKey(options)` + `getClient(apiKey, network)` from `src/lib/helius.ts`
 3. Support `--json` via `outputJson()` / formatted chalk output
-4. Register in `bin/helius.ts` with Commander.js
-5. Run `pnpm build` and verify
+4. Use the standard catch block template (see Command Pattern above) — import `classifyError` from `../lib/output.js`
+5. Register in `bin/helius.ts` with Commander.js
+6. Run `pnpm build` and verify

--- a/helius-cli/CLAUDE.md
+++ b/helius-cli/CLAUDE.md
@@ -30,7 +30,7 @@ src/
     helius.ts          # SDK client wrapper — resolveApiKey(), getClient(), restRequest(), HeliusHttpError
     formatters.ts      # formatSol(), formatAddress(), formatTimestamp(), formatTable()
     config.ts          # ~/.helius-cli/config.json — jwt, apiKey, network, projectId
-    output.ts          # ExitCode enum, classifyError(), outputJson(), exitWithError()
+    output.ts          # ExitCode enum, classifyError(), handleCommandError(), outputJson(), exitWithError()
     api.ts             # Helius management API (signup, projects, API keys)
     payment.ts         # USDC payment for signup
     wallet.ts          # Keypair loading
@@ -45,24 +45,18 @@ All data commands follow this pattern:
 3. Get SDK client via `getClient(apiKey, network)`
 4. Call SDK method
 5. Output: formatted terminal (chalk) or `outputJson()` for `--json`
-6. Error: call `classifyError(error)`, emit `outputJson({ error, message, retryable })` in JSON mode, show spinner hint in terminal mode, exit with the classified exit code
+6. Error: use `handleCommandError(error, options, spinner)` — classifies the error, emits JSON or spinner output, and exits with the classified exit code
 
-Standard catch block template (all commands except `ws.ts`):
+Standard catch block template (all commands except `ws.ts` and `signup.ts`):
 ```ts
 } catch (error) {
-  const { exitCode, errorCode, retryable } = classifyError(error);
-  const message = error instanceof Error ? error.message : String(error);
-  if (options.json) {
-    outputJson({ error: errorCode, message, retryable });
-  } else {
-    const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-    spinner?.fail(`${message}${hint}`);
-  }
-  process.exit(exitCode);
+  handleCommandError(error, options, spinner);
 }
 ```
 
-WebSocket commands (`ws.ts`) use a variant that preserves the AbortError early-return and uses `console.error` instead of spinner.
+`handleCommandError()` in `src/lib/output.ts` calls `classifyError()` internally, formats JSON or spinner output (with retryable hint), and exits with the classified exit code. All error output logic lives in this single function — do not duplicate it inline.
+
+WebSocket commands (`ws.ts`) use a variant that preserves the AbortError early-return and uses `console.error` instead of spinner. `signup.ts` uses a custom catch block with `mapErrorToExitCode()` for domain-specific payment errors (Insufficient SOL/USDC, Checkout failed).
 
 ## API Key Resolution Chain
 
@@ -123,6 +117,6 @@ node dist/bin/helius.js --help
 1. Create `src/commands/mycommand.ts` exporting async handler(s)
 2. Use `resolveApiKey(options)` + `getClient(apiKey, network)` from `src/lib/helius.ts`
 3. Support `--json` via `outputJson()` / formatted chalk output
-4. Use the standard catch block template (see Command Pattern above) — import `classifyError` from `../lib/output.js`
+4. Use `handleCommandError(error, options, spinner)` in the catch block — import from `../lib/output.js`
 5. Register in `bin/helius.ts` with Commander.js
 6. Run `pnpm build` and verify

--- a/helius-cli/src/commands/account.ts
+++ b/helius-cli/src/commands/account.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface AccountOptions extends OutputOptions, ResolveOptions {}
 
@@ -36,14 +36,6 @@ export async function accountCommand(address: string, options: AccountOptions = 
     console.log(`  ${chalk.gray("Executable:")}  ${info.executable ? chalk.green("yes") : "no"}`);
     console.log(`  ${chalk.gray("Rent epoch:")}  ${info.rentEpoch ?? "N/A"}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/account.ts
+++ b/helius-cli/src/commands/account.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface AccountOptions extends OutputOptions, ResolveOptions {}
 
@@ -36,7 +36,14 @@ export async function accountCommand(address: string, options: AccountOptions = 
     console.log(`  ${chalk.gray("Executable:")}  ${info.executable ? chalk.green("yes") : "no"}`);
     console.log(`  ${chalk.gray("Rent epoch:")}  ${info.rentEpoch ?? "N/A"}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/apikeys.ts
+++ b/helius-cli/src/commands/apikeys.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { getProject, listProjects, createApiKey } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 async function resolveProjectId(jwt: string, projectId?: string, json?: boolean): Promise<string> {
   if (projectId) {
@@ -100,13 +100,7 @@ export async function apikeysCommand(projectId?: string, options: ApikeysOptions
       `\n${chalk.gray(`Total: ${project.apiKeys.length} API key(s)`)}`
     );
   } catch (error) {
-    if (options.json) {
-      exitWithError("API_ERROR", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.API_ERROR);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -181,12 +175,6 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
       console.log(`Name:   ${apiKey.keyName}`);
     }
   } catch (error) {
-    if (options.json) {
-      exitWithError("API_ERROR", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.API_ERROR);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/asset.ts
+++ b/helius-cli/src/commands/asset.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface AssetOptions extends OutputOptions, ResolveOptions {}
 
@@ -61,15 +61,7 @@ export async function assetGetCommand(id: string, options: AssetOptions = {}): P
     console.log(chalk.bold("\nAsset Details:\n"));
     printAssetSummary(result);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -84,15 +76,7 @@ export async function assetBatchCommand(ids: string[], options: AssetOptions = {
     console.log(chalk.bold(`\nBatch Assets (${items.length}):\n`));
     printAssetList(items, "assets");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -110,15 +94,7 @@ export async function assetOwnerCommand(address: string, options: AssetOptions &
     console.log(chalk.bold(`\nAssets owned by ${chalk.cyan(address)}:\n`));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -137,15 +113,7 @@ export async function assetCreatorCommand(address: string, options: AssetOptions
     console.log(chalk.bold(`\nAssets by creator ${chalk.cyan(address)}:\n`));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -163,15 +131,7 @@ export async function assetAuthorityCommand(address: string, options: AssetOptio
     console.log(chalk.bold(`\nAssets by authority ${chalk.cyan(address)}:\n`));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -190,15 +150,7 @@ export async function assetCollectionCommand(address: string, options: AssetOpti
     console.log(chalk.bold(`\nAssets in collection ${chalk.cyan(address)}:\n`));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -226,15 +178,7 @@ export async function assetSearchCommand(options: AssetOptions & {
     console.log(chalk.bold("\nSearch Results:\n"));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -255,15 +199,7 @@ export async function assetProofCommand(id: string, options: AssetOptions = {}):
       console.log(`  ${chalk.gray("Proof:")}      ${proof.proof.length} node(s)`);
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -280,15 +216,7 @@ export async function assetProofBatchCommand(ids: string[], options: AssetOption
       console.log(`  ${chalk.cyan(id)}: root=${p?.root || "N/A"}, ${p?.proof?.length || 0} node(s)`);
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -313,15 +241,7 @@ export async function assetEditionsCommand(mint: string, options: AssetOptions &
       console.log(`  ${chalk.gray("Edition:")} ${ed.mint || "N/A"} (${ed.edition_number || "?"})`);
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -347,15 +267,7 @@ export async function assetSignaturesCommand(id: string, options: AssetOptions &
       console.log(`  ${chalk.cyan(s)}`);
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -393,14 +305,6 @@ export async function assetTokenAccountsCommand(options: AssetOptions & { owner?
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${accounts.length} account(s) shown`));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/asset.ts
+++ b/helius-cli/src/commands/asset.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface AssetOptions extends OutputOptions, ResolveOptions {}
 
@@ -61,8 +61,15 @@ export async function assetGetCommand(id: string, options: AssetOptions = {}): P
     console.log(chalk.bold("\nAsset Details:\n"));
     printAssetSummary(result);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -77,8 +84,15 @@ export async function assetBatchCommand(ids: string[], options: AssetOptions = {
     console.log(chalk.bold(`\nBatch Assets (${items.length}):\n`));
     printAssetList(items, "assets");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -96,8 +110,15 @@ export async function assetOwnerCommand(address: string, options: AssetOptions &
     console.log(chalk.bold(`\nAssets owned by ${chalk.cyan(address)}:\n`));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -116,8 +137,15 @@ export async function assetCreatorCommand(address: string, options: AssetOptions
     console.log(chalk.bold(`\nAssets by creator ${chalk.cyan(address)}:\n`));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -135,8 +163,15 @@ export async function assetAuthorityCommand(address: string, options: AssetOptio
     console.log(chalk.bold(`\nAssets by authority ${chalk.cyan(address)}:\n`));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -155,8 +190,15 @@ export async function assetCollectionCommand(address: string, options: AssetOpti
     console.log(chalk.bold(`\nAssets in collection ${chalk.cyan(address)}:\n`));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -184,8 +226,15 @@ export async function assetSearchCommand(options: AssetOptions & {
     console.log(chalk.bold("\nSearch Results:\n"));
     printAssetList(result.items || [], "assets");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -206,8 +255,15 @@ export async function assetProofCommand(id: string, options: AssetOptions = {}):
       console.log(`  ${chalk.gray("Proof:")}      ${proof.proof.length} node(s)`);
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -224,8 +280,15 @@ export async function assetProofBatchCommand(ids: string[], options: AssetOption
       console.log(`  ${chalk.cyan(id)}: root=${p?.root || "N/A"}, ${p?.proof?.length || 0} node(s)`);
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -250,8 +313,15 @@ export async function assetEditionsCommand(mint: string, options: AssetOptions &
       console.log(`  ${chalk.gray("Edition:")} ${ed.mint || "N/A"} (${ed.edition_number || "?"})`);
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -277,8 +347,15 @@ export async function assetSignaturesCommand(id: string, options: AssetOptions &
       console.log(`  ${chalk.cyan(s)}`);
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -316,7 +393,14 @@ export async function assetTokenAccountsCommand(options: AssetOptions & { owner?
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${accounts.length} account(s) shown`));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/balance.ts
+++ b/helius-cli/src/commands/balance.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatAddress, formatTokenAmount, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface BalanceOptions extends OutputOptions, ResolveOptions {}
 
@@ -29,8 +29,15 @@ export async function balanceCommand(address: string, options: BalanceOptions = 
     console.log(`  ${chalk.gray(`(${lamports.toLocaleString()} lamports)`)}`);
     console.log(`  ${chalk.gray(`Network: ${network}`)}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -84,8 +91,15 @@ export async function tokensCommand(address: string, options: BalanceOptions & {
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${fungibles.length} token(s) found`));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -130,7 +144,14 @@ export async function tokenHoldersCommand(mint: string, options: BalanceOptions 
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${accounts.length} holder(s) shown`));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/balance.ts
+++ b/helius-cli/src/commands/balance.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatAddress, formatTokenAmount, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface BalanceOptions extends OutputOptions, ResolveOptions {}
 
@@ -29,15 +29,7 @@ export async function balanceCommand(address: string, options: BalanceOptions = 
     console.log(`  ${chalk.gray(`(${lamports.toLocaleString()} lamports)`)}`);
     console.log(`  ${chalk.gray(`Network: ${network}`)}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -91,15 +83,7 @@ export async function tokensCommand(address: string, options: BalanceOptions & {
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${fungibles.length} token(s) found`));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -144,14 +128,6 @@ export async function tokenHoldersCommand(mint: string, options: BalanceOptions 
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${accounts.length} holder(s) shown`));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/block.ts
+++ b/helius-cli/src/commands/block.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatTimestamp } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface BlockOptions extends OutputOptions, ResolveOptions {}
 
@@ -47,7 +47,14 @@ export async function blockCommand(slot: string, options: BlockOptions = {}): Pr
       console.log(`  ${chalk.gray("Total rewards:")}   ${(totalRewards / 1e9).toFixed(4)} SOL`);
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/block.ts
+++ b/helius-cli/src/commands/block.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatTimestamp } from "../lib/formatters.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface BlockOptions extends OutputOptions, ResolveOptions {}
 
@@ -47,14 +47,6 @@ export async function blockCommand(slot: string, options: BlockOptions = {}): Pr
       console.log(`  ${chalk.gray("Total rewards:")}   ${(totalRewards / 1e9).toFixed(4)} SOL`);
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -4,7 +4,7 @@ import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.
 import { signup } from "../lib/api.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface LoginOptions extends OutputOptions {
   keypair: string;
@@ -52,12 +52,6 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
     console.log("\n" + chalk.green("✓ Login successful!"));
     console.log(`\nJWT saved to ~/.helius/config.json`);
   } catch (error) {
-    if (options.json) {
-      exitWithError("AUTH_FAILED", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.AUTH_FAILED);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -52,6 +52,6 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
     console.log("\n" + chalk.green("✓ Login successful!"));
     console.log(`\nJWT saved to ~/.helius/config.json`);
   } catch (error) {
-    handleCommandError(error, options, spinner);
+    handleCommandError(error, options, spinner, "AUTH_FAILED");
   }
 }

--- a/helius-cli/src/commands/network-status.ts
+++ b/helius-cli/src/commands/network-status.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface NetworkOptions extends OutputOptions, ResolveOptions {}
 
@@ -36,14 +36,6 @@ export async function networkStatusCommand(options: NetworkOptions = {}): Promis
     const progress = (Number(epochInfo.slotIndex) / Number(epochInfo.slotsInEpoch) * 100).toFixed(1);
     console.log(`  ${chalk.gray("Epoch progress:")} ${progress}%`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/network-status.ts
+++ b/helius-cli/src/commands/network-status.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface NetworkOptions extends OutputOptions, ResolveOptions {}
 
@@ -36,7 +36,14 @@ export async function networkStatusCommand(options: NetworkOptions = {}): Promis
     const progress = (Number(epochInfo.slotIndex) / Number(epochInfo.slotsInEpoch) * 100).toFixed(1);
     console.log(`  ${chalk.gray("Epoch progress:")} ${progress}%`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -113,6 +113,6 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
       console.log(`\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`);
     }
   } catch (error) {
-    handleCommandError(error, options, spinner);
+    handleCommandError(error, options, spinner, "PAYMENT_FAILED");
   }
 }

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -6,7 +6,7 @@ import { getPaymentIntent, executeRenewal } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
 
 interface PayOptions extends OutputOptions {
@@ -113,12 +113,6 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
       console.log(`\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`);
     }
   } catch (error) {
-    if (options.json) {
-      exitWithError("PAYMENT_FAILED", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.GENERAL_ERROR);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/program.ts
+++ b/helius-cli/src/commands/program.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface ProgramOptions extends OutputOptions, ResolveOptions {}
 
@@ -43,8 +43,15 @@ export async function programAccountsCommand(programId: string, options: Program
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${items.length} account(s) shown`));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -68,8 +75,15 @@ export async function programAccountsAllCommand(programId: string, options: Prog
     console.log(chalk.bold(`\nAll program accounts for ${chalk.cyan(programId)}:\n`));
     console.log(`  ${chalk.gray("Total accounts:")} ${chalk.cyan(items.length.toLocaleString())}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -112,7 +126,14 @@ export async function programTokenAccountsCommand(owner: string, options: Progra
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${items.length} account(s) shown`));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/program.ts
+++ b/helius-cli/src/commands/program.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface ProgramOptions extends OutputOptions, ResolveOptions {}
 
@@ -43,15 +43,7 @@ export async function programAccountsCommand(programId: string, options: Program
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${items.length} account(s) shown`));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -75,15 +67,7 @@ export async function programAccountsAllCommand(programId: string, options: Prog
     console.log(chalk.bold(`\nAll program accounts for ${chalk.cyan(programId)}:\n`));
     console.log(`  ${chalk.gray("Total accounts:")} ${chalk.cyan(items.length.toLocaleString())}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -126,14 +110,6 @@ export async function programTokenAccountsCommand(owner: string, options: Progra
     console.log(formatTable(rows, columns));
     console.log(chalk.gray(`\n  ${items.length} account(s) shown`));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/project.ts
+++ b/helius-cli/src/commands/project.ts
@@ -3,7 +3,7 @@ import ora from "ora";
 import { getProject, listProjects } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 export async function projectCommand(projectId?: string, options: OutputOptions = {}): Promise<void> {
   const spinner = options.json ? null : ora();
@@ -152,12 +152,6 @@ export async function projectCommand(projectId?: string, options: OutputOptions 
       }
     }
   } catch (error) {
-    if (options.json) {
-      exitWithError("API_ERROR", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.API_ERROR);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/projects.ts
+++ b/helius-cli/src/commands/projects.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { listProjects } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 export async function projectsCommand(options: OutputOptions): Promise<void> {
   const spinner = options.json ? null : ora();
@@ -73,12 +73,6 @@ export async function projectsCommand(options: OutputOptions): Promise<void> {
     console.log(chalk.gray(`\nRun \`helius apikeys ${firstProjectId}\` to view API keys`));
     console.log(chalk.gray(`Run \`helius rpc ${firstProjectId}\` to view RPC endpoints`));
   } catch (error) {
-    if (options.json) {
-      exitWithError("API_ERROR", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.API_ERROR);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/rpc.ts
+++ b/helius-cli/src/commands/rpc.ts
@@ -3,7 +3,7 @@ import ora from "ora";
 import { listProjects, getProject } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 export async function rpcCommand(projectId?: string, options: OutputOptions = {}): Promise<void> {
   const spinner = options.json ? null : ora();
@@ -154,12 +154,6 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
       console.log(`  ${chalk.blue("https://" + record.dns)}`);
     }
   } catch (error) {
-    if (options.json) {
-      exitWithError("API_ERROR", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.API_ERROR);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface SendOptions extends OutputOptions, ResolveOptions {}
 
@@ -21,15 +21,7 @@ export async function sendBroadcastCommand(base64Tx: string, options: SendOption
     console.log(chalk.green("\nTransaction broadcast successfully!"));
     console.log(`  ${chalk.gray("Signature:")} ${chalk.cyan(signature)}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -49,15 +41,7 @@ export async function sendRawCommand(base64Tx: string, options: SendOptions = {}
     console.log(chalk.green("\nTransaction sent!"));
     console.log(`  ${chalk.gray("Signature:")} ${chalk.cyan(String(signature))}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -81,15 +65,7 @@ export async function sendSenderCommand(base64Tx: string, options: SendOptions &
     console.log(chalk.green("\nTransaction sent via Helius Sender!"));
     console.log(`  ${chalk.gray("Signature:")} ${chalk.cyan(signature)}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -109,15 +85,7 @@ export async function sendPollCommand(signature: string, options: SendOptions = 
     console.log(chalk.green("\nTransaction confirmed!"));
     console.log(`  ${chalk.gray("Signature:")} ${chalk.cyan(String(result))}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -137,14 +105,6 @@ export async function sendComputeUnitsCommand(base64Tx: string, options: SendOpt
     console.log(chalk.bold("\nCompute Unit Estimate:\n"));
     console.log(`  ${chalk.cyan(String(result))} CU`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface SendOptions extends OutputOptions, ResolveOptions {}
 
@@ -21,8 +21,15 @@ export async function sendBroadcastCommand(base64Tx: string, options: SendOption
     console.log(chalk.green("\nTransaction broadcast successfully!"));
     console.log(`  ${chalk.gray("Signature:")} ${chalk.cyan(signature)}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -42,8 +49,15 @@ export async function sendRawCommand(base64Tx: string, options: SendOptions = {}
     console.log(chalk.green("\nTransaction sent!"));
     console.log(`  ${chalk.gray("Signature:")} ${chalk.cyan(String(signature))}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -67,8 +81,15 @@ export async function sendSenderCommand(base64Tx: string, options: SendOptions &
     console.log(chalk.green("\nTransaction sent via Helius Sender!"));
     console.log(`  ${chalk.gray("Signature:")} ${chalk.cyan(signature)}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -88,8 +109,15 @@ export async function sendPollCommand(signature: string, options: SendOptions = 
     console.log(chalk.green("\nTransaction confirmed!"));
     console.log(`  ${chalk.gray("Signature:")} ${chalk.cyan(String(result))}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -109,7 +137,14 @@ export async function sendComputeUnitsCommand(base64Tx: string, options: SendOpt
     console.log(chalk.bold("\nCompute Unit Estimate:\n"));
     console.log(`  ${chalk.cyan(String(result))} CU`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, ExitCode, type OutputOptions } from "../lib/output.js";
 
 interface StakeOptions extends OutputOptions, ResolveOptions {}
 
@@ -30,8 +30,15 @@ export async function stakeAccountsCommand(wallet: string, options: StakeOptions
       console.log(`  ${chalk.cyan(typeof a === "string" ? a : JSON.stringify(a))}`);
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -52,8 +59,15 @@ export async function stakeWithdrawableCommand(stakeAccount: string, options: St
     console.log(chalk.bold(`\nWithdrawable Amount for ${chalk.cyan(stakeAccount)}:\n`));
     console.log(`  ${chalk.green(typeof result === "number" || typeof result === "bigint" ? formatSol(result) : JSON.stringify(result))}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -75,8 +89,15 @@ export async function stakeInstructionsCommand(amount: string, options: StakeOpt
     console.log(chalk.bold(`\nStake Instructions for ${amount} SOL:\n`));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -97,8 +118,15 @@ export async function stakeUnstakeInstructionCommand(stakeAccount: string, optio
     console.log(chalk.bold(`\nUnstake Instruction for ${chalk.cyan(stakeAccount)}:\n`));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -119,8 +147,15 @@ export async function stakeWithdrawInstructionCommand(stakeAccount: string, opti
     console.log(chalk.bold(`\nWithdraw Instruction for ${chalk.cyan(stakeAccount)}:\n`));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -147,8 +182,15 @@ export async function stakeCreateCommand(amount: string, options: StakeOptions &
     console.log(chalk.gray("Transaction needs to be signed and sent with your keypair."));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -173,8 +215,15 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
     console.log(chalk.bold("\nUnstake Transaction Created:\n"));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -199,7 +248,14 @@ export async function stakeWithdrawCommand(stakeAccount: string, options: StakeO
     console.log(chalk.bold("\nWithdraw Transaction Created:\n"));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, classifyError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, ExitCode, type OutputOptions } from "../lib/output.js";
 
 interface StakeOptions extends OutputOptions, ResolveOptions {}
 
@@ -30,15 +30,7 @@ export async function stakeAccountsCommand(wallet: string, options: StakeOptions
       console.log(`  ${chalk.cyan(typeof a === "string" ? a : JSON.stringify(a))}`);
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -59,15 +51,7 @@ export async function stakeWithdrawableCommand(stakeAccount: string, options: St
     console.log(chalk.bold(`\nWithdrawable Amount for ${chalk.cyan(stakeAccount)}:\n`));
     console.log(`  ${chalk.green(typeof result === "number" || typeof result === "bigint" ? formatSol(result) : JSON.stringify(result))}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -89,15 +73,7 @@ export async function stakeInstructionsCommand(amount: string, options: StakeOpt
     console.log(chalk.bold(`\nStake Instructions for ${amount} SOL:\n`));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -118,15 +94,7 @@ export async function stakeUnstakeInstructionCommand(stakeAccount: string, optio
     console.log(chalk.bold(`\nUnstake Instruction for ${chalk.cyan(stakeAccount)}:\n`));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -147,15 +115,7 @@ export async function stakeWithdrawInstructionCommand(stakeAccount: string, opti
     console.log(chalk.bold(`\nWithdraw Instruction for ${chalk.cyan(stakeAccount)}:\n`));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -182,15 +142,7 @@ export async function stakeCreateCommand(amount: string, options: StakeOptions &
     console.log(chalk.gray("Transaction needs to be signed and sent with your keypair."));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -215,15 +167,7 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
     console.log(chalk.bold("\nUnstake Transaction Created:\n"));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -248,14 +192,6 @@ export async function stakeWithdrawCommand(stakeAccount: string, options: StakeO
     console.log(chalk.bold("\nWithdraw Transaction Created:\n"));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatTimestamp, formatAddress, formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface TxOptions extends OutputOptions, ResolveOptions {}
 
@@ -54,8 +54,15 @@ export async function txParseCommand(signatures: string[], options: TxOptions = 
     }
     console.log();
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -99,8 +106,15 @@ export async function txHistoryCommand(address: string, options: TxOptions & { l
     }
     console.log(chalk.gray(`\n  ${txs.length} transaction(s) shown`));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -135,7 +149,14 @@ export async function txFeesCommand(options: TxOptions & { accounts?: string } =
       console.log(chalk.gray("  No fee data available."));
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatTimestamp, formatAddress, formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface TxOptions extends OutputOptions, ResolveOptions {}
 
@@ -54,15 +54,7 @@ export async function txParseCommand(signatures: string[], options: TxOptions = 
     }
     console.log();
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -106,15 +98,7 @@ export async function txHistoryCommand(address: string, options: TxOptions & { l
     }
     console.log(chalk.gray(`\n  ${txs.length} transaction(s) shown`));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -149,14 +133,6 @@ export async function txFeesCommand(options: TxOptions & { accounts?: string } =
       console.log(chalk.gray("  No fee data available."));
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -5,7 +5,7 @@ import { signup, listProjects, getProject } from "../lib/api.js";
 import { getCheckoutPreview, executeUpgrade, PLAN_CATALOG } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
 
 interface UpgradeOptions extends OutputOptions {
@@ -169,12 +169,6 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
       console.log(`\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`);
     }
   } catch (error) {
-    if (options.json) {
-      exitWithError("PAYMENT_FAILED", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.GENERAL_ERROR);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -169,6 +169,6 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
       console.log(`\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`);
     }
   } catch (error) {
-    handleCommandError(error, options, spinner);
+    handleCommandError(error, options, spinner, "PAYMENT_FAILED");
   }
 }

--- a/helius-cli/src/commands/usage.ts
+++ b/helius-cli/src/commands/usage.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { getProject, listProjects } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 export async function usageCommand(projectId?: string, options: OutputOptions = {}): Promise<void> {
   const spinner = options.json ? null : ora();
@@ -110,12 +110,6 @@ export async function usageCommand(projectId?: string, options: OutputOptions = 
       console.log(`  ${project.billingCycle.start} to ${project.billingCycle.end}`);
     }
   } catch (error) {
-    if (options.json) {
-      exitWithError("API_ERROR", error instanceof Error ? error.message : String(error), undefined, true);
-    }
-    spinner?.fail(
-      `Error: ${error instanceof Error ? error.message : String(error)}`
-    );
-    process.exit(ExitCode.API_ERROR);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/wallet.ts
+++ b/helius-cli/src/commands/wallet.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, restRequest, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, formatEnumLabel, type TableColumn } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface WalletOptions extends OutputOptions, ResolveOptions {}
 
@@ -25,8 +25,15 @@ export async function walletIdentityCommand(address: string, options: WalletOpti
     if (result.category) console.log(`  ${chalk.gray("Category:")} ${result.category}`);
     if (result.tags?.length) console.log(`  ${chalk.gray("Tags:")}     ${result.tags.join(", ")}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -54,8 +61,15 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
       console.log(chalk.gray(`\n  ${unknown.length} wallet(s) have no known identity`));
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -98,8 +112,15 @@ export async function walletBalancesCommand(address: string, options: WalletOpti
       console.log(formatTable(rows, columns));
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -134,8 +155,15 @@ export async function walletHistoryCommand(address: string, options: WalletOptio
       console.log(chalk.gray(`  Next cursor: ${result.pagination.nextCursor}`));
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -168,8 +196,15 @@ export async function walletTransfersCommand(address: string, options: WalletOpt
       console.log(chalk.gray(`  Next cursor: ${result.pagination.nextCursor}`));
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -194,7 +229,14 @@ export async function walletFundedByCommand(address: string, options: WalletOpti
     if (result.signature) console.log(`  ${chalk.gray("Signature:")}   ${result.signature}`);
     if (result.amount != null) console.log(`  ${chalk.gray("Amount:")}      ${result.amount} SOL`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/wallet.ts
+++ b/helius-cli/src/commands/wallet.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, restRequest, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, formatEnumLabel, type TableColumn } from "../lib/formatters.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface WalletOptions extends OutputOptions, ResolveOptions {}
 
@@ -25,15 +25,7 @@ export async function walletIdentityCommand(address: string, options: WalletOpti
     if (result.category) console.log(`  ${chalk.gray("Category:")} ${result.category}`);
     if (result.tags?.length) console.log(`  ${chalk.gray("Tags:")}     ${result.tags.join(", ")}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -61,15 +53,7 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
       console.log(chalk.gray(`\n  ${unknown.length} wallet(s) have no known identity`));
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -112,15 +96,7 @@ export async function walletBalancesCommand(address: string, options: WalletOpti
       console.log(formatTable(rows, columns));
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -155,15 +131,7 @@ export async function walletHistoryCommand(address: string, options: WalletOptio
       console.log(chalk.gray(`  Next cursor: ${result.pagination.nextCursor}`));
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -196,15 +164,7 @@ export async function walletTransfersCommand(address: string, options: WalletOpt
       console.log(chalk.gray(`  Next cursor: ${result.pagination.nextCursor}`));
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -229,14 +189,6 @@ export async function walletFundedByCommand(address: string, options: WalletOpti
     if (result.signature) console.log(`  ${chalk.gray("Signature:")}   ${result.signature}`);
     if (result.amount != null) console.log(`  ${chalk.gray("Amount:")}      ${result.amount} SOL`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface WebhookOptions extends OutputOptions, ResolveOptions {}
 
@@ -35,8 +35,15 @@ export async function webhookListCommand(options: WebhookOptions = {}): Promise<
       console.log();
     }
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -65,8 +72,15 @@ export async function webhookGetCommand(webhookId: string, options: WebhookOptio
     }
     console.log(`  ${chalk.gray("Tx Types:")} ${(result.transactionTypes || []).map(formatEnumLabel).join(", ") || "ANY"}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -99,8 +113,15 @@ export async function webhookCreateCommand(options: WebhookOptions & {
     console.log(`  ${chalk.gray("URL:")}  ${result.webhookURL}`);
     console.log(`  ${chalk.gray("Type:")} ${result.webhookType ? formatEnumLabel(result.webhookType) : "N/A"}`);
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -126,8 +147,15 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
 
     console.log(chalk.green(`\nWebhook ${webhookId} updated successfully!`));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -146,7 +174,14 @@ export async function webhookDeleteCommand(webhookId: string, options: WebhookOp
 
     console.log(chalk.green(`\nWebhook ${webhookId} deleted successfully.`));
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface WebhookOptions extends OutputOptions, ResolveOptions {}
 
@@ -35,15 +35,7 @@ export async function webhookListCommand(options: WebhookOptions = {}): Promise<
       console.log();
     }
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -72,15 +64,7 @@ export async function webhookGetCommand(webhookId: string, options: WebhookOptio
     }
     console.log(`  ${chalk.gray("Tx Types:")} ${(result.transactionTypes || []).map(formatEnumLabel).join(", ") || "ANY"}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -113,15 +97,7 @@ export async function webhookCreateCommand(options: WebhookOptions & {
     console.log(`  ${chalk.gray("URL:")}  ${result.webhookURL}`);
     console.log(`  ${chalk.gray("Type:")} ${result.webhookType ? formatEnumLabel(result.webhookType) : "N/A"}`);
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -147,15 +123,7 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
 
     console.log(chalk.green(`\nWebhook ${webhookId} updated successfully!`));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -174,14 +142,6 @@ export async function webhookDeleteCommand(webhookId: string, options: WebhookOp
 
     console.log(chalk.green(`\nWebhook ${webhookId} deleted successfully.`));
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/ws.ts
+++ b/helius-cli/src/commands/ws.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { jsonReplacer, ExitCode, type OutputOptions } from "../lib/output.js";
+import { jsonReplacer, outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface WsOptions extends OutputOptions, ResolveOptions {}
 
@@ -47,8 +47,15 @@ export async function wsAccountCommand(address: string, options: WsOptions = {})
     await streamSubscription(channel as any, ac, options);
   } catch (error) {
     if ((error as any)?.name === "AbortError") return;
-    console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      console.error(chalk.red(`Error: ${message}${hint}`));
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -65,8 +72,15 @@ export async function wsLogsCommand(options: WsOptions & { mentions?: string } =
     await streamSubscription(channel as any, ac, options);
   } catch (error) {
     if ((error as any)?.name === "AbortError") return;
-    console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      console.error(chalk.red(`Error: ${message}${hint}`));
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -93,8 +107,15 @@ export async function wsSlotCommand(options: WsOptions = {}): Promise<void> {
     }
   } catch (error) {
     if ((error as any)?.name === "AbortError") return;
-    console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      console.error(chalk.red(`Error: ${message}${hint}`));
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -110,8 +131,15 @@ export async function wsSignatureCommand(signature: string, options: WsOptions =
     await streamSubscription(channel as any, ac, options);
   } catch (error) {
     if ((error as any)?.name === "AbortError") return;
-    console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      console.error(chalk.red(`Error: ${message}${hint}`));
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -127,7 +155,14 @@ export async function wsProgramCommand(programId: string, options: WsOptions = {
     await streamSubscription(channel as any, ac, options);
   } catch (error) {
     if ((error as any)?.name === "AbortError") return;
-    console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      console.error(chalk.red(`Error: ${message}${hint}`));
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/ws.ts
+++ b/helius-cli/src/commands/ws.ts
@@ -23,6 +23,19 @@ async function streamSubscription(
   }
 }
 
+function handleWsError(error: unknown, options: WsOptions): void {
+  if ((error as any)?.name === "AbortError") return;
+  const { exitCode, errorCode, retryable } = classifyError(error);
+  const message = error instanceof Error ? error.message : String(error);
+  if (options.json) {
+    outputJson({ error: errorCode, message, retryable });
+  } else {
+    const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+    console.error(chalk.red(`Error: ${message}${hint}`));
+  }
+  process.exit(exitCode);
+}
+
 function setupShutdown(helius: any, abortController: AbortController, label: string): void {
   console.log(chalk.gray(`\nStreaming ${label}... (Ctrl+C to stop)\n`));
   const cleanup = () => {
@@ -46,16 +59,7 @@ export async function wsAccountCommand(address: string, options: WsOptions = {})
     const channel = await helius.ws.accountNotifications(address as any, { encoding: "jsonParsed" });
     await streamSubscription(channel as any, ac, options);
   } catch (error) {
-    if ((error as any)?.name === "AbortError") return;
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      console.error(chalk.red(`Error: ${message}${hint}`));
-    }
-    process.exit(exitCode);
+    handleWsError(error, options);
   }
 }
 
@@ -71,16 +75,7 @@ export async function wsLogsCommand(options: WsOptions & { mentions?: string } =
     const channel = await helius.ws.logsNotifications(filter);
     await streamSubscription(channel as any, ac, options);
   } catch (error) {
-    if ((error as any)?.name === "AbortError") return;
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      console.error(chalk.red(`Error: ${message}${hint}`));
-    }
-    process.exit(exitCode);
+    handleWsError(error, options);
   }
 }
 
@@ -106,16 +101,7 @@ export async function wsSlotCommand(options: WsOptions = {}): Promise<void> {
       printNotification(notification, options);
     }
   } catch (error) {
-    if ((error as any)?.name === "AbortError") return;
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      console.error(chalk.red(`Error: ${message}${hint}`));
-    }
-    process.exit(exitCode);
+    handleWsError(error, options);
   }
 }
 
@@ -130,16 +116,7 @@ export async function wsSignatureCommand(signature: string, options: WsOptions =
     const channel = await helius.ws.signatureNotifications(signature);
     await streamSubscription(channel as any, ac, options);
   } catch (error) {
-    if ((error as any)?.name === "AbortError") return;
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      console.error(chalk.red(`Error: ${message}${hint}`));
-    }
-    process.exit(exitCode);
+    handleWsError(error, options);
   }
 }
 
@@ -154,15 +131,6 @@ export async function wsProgramCommand(programId: string, options: WsOptions = {
     const channel = await helius.ws.programNotifications(programId as any, { encoding: "jsonParsed" });
     await streamSubscription(channel as any, ac, options);
   } catch (error) {
-    if ((error as any)?.name === "AbortError") return;
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      console.error(chalk.red(`Error: ${message}${hint}`));
-    }
-    process.exit(exitCode);
+    handleWsError(error, options);
   }
 }

--- a/helius-cli/src/commands/zk.ts
+++ b/helius-cli/src/commands/zk.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface ZkOptions extends OutputOptions, ResolveOptions {}
 
@@ -28,8 +28,15 @@ export async function zkAccountCommand(addressOrHash: string, options: ZkOptions
     const result = await helius.zk.getCompressedAccount({ address: addressOrHash });
     handleResult(spinner, result, options, "Compressed Account");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -40,8 +47,15 @@ export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions
     const result = await helius.zk.getCompressedAccountsByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Accounts by Owner");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -52,8 +66,15 @@ export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions
     const result = await helius.zk.getCompressedBalance({ address: addressOrHash });
     handleResult(spinner, result, options, "Compressed Balance");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -64,8 +85,15 @@ export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions 
     const result = await helius.zk.getCompressedBalanceByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Balance by Owner");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -76,8 +104,15 @@ export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {
     const result = await helius.zk.getCompressedMintTokenHolders({ mint });
     handleResult(spinner, result, options, "Compressed Token Holders");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -88,8 +123,15 @@ export async function zkTokenBalanceCommand(account: string, options: ZkOptions 
     const result = await helius.zk.getCompressedTokenAccountBalance({ address: account });
     handleResult(spinner, result, options, "Compressed Token Account Balance");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -100,8 +142,15 @@ export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOp
     const result = await helius.zk.getCompressedTokenAccountsByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Token Accounts by Owner");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -112,8 +161,15 @@ export async function zkTokenAccountsByDelegateCommand(delegate: string, options
     const result = await helius.zk.getCompressedTokenAccountsByDelegate({ delegate });
     handleResult(spinner, result, options, "Compressed Token Accounts by Delegate");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -124,8 +180,15 @@ export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOp
     const result = await helius.zk.getCompressedTokenBalancesByOwnerV2({ owner });
     handleResult(spinner, result, options, "Compressed Token Balances by Owner (V2)");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -136,8 +199,15 @@ export async function zkProofCommand(addressOrHash: string, options: ZkOptions =
     const result = await helius.zk.getCompressedAccountProof({ hash: addressOrHash });
     handleResult(spinner, result, options, "Compressed Account Proof");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -148,8 +218,15 @@ export async function zkProofsCommand(addresses: string[], options: ZkOptions = 
     const result = await helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses });
     handleResult(spinner, result, options, "Multiple Compressed Account Proofs");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -160,8 +237,15 @@ export async function zkMultipleAccountsCommand(addresses: string[], options: Zk
     const result = await helius.zk.getMultipleCompressedAccounts({ addresses });
     handleResult(spinner, result, options, "Multiple Compressed Accounts");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -172,8 +256,15 @@ export async function zkAddressProofsCommand(addresses: string[], options: ZkOpt
     const result = await helius.zk.getMultipleNewAddressProofsV2(addresses);
     handleResult(spinner, result, options, "Multiple New Address Proofs (V2)");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -184,8 +275,15 @@ export async function zkSignaturesAccountCommand(account: string, options: ZkOpt
     const result = await helius.zk.getCompressionSignaturesForAccount({ hash: account });
     handleResult(spinner, result, options, "Compression Signatures for Account");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -196,8 +294,15 @@ export async function zkSignaturesAddressCommand(address: string, options: ZkOpt
     const result = await helius.zk.getCompressionSignaturesForAddress({ address });
     handleResult(spinner, result, options, "Compression Signatures for Address");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -208,8 +313,15 @@ export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions
     const result = await helius.zk.getCompressionSignaturesForOwner({ owner });
     handleResult(spinner, result, options, "Compression Signatures for Owner");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -220,8 +332,15 @@ export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOp
     const result = await helius.zk.getCompressionSignaturesForTokenOwner({ owner });
     handleResult(spinner, result, options, "Compression Signatures for Token Owner");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -232,8 +351,15 @@ export async function zkLatestSignaturesCommand(options: ZkOptions = {}): Promis
     const result = await helius.zk.getLatestCompressionSignatures({});
     handleResult(spinner, result, options, "Latest Compression Signatures");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -244,8 +370,15 @@ export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise
     const result = await helius.zk.getLatestNonVotingSignatures({});
     handleResult(spinner, result, options, "Latest Non-Voting Signatures");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -256,8 +389,15 @@ export async function zkTxCommand(signature: string, options: ZkOptions = {}): P
     const result = await helius.zk.getTransactionWithCompressionInfo({ signature });
     handleResult(spinner, result, options, "Transaction with Compression Info");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -271,8 +411,15 @@ export async function zkValidityProofCommand(options: ZkOptions & { hashes?: str
     const result = await helius.zk.getValidityProof(params);
     handleResult(spinner, result, options, "Validity Proof");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -283,8 +430,15 @@ export async function zkIndexerHealthCommand(options: ZkOptions = {}): Promise<v
     const result = await helius.zk.getIndexerHealth();
     handleResult(spinner, result, options, "Indexer Health");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -295,8 +449,15 @@ export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<voi
     const result = await helius.zk.getIndexerSlot();
     handleResult(spinner, result, options, "Indexer Slot");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }
 
@@ -307,7 +468,14 @@ export async function zkSignaturesForAssetCommand(id: string, options: ZkOptions
     const result = await helius.zk.getSignaturesForAsset({ id, page: 1 });
     handleResult(spinner, result, options, "Signatures for Asset");
   } catch (error) {
-    spinner?.fail(`Error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(ExitCode.SDK_ERROR);
+    const { exitCode, errorCode, retryable } = classifyError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      outputJson({ error: errorCode, message, retryable });
+    } else {
+      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+      spinner?.fail(`${message}${hint}`);
+    }
+    process.exit(exitCode);
   }
 }

--- a/helius-cli/src/commands/zk.ts
+++ b/helius-cli/src/commands/zk.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface ZkOptions extends OutputOptions, ResolveOptions {}
 
@@ -28,15 +28,7 @@ export async function zkAccountCommand(addressOrHash: string, options: ZkOptions
     const result = await helius.zk.getCompressedAccount({ address: addressOrHash });
     handleResult(spinner, result, options, "Compressed Account");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -47,15 +39,7 @@ export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions
     const result = await helius.zk.getCompressedAccountsByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Accounts by Owner");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -66,15 +50,7 @@ export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions
     const result = await helius.zk.getCompressedBalance({ address: addressOrHash });
     handleResult(spinner, result, options, "Compressed Balance");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -85,15 +61,7 @@ export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions 
     const result = await helius.zk.getCompressedBalanceByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Balance by Owner");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -104,15 +72,7 @@ export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {
     const result = await helius.zk.getCompressedMintTokenHolders({ mint });
     handleResult(spinner, result, options, "Compressed Token Holders");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -123,15 +83,7 @@ export async function zkTokenBalanceCommand(account: string, options: ZkOptions 
     const result = await helius.zk.getCompressedTokenAccountBalance({ address: account });
     handleResult(spinner, result, options, "Compressed Token Account Balance");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -142,15 +94,7 @@ export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOp
     const result = await helius.zk.getCompressedTokenAccountsByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Token Accounts by Owner");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -161,15 +105,7 @@ export async function zkTokenAccountsByDelegateCommand(delegate: string, options
     const result = await helius.zk.getCompressedTokenAccountsByDelegate({ delegate });
     handleResult(spinner, result, options, "Compressed Token Accounts by Delegate");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -180,15 +116,7 @@ export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOp
     const result = await helius.zk.getCompressedTokenBalancesByOwnerV2({ owner });
     handleResult(spinner, result, options, "Compressed Token Balances by Owner (V2)");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -199,15 +127,7 @@ export async function zkProofCommand(addressOrHash: string, options: ZkOptions =
     const result = await helius.zk.getCompressedAccountProof({ hash: addressOrHash });
     handleResult(spinner, result, options, "Compressed Account Proof");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -218,15 +138,7 @@ export async function zkProofsCommand(addresses: string[], options: ZkOptions = 
     const result = await helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses });
     handleResult(spinner, result, options, "Multiple Compressed Account Proofs");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -237,15 +149,7 @@ export async function zkMultipleAccountsCommand(addresses: string[], options: Zk
     const result = await helius.zk.getMultipleCompressedAccounts({ addresses });
     handleResult(spinner, result, options, "Multiple Compressed Accounts");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -256,15 +160,7 @@ export async function zkAddressProofsCommand(addresses: string[], options: ZkOpt
     const result = await helius.zk.getMultipleNewAddressProofsV2(addresses);
     handleResult(spinner, result, options, "Multiple New Address Proofs (V2)");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -275,15 +171,7 @@ export async function zkSignaturesAccountCommand(account: string, options: ZkOpt
     const result = await helius.zk.getCompressionSignaturesForAccount({ hash: account });
     handleResult(spinner, result, options, "Compression Signatures for Account");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -294,15 +182,7 @@ export async function zkSignaturesAddressCommand(address: string, options: ZkOpt
     const result = await helius.zk.getCompressionSignaturesForAddress({ address });
     handleResult(spinner, result, options, "Compression Signatures for Address");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -313,15 +193,7 @@ export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions
     const result = await helius.zk.getCompressionSignaturesForOwner({ owner });
     handleResult(spinner, result, options, "Compression Signatures for Owner");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -332,15 +204,7 @@ export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOp
     const result = await helius.zk.getCompressionSignaturesForTokenOwner({ owner });
     handleResult(spinner, result, options, "Compression Signatures for Token Owner");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -351,15 +215,7 @@ export async function zkLatestSignaturesCommand(options: ZkOptions = {}): Promis
     const result = await helius.zk.getLatestCompressionSignatures({});
     handleResult(spinner, result, options, "Latest Compression Signatures");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -370,15 +226,7 @@ export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise
     const result = await helius.zk.getLatestNonVotingSignatures({});
     handleResult(spinner, result, options, "Latest Non-Voting Signatures");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -389,15 +237,7 @@ export async function zkTxCommand(signature: string, options: ZkOptions = {}): P
     const result = await helius.zk.getTransactionWithCompressionInfo({ signature });
     handleResult(spinner, result, options, "Transaction with Compression Info");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -411,15 +251,7 @@ export async function zkValidityProofCommand(options: ZkOptions & { hashes?: str
     const result = await helius.zk.getValidityProof(params);
     handleResult(spinner, result, options, "Validity Proof");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -430,15 +262,7 @@ export async function zkIndexerHealthCommand(options: ZkOptions = {}): Promise<v
     const result = await helius.zk.getIndexerHealth();
     handleResult(spinner, result, options, "Indexer Health");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -449,15 +273,7 @@ export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<voi
     const result = await helius.zk.getIndexerSlot();
     handleResult(spinner, result, options, "Indexer Slot");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }
 
@@ -468,14 +284,6 @@ export async function zkSignaturesForAssetCommand(id: string, options: ZkOptions
     const result = await helius.zk.getSignaturesForAsset({ id, page: 1 });
     handleResult(spinner, result, options, "Signatures for Asset");
   } catch (error) {
-    const { exitCode, errorCode, retryable } = classifyError(error);
-    const message = error instanceof Error ? error.message : String(error);
-    if (options.json) {
-      outputJson({ error: errorCode, message, retryable });
-    } else {
-      const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
-      spinner?.fail(`${message}${hint}`);
-    }
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/lib/helius.ts
+++ b/helius-cli/src/lib/helius.ts
@@ -1,6 +1,22 @@
 import { createHelius, type HeliusClient } from "helius-sdk";
 import { getApiKey as getConfigApiKey, getNetwork as getConfigNetwork, getJwt, getProjectId } from "./config.js";
 import { listProjects, getProject } from "./api.js";
+import { registerHttpErrorClass } from "./output.js";
+
+/**
+ * Thrown by restRequest() on non-2xx responses
+ * Carries the exact HTTP status code for precise error classification
+ */
+export class HeliusHttpError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+    this.name = "HeliusHttpError";
+  }
+}
+
+// Register with classifyError() in output.ts so it can instanceof-check
+// without creating a circular import
+registerHttpErrorClass(HeliusHttpError);
 
 let cachedClient: HeliusClient | null = null;
 let cachedClientKey: string | null = null;
@@ -79,7 +95,8 @@ export function getClient(apiKey: string, network?: string): HeliusClient {
 }
 
 /**
- * REST request helper for Wallet API endpoints (not in SDK)
+ * REST request helper for Wallet API endpoints (not in SDK).
+ * Throws HeliusHttpError on non-2xx so classifyError() gets an exact status code.
  */
 export async function restRequest(endpoint: string, apiKey: string, options: RequestInit = {}): Promise<any> {
   const separator = endpoint.includes("?") ? "&" : "?";
@@ -94,7 +111,7 @@ export async function restRequest(endpoint: string, apiKey: string, options: Req
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`HTTP ${response.status}: ${text}`);
+    throw new HeliusHttpError(response.status, `HTTP ${response.status}: ${text}`);
   }
 
   const text = await response.text();

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -185,13 +185,29 @@ export function classifyError(error: unknown): ErrorClassification {
  *   } catch (error) {
  *     handleCommandError(error, options, spinner);
  *   }
+ *
+ * Commands with domain-specific knowledge can pass `fallbackCode` so that
+ * unclassified errors (SDK_ERROR) get a more meaningful code.  Specific
+ * classifications (RATE_LIMITED, NETWORK_ERROR, etc.) are never overridden.
+ *
+ *   handleCommandError(error, options, spinner, "AUTH_FAILED");
  */
 export function handleCommandError(
   error: unknown,
   options: { json?: boolean },
   spinner?: { fail(text: string): void } | null,
+  fallbackCode?: string,
 ): never {
-  const { exitCode, errorCode, retryable } = classifyError(error);
+  let { exitCode, errorCode, retryable } = classifyError(error);
+
+  // If the generic classifier couldn't do better than SDK_ERROR and the
+  // caller provided a domain-specific fallback, use it instead.
+  if (fallbackCode && errorCode === "SDK_ERROR") {
+    errorCode = fallbackCode;
+    exitCode = getExitCode(fallbackCode);
+    retryable = RETRYABLE_CODES.has(exitCode);
+  }
+
   const message = error instanceof Error ? error.message : String(error);
   if (options.json) {
     outputJson({ error: errorCode, message, retryable });

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -11,6 +11,7 @@ export interface OutputOptions {
 // 20-29 = balance/payment errors
 // 30-39 = project errors
 // 40-49 = API errors
+// 50-59 = SDK/data errors
 export const ExitCode = {
   SUCCESS: 0,
   GENERAL_ERROR: 1,
@@ -36,12 +37,27 @@ export const ExitCode = {
   NO_API_KEYS: 41,
 
   // SDK/data errors (50-59)
-  SDK_ERROR: 51,
+  NO_API_KEY: 50,      // resolveApiKey() failed — permanent, fix config
+  SDK_ERROR: 51,       // unclassified SDK error
+  INVALID_ADDRESS: 52, // bad base58 / pubkey format — permanent
+  INVALID_INPUT: 53,   // bad parameters / 400 — permanent
+  INVALID_API_KEY: 54, // 401 / 403 — permanent, fix the key
+  NOT_FOUND: 55,       // 404 — permanent for that resource
+  RATE_LIMITED: 56,    // 429 — transient, safe to retry
+  SERVER_ERROR: 57,    // 5xx — transient, safe to retry
+  NETWORK_ERROR: 58,   // connection/timeout — transient, safe to retry
 } as const;
 
 export type ExitCodeType = (typeof ExitCode)[keyof typeof ExitCode];
 
-// Map error codes to exit codes
+// Exit codes that indicate a transient error safe to retry
+const RETRYABLE_CODES = new Set<ExitCodeType>([
+  ExitCode.RATE_LIMITED,
+  ExitCode.SERVER_ERROR,
+  ExitCode.NETWORK_ERROR,
+]);
+
+// Map error code strings to exit codes
 const errorToExitCode: Record<string, ExitCodeType> = {
   NOT_LOGGED_IN: ExitCode.NOT_LOGGED_IN,
   KEYPAIR_NOT_FOUND: ExitCode.KEYPAIR_NOT_FOUND,
@@ -55,11 +71,127 @@ const errorToExitCode: Record<string, ExitCodeType> = {
   PROJECT_EXISTS: ExitCode.PROJECT_EXISTS,
   API_ERROR: ExitCode.API_ERROR,
   NO_API_KEYS: ExitCode.NO_API_KEYS,
+  NO_API_KEY: ExitCode.NO_API_KEY,
   SDK_ERROR: ExitCode.SDK_ERROR,
+  INVALID_ADDRESS: ExitCode.INVALID_ADDRESS,
+  INVALID_INPUT: ExitCode.INVALID_INPUT,
+  INVALID_API_KEY: ExitCode.INVALID_API_KEY,
+  NOT_FOUND: ExitCode.NOT_FOUND,
+  RATE_LIMITED: ExitCode.RATE_LIMITED,
+  SERVER_ERROR: ExitCode.SERVER_ERROR,
+  NETWORK_ERROR: ExitCode.NETWORK_ERROR,
 };
 
 export function getExitCode(errorCode: string): ExitCodeType {
   return errorToExitCode[errorCode] || ExitCode.GENERAL_ERROR;
+}
+
+// Classification result returned by classifyError()
+export interface ErrorClassification {
+  exitCode: ExitCodeType;
+  errorCode: string;
+  retryable: boolean;
+}
+
+// Import here to avoid circular dependency — helius.ts imports from output.ts
+// so we use a type-only import path trick: classifyError checks instanceof at runtime
+// by importing HeliusHttpError lazily via the class reference passed in.
+// Instead, we export a registration function so helius.ts can register its error class
+let _HeliusHttpError: (new (...args: any[]) => { status: number }) | null = null;
+
+export function registerHttpErrorClass(cls: new (...args: any[]) => { status: number }): void {
+  _HeliusHttpError = cls;
+}
+
+/**
+ * Classifies an unknown error into a structured result with exit code and retryability
+ *
+ * Three classification tiers:
+ *   1. HeliusHttpError (restRequest() path) — exact HTTP status property
+ *   2. Status embedded in message (enhanced TX: "Helius HTTP 429:", webhooks: "HTTP error! status: 429")
+ *   3. Keyword matching (RPC caller path: "RPC error (method): <server message>")
+ */
+export function classifyError(error: unknown): ErrorClassification {
+  const msg = error instanceof Error ? error.message : String(error);
+
+  // Tier 1 — HeliusHttpError from restRequest(): exact status code available
+  if (_HeliusHttpError && error instanceof _HeliusHttpError) {
+    return classifyByStatus(error.status);
+  }
+
+  // Tier 2 — HTTP status embedded in message (Enhanced TX and webhooks SDK paths)
+  // Matches: "Helius HTTP 429: ..." or "HTTP error! status: 429 - ..."
+  const heliusMatch = msg.match(/Helius HTTP (\d+):/);
+  const webhookMatch = msg.match(/HTTP error! status: (\d+)/);
+  const embeddedStatus = heliusMatch ? parseInt(heliusMatch[1], 10)
+    : webhookMatch ? parseInt(webhookMatch[1], 10)
+    : null;
+  if (embeddedStatus !== null) {
+    return classifyByStatus(embeddedStatus);
+  }
+
+  // Tier 3 — Keyword matching (RPC caller path, resolveApiKey, network errors)
+
+  // resolveApiKey() failure
+  if (msg.includes("No API key found")) {
+    return { exitCode: ExitCode.NO_API_KEY, errorCode: "NO_API_KEY", retryable: false };
+  }
+
+  // Auth — Helius server returns these strings inside "RPC error (method): ..."
+  if (/invalid.?api.?key|unauthorized|restricted access/i.test(msg)) {
+    return { exitCode: ExitCode.INVALID_API_KEY, errorCode: "INVALID_API_KEY", retryable: false };
+  }
+
+  // Rate limiting
+  if (/rate.?limit|too many requests|insufficient credits/i.test(msg)) {
+    return { exitCode: ExitCode.RATE_LIMITED, errorCode: "RATE_LIMITED", retryable: true };
+  }
+
+  // Not found
+  if (/not found/i.test(msg)) {
+    return { exitCode: ExitCode.NOT_FOUND, errorCode: "NOT_FOUND", retryable: false };
+  }
+
+  // Invalid address / pubkey — @solana/kit throws on bad base58
+  if (/invalid.*(address|pubkey|base58)|PublicKey/i.test(msg)) {
+    return { exitCode: ExitCode.INVALID_ADDRESS, errorCode: "INVALID_ADDRESS", retryable: false };
+  }
+
+  // Bad input: SyntaxError (e.g. BigInt("abc") in block.ts) or bad params
+  if (error instanceof SyntaxError || /invalid.*param|bad request/i.test(msg)) {
+    return { exitCode: ExitCode.INVALID_INPUT, errorCode: "INVALID_INPUT", retryable: false };
+  }
+
+  // Network / connection errors — Node.js / undici error codes
+  if (/ECONNREFUSED|ETIMEDOUT|ENOTFOUND|ECONNRESET|fetch failed/i.test(msg)) {
+    return { exitCode: ExitCode.NETWORK_ERROR, errorCode: "NETWORK_ERROR", retryable: true };
+  }
+
+  // Server errors surfaced in RPC message body
+  if (/internal server|server error/i.test(msg)) {
+    return { exitCode: ExitCode.SERVER_ERROR, errorCode: "SERVER_ERROR", retryable: true };
+  }
+
+  return { exitCode: ExitCode.SDK_ERROR, errorCode: "SDK_ERROR", retryable: false };
+}
+
+function classifyByStatus(status: number): ErrorClassification {
+  if (status === 401 || status === 403) {
+    return { exitCode: ExitCode.INVALID_API_KEY, errorCode: "INVALID_API_KEY", retryable: false };
+  }
+  if (status === 404) {
+    return { exitCode: ExitCode.NOT_FOUND, errorCode: "NOT_FOUND", retryable: false };
+  }
+  if (status === 400) {
+    return { exitCode: ExitCode.INVALID_INPUT, errorCode: "INVALID_INPUT", retryable: false };
+  }
+  if (status === 429) {
+    return { exitCode: ExitCode.RATE_LIMITED, errorCode: "RATE_LIMITED", retryable: true };
+  }
+  if (status >= 500) {
+    return { exitCode: ExitCode.SERVER_ERROR, errorCode: "SERVER_ERROR", retryable: true };
+  }
+  return { exitCode: ExitCode.SDK_ERROR, errorCode: "SDK_ERROR", retryable: false };
 }
 
 export function jsonReplacer(_key: string, value: unknown): unknown {
@@ -79,7 +211,8 @@ export function exitWithError(
   const exitCode = getExitCode(errorCode);
 
   if (json) {
-    outputJson({ error: errorCode, message, ...details });
+    const retryable = RETRYABLE_CODES.has(exitCode);
+    outputJson({ error: errorCode, message, retryable, ...details });
   }
 
   process.exit(exitCode);

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -1,4 +1,5 @@
 // Output utilities for JSON mode
+import chalk from "chalk";
 
 export interface OutputOptions {
   json?: boolean;
@@ -153,7 +154,7 @@ export function classifyError(error: unknown): ErrorClassification {
   }
 
   // Invalid address / pubkey — @solana/kit throws on bad base58
-  if (/invalid.*(address|pubkey|base58)|PublicKey/i.test(msg)) {
+  if (/invalid.*(address|pubkey|base58|public.?key)/i.test(msg)) {
     return { exitCode: ExitCode.INVALID_ADDRESS, errorCode: "INVALID_ADDRESS", retryable: false };
   }
 
@@ -173,6 +174,32 @@ export function classifyError(error: unknown): ErrorClassification {
   }
 
   return { exitCode: ExitCode.SDK_ERROR, errorCode: "SDK_ERROR", retryable: false };
+}
+
+/**
+ * Shared error handler for command catch blocks.
+ *
+ * Classifies the error, emits JSON or spinner output, and exits.
+ * All commands except ws.ts should use this in their catch block:
+ *
+ *   } catch (error) {
+ *     handleCommandError(error, options, spinner);
+ *   }
+ */
+export function handleCommandError(
+  error: unknown,
+  options: { json?: boolean },
+  spinner?: { fail(text: string): void } | null,
+): never {
+  const { exitCode, errorCode, retryable } = classifyError(error);
+  const message = error instanceof Error ? error.message : String(error);
+  if (options.json) {
+    outputJson({ error: errorCode, message, retryable });
+  } else {
+    const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
+    spinner?.fail(`${message}${hint}`);
+  }
+  process.exit(exitCode);
 }
 
 function classifyByStatus(status: number): ErrorClassification {


### PR DESCRIPTION
Currently, every error in every catch block in 13 command files exited with code 51 and produced no output in `--json` mode, leaving agents with zero signal to act on. This PR classifies all errors into 9 distinct exit codes with a `retryable` flag, and `--json` mode always emits a structured payload:
```shell
{
  "error": "RATE_LIMITED",
  "message": "RPC error (getAsset): too many requests",
  "retryable": true
}
```

