### PR TITLE
feat(mcp): Add Credit Cost Annotations

### DIFF
--- a/helius-mcp/src/tools/accounts.ts
+++ b/helius-mcp/src/tools/accounts.ts
@@ -214,7 +214,7 @@ export function registerAccountTools(server: McpServer) {
   // Get Program Accounts (V2 with pagination) — uses SDK RpcCaller (no bigint)
   server.tool(
     'getProgramAccounts',
-    'Get all accounts owned by a specific program. Returns account addresses, balances, and data sizes. Use dataSize to filter by account data length (e.g. 165 for token accounts). Useful for finding all accounts created by a program like a DEX, lending protocol, or custom program.',
+    'Get all accounts owned by a specific program. Returns account addresses, balances, and data sizes. Use dataSize to filter by account data length (e.g. 165 for token accounts). Useful for finding all accounts created by a program like a DEX, lending protocol, or custom program. Credit cost: 10 credits/call.',
     {
       programId: z.string().describe('Program ID (base58 encoded) — the owner program of the accounts to find'),
       limit: z.number().optional().default(20).describe('Maximum accounts to return (default 20, max 100)'),

--- a/helius-mcp/src/tools/accounts.ts
+++ b/helius-mcp/src/tools/accounts.ts
@@ -39,7 +39,7 @@ export function registerAccountTools(server: McpServer) {
   // Get Account Info (single or batch) — uses SDK standard Solana RPC (Kit, bigint)
   server.tool(
     'getAccountInfo',
-    'Get detailed Solana account information for one or more accounts. For a single account: returns owner program, lamport balance, data size, executable status, and rent epoch. For batch: pass up to 100 addresses in "addresses" for fast bulk lookups. Use jsonParsed encoding (default) on token mint addresses to see Token-2022 extensions, authorities, and supply data. Use this to inspect any on-chain account.',
+    'Get detailed Solana account information for one or more accounts. For a single account: returns owner program, lamport balance, data size, executable status, and rent epoch. For batch: pass up to 100 addresses in "addresses" for fast bulk lookups. Use jsonParsed encoding (default) on token mint addresses to see Token-2022 extensions, authorities, and supply data. Use this to inspect any on-chain account. Credit cost: 1 credit (standard RPC).',
     {
       address: z.string().optional().describe('Single account address (base58 encoded). Use this OR addresses, not both.'),
       addresses: z.array(z.string()).optional().describe('Array of account addresses for batch lookup (up to 100). Use this OR address, not both.'),
@@ -133,7 +133,7 @@ export function registerAccountTools(server: McpServer) {
   // Get Token Accounts
   server.tool(
     'getTokenAccounts',
-    'Query token accounts with advanced filters. Can filter by mint address, owner address, or both. Returns token account addresses and balances.',
+    'Query token accounts with advanced filters. Can filter by mint address, owner address, or both. Returns token account addresses and balances. Credit cost: 10 credits/call (DAS API).',
     {
       owner: z.string().optional().describe('Filter by owner wallet address'),
       mint: z.string().optional().describe('Filter by token mint address'),

--- a/helius-mcp/src/tools/assets.ts
+++ b/helius-mcp/src/tools/assets.ts
@@ -9,7 +9,7 @@ export function registerAssetTools(server: McpServer) {
   // Get Assets by Owner (NFTs and tokens via DAS)
   server.tool(
     'getAssetsByOwner',
-    'Get all NFTs and digital assets owned by a Solana wallet using the DAS (Digital Asset Standard) API. Returns asset names, types (NFT, cNFT, Fungible, etc.), and mint addresses. Supports both regular NFTs and compressed NFTs (cNFTs). Use this to see what NFTs/collectibles a wallet owns. For fungible token balances, use getTokenBalances instead.',
+    'Get all NFTs and digital assets owned by a Solana wallet using the DAS (Digital Asset Standard) API. Returns asset names, types (NFT, cNFT, Fungible, etc.), and mint addresses. Supports both regular NFTs and compressed NFTs (cNFTs). Use this to see what NFTs/collectibles a wallet owns. For fungible token balances, use getTokenBalances instead. DAS API (10 credits/call).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       limit: z.number().optional().default(20).describe('Number of assets to return (default 20). Increase for wallets with many NFTs.'),
@@ -87,7 +87,7 @@ export function registerAssetTools(server: McpServer) {
   // Get Asset (single or batch)
   server.tool(
     'getAsset',
-    'Get detailed information about one or more NFTs/tokens by mint address. For a single asset: returns name, symbol, description, image, owner, creators, authorities, supply, decimals, royalties, mutability. For batch: pass an array of up to 1000 mint addresses in "ids" for fast bulk lookups. Use this to find who created/deployed a token, verify token details, or get full NFT metadata.',
+    'Get detailed information about one or more NFTs/tokens by mint address. For a single asset: returns name, symbol, description, image, owner, creators, authorities, supply, decimals, royalties, mutability. For batch: pass an array of up to 1000 mint addresses in "ids" for fast bulk lookups. Use this to find who created/deployed a token, verify token details, or get full NFT metadata. DAS API (10 credits/call).',
     {
       id: z.string().optional().describe('Single asset mint address (base58 encoded). Use this OR ids, not both.'),
       ids: z.array(z.string()).optional().describe('Array of asset mint addresses for batch lookup (up to 1000). Use this OR id, not both.')
@@ -269,7 +269,7 @@ export function registerAssetTools(server: McpServer) {
   // Search Assets — unified search with smart routing for creator/authority/general queries
   server.tool(
     'searchAssets',
-    'Advanced search for digital assets (NFTs, tokens) with multiple filters. Search by owner, creator, authority, name, compression status, burnt status, or frozen status. Also replaces getAssetsByCreator and getAssetsByAuthority — pass creatorAddress (with optional onlyVerified) to find assets by creator, or authorityAddress to find assets controlled by an authority.',
+    'Advanced search for digital assets (NFTs, tokens) with multiple filters. Search by owner, creator, authority, name, compression status, burnt status, or frozen status. Also replaces getAssetsByCreator and getAssetsByAuthority — pass creatorAddress (with optional onlyVerified) to find assets by creator, or authorityAddress to find assets controlled by an authority. DAS API (10 credits/call).',
     {
       ownerAddress: z.string().optional().describe('Filter by owner wallet address'),
       creatorAddress: z.string().optional().describe('Filter by creator address'),
@@ -406,7 +406,7 @@ export function registerAssetTools(server: McpServer) {
   // Get Assets by Group (Collection)
   server.tool(
     'getAssetsByGroup',
-    'Get all NFTs in a collection by group key/value. The groupKey is usually "collection" and groupValue is the collection mint address. Use this to browse all NFTs in a specific collection.',
+    'Get all NFTs in a collection by group key/value. The groupKey is usually "collection" and groupValue is the collection mint address. Use this to browse all NFTs in a specific collection. DAS API (10 credits/call).',
     {
       groupKey: z.string().describe('Group key - usually "collection"'),
       groupValue: z.string().describe('Group value - usually the collection mint address'),

--- a/helius-mcp/src/tools/balance.ts
+++ b/helius-mcp/src/tools/balance.ts
@@ -32,7 +32,7 @@ export function registerBalanceTools(server: McpServer) {
   // Get Token Balances
   server.tool(
     'getTokenBalances',
-    'Get all SPL token balances for a Solana wallet with full token info: names, symbols, properly formatted amounts with decimals, and USD prices (when available). Includes fungible tokens like USDC, BONK, JUP, etc. Does NOT include NFTs — use getAssetsByOwner for NFTs. For native SOL balance, use getBalance instead. Automatically paginates to fetch all tokens using parallel requests for speed.',
+    'Get all SPL token balances for a Solana wallet with full token info: names, symbols, properly formatted amounts with decimals, and USD prices (when available). Includes fungible tokens like USDC, BONK, JUP, etc. Does NOT include NFTs — use getAssetsByOwner for NFTs. For native SOL balance, use getBalance instead. Automatically paginates to fetch all tokens using parallel requests for speed. Uses DAS API (10 credits per page, ~10 items/page). A wallet with 50 tokens costs ~50 credits; 100+ tokens may cost 100+ credits. For a flat-rate portfolio view with USD values sorted by total value and optional NFTs, use getWalletBalances instead (100 credits flat, includes SOL).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)')
     },

--- a/helius-mcp/src/tools/balance.ts
+++ b/helius-mcp/src/tools/balance.ts
@@ -9,7 +9,7 @@ export function registerBalanceTools(server: McpServer) {
   // Get SOL Balance
   server.tool(
     'getBalance',
-    'Get native SOL balance for a Solana wallet address. Returns balance in both SOL and lamports (1 SOL = 1 billion lamports). Use this for checking how much SOL a wallet has. For token balances, use getTokenBalances instead.',
+    'Get native SOL balance for a Solana wallet address. Returns balance in both SOL and lamports (1 SOL = 1 billion lamports). Use this for checking how much SOL a wallet has. For token balances, use getTokenBalances instead. Credit cost: 1 credit (standard RPC).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded, e.g. Gh4tdJhLP1s55xGfghHHvPNPPrNtaDjc6dzZJ374DGHJ)')
     },

--- a/helius-mcp/src/tools/blocks.ts
+++ b/helius-mcp/src/tools/blocks.ts
@@ -8,7 +8,7 @@ import { mcpText, validateEnum, handleToolError } from '../utils/errors.js';
 export function registerBlockTools(server: McpServer) {
   server.tool(
     'getBlock',
-    'Get detailed information about a specific Solana block by slot number. Returns block time, blockhash, parent slot, transaction count, and reward summary. Use transactionDetails to control how much transaction data is included: "none" for just block metadata, "signatures" for a list of transaction signatures, or "full" for complete transaction data.',
+    'Get detailed information about a specific Solana block by slot number. Returns block time, blockhash, parent slot, transaction count, and reward summary. Use transactionDetails to control how much transaction data is included: "none" for just block metadata, "signatures" for a list of transaction signatures, or "full" for complete transaction data. Credit cost: 10 credits/call (historical data).',
     {
       slot: z.number().describe('Slot number of the block to fetch'),
       transactionDetails: z.string().optional().default('signatures').describe('"none" = block metadata only, "signatures" = list of tx signatures (default), "full" = complete transaction data')

--- a/helius-mcp/src/tools/das-extras.ts
+++ b/helius-mcp/src/tools/das-extras.ts
@@ -8,7 +8,7 @@ import { noApiKeyResponse } from './shared.js';
 export function registerDasExtraTools(server: McpServer) {
   server.tool(
     'getAssetProof',
-    'Get Merkle proof for a compressed NFT. Required for transferring or burning cNFTs.',
+    'Get Merkle proof for a compressed NFT. Required for transferring or burning cNFTs. DAS API (10 credits/call).',
     {
       id: z.string().describe('Compressed NFT mint address')
     },
@@ -30,7 +30,7 @@ export function registerDasExtraTools(server: McpServer) {
 
   server.tool(
     'getAssetProofBatch',
-    'Get Merkle proofs for multiple compressed NFTs in one request (up to 1000).',
+    'Get Merkle proofs for multiple compressed NFTs in one request (up to 1000). DAS API (10 credits/call).',
     {
       ids: z.array(z.string()).describe('Array of cNFT mint addresses (up to 1000)')
     },
@@ -55,7 +55,7 @@ export function registerDasExtraTools(server: McpServer) {
 
   server.tool(
     'getSignaturesForAsset',
-    'Get transaction history for a compressed NFT.',
+    'Get transaction history for a compressed NFT. DAS API (10 credits/call).',
     {
       id: z.string().describe('Compressed NFT mint address'),
       page: z.number().optional().default(1),
@@ -88,7 +88,7 @@ export function registerDasExtraTools(server: McpServer) {
 
   server.tool(
     'getNftEditions',
-    'Get all edition NFTs for a master NFT.',
+    'Get all edition NFTs for a master NFT. DAS API (10 credits/call).',
     {
       mint: z.string().describe('Master NFT mint address'),
       page: z.number().optional().default(1),

--- a/helius-mcp/src/tools/enhanced-websockets.ts
+++ b/helius-mcp/src/tools/enhanced-websockets.ts
@@ -7,7 +7,7 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
 
   server.tool(
     'transactionSubscribe',
-    'Get Enhanced WebSocket config for real-time Solana transaction streaming. Filter by accounts, vote/failed txns, or signatures. Up to 50,000 addresses per filter. Business+ plans only. Returns connection config and code example.',
+    'Get Enhanced WebSocket config for real-time Solana transaction streaming. Filter by accounts, vote/failed txns, or signatures. Up to 50,000 addresses per filter. Business+ plans only. Returns connection config and code example. Data streaming cost: 3 credits per 0.1 MB received.',
     {
       vote: z.boolean().optional().describe('Include vote transactions'),
       failed: z.boolean().optional().describe('Include failed transactions'),
@@ -124,7 +124,7 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
 
   server.tool(
     'accountSubscribe',
-    'Get Enhanced WebSocket config for real-time Solana account monitoring. Track balance changes and data updates. Business+ plans only. Returns connection config and code example.',
+    'Get Enhanced WebSocket config for real-time Solana account monitoring. Track balance changes and data updates. Business+ plans only. Returns connection config and code example. Data streaming cost: 3 credits per 0.1 MB received.',
     {
       account: z.string().describe('Account public key (base58)'),
       encoding: z.string().optional().default('base58'),

--- a/helius-mcp/src/tools/fees.ts
+++ b/helius-mcp/src/tools/fees.ts
@@ -8,7 +8,7 @@ export function registerFeeTools(server: McpServer) {
   // Get Priority Fee Estimate
   server.tool(
     'getPriorityFeeEstimate',
-    'Get optimal priority fee estimates for Solana transactions. Returns recommended fees in microlamports for different priority levels (Min, Low, Medium, High, VeryHigh, UnsafeMax). Essential for ensuring transaction confirmation during network congestion.',
+    'Get optimal priority fee estimates for Solana transactions. Returns recommended fees in microlamports for different priority levels (Min, Low, Medium, High, VeryHigh, UnsafeMax). Essential for ensuring transaction confirmation during network congestion. Credit cost: 1 credit (Priority Fee API).',
     {
       accountKeys: z.array(z.string()).optional().describe('Account addresses involved in transaction for more accurate estimates'),
       priorityLevel: z.string().optional().describe('Desired priority level'),

--- a/helius-mcp/src/tools/network.ts
+++ b/helius-mcp/src/tools/network.ts
@@ -7,7 +7,7 @@ import { mcpText, handleToolError } from '../utils/errors.js';
 export function registerNetworkTools(server: McpServer) {
   server.tool(
     'getNetworkStatus',
-    'Get current Solana network status including epoch info (current epoch, slot, progress), total SOL supply, cluster version, and current block height. No parameters needed — gives a quick overview of blockchain health and state.',
+    'Get current Solana network status including epoch info (current epoch, slot, progress), total SOL supply, cluster version, and current block height. No parameters needed — gives a quick overview of blockchain health and state. Credit cost: 3 credits (3 standard RPC calls).',
     {},
     async () => {
       if (!hasApiKey()) return noApiKeyResponse();

--- a/helius-mcp/src/tools/tokens.ts
+++ b/helius-mcp/src/tools/tokens.ts
@@ -8,7 +8,7 @@ import { mcpText, handleToolError, addressError } from '../utils/errors.js';
 export function registerTokenTools(server: McpServer) {
   server.tool(
     'getTokenHolders',
-    'Get the top 20 holders of a specific SPL token by mint address. Returns holder wallet addresses and their token balances (raw amounts). Useful for checking token distribution, finding whale wallets, or verifying token decentralization.',
+    'Get the top 20 holders of a specific SPL token by mint address. Returns holder wallet addresses and their token balances (raw amounts). Useful for checking token distribution, finding whale wallets, or verifying token decentralization. Credit cost: ~20 credits/call (10 for token accounts + 10 for token metadata via DAS API).',
     {
       mint: z.string().describe('Token mint address (base58 encoded)')
     },

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -261,7 +261,7 @@ export function registerTransactionTools(server: McpServer) {
   // Parse Transactions (Enhanced API)
   server.tool(
     'parseTransactions',
-    'Parse one or more Solana transactions into human-readable format. Returns transaction type (SWAP, TRANSFER, NFT_SALE, etc.), source program (Jupiter, Raydium, Magic Eden, etc.), SOL and token transfers with token names and proper decimal formatting, fees (in both SOL and lamports), timestamp, program IDs involved, and a plain-English description. Use showRaw=true to see all program IDs, instruction accounts, instruction data bytes, inner instructions, and auto-decoded ComputeBudget instructions (CU limit, priority fee, heap frame).',
+    'Parse one or more Solana transactions into human-readable format. Returns transaction type (SWAP, TRANSFER, NFT_SALE, etc.), source program (Jupiter, Raydium, Magic Eden, etc.), SOL and token transfers with token names and proper decimal formatting, fees (in both SOL and lamports), timestamp, program IDs involved, and a plain-English description. Use showRaw=true to see all program IDs, instruction accounts, instruction data bytes, inner instructions, and auto-decoded ComputeBudget instructions (CU limit, priority fee, heap frame). Credit cost: 100 credits/call (Enhanced Transactions API). To fetch and parse wallet transaction history, use getTransactionHistory instead.',
     {
       signatures: z.array(z.string()).describe('Array of transaction signatures (base58 encoded). Can be 1 or more.'),
       showRaw: z.boolean().optional().default(false).describe('Include raw instruction data: program IDs, accounts, inner instructions. Useful for debugging or tracing fund flows.')
@@ -494,7 +494,7 @@ export function registerTransactionTools(server: McpServer) {
   // Get Transaction History (unified: parsed, signatures, or raw mode)
   server.tool(
     'getTransactionHistory',
-    'Get transaction history for a Solana wallet. Supports three modes: "parsed" (default) returns human-readable decoded data with types, descriptions, actions, and fees. "signatures" returns a lightweight list of transaction signatures with slot/time/status. "raw" returns full raw data with advanced Helius filters (time/slot ranges, status, token accounts). All modes support sortOrder="asc" for finding wallet funding sources — no pagination needed. By default only successful transactions are shown; set status="any" or status="failed" to include failed ones.',
+    'Get transaction history for a Solana wallet. Supports three modes: "parsed" (default) returns human-readable decoded data with types, descriptions, actions, and fees. "signatures" returns a lightweight list of transaction signatures with slot/time/status. "raw" returns full raw data with advanced Helius filters (time/slot ranges, status, token accounts). All modes support sortOrder="asc" for finding wallet funding sources — no pagination needed. By default only successful transactions are shown; set status="any" or status="failed" to include failed ones. Credit cost varies by mode: "parsed" ~110 credits/call (signatures fetch + Enhanced API enrichment); "signatures" and "raw" ~10 credits/call.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       mode: z.string().optional().default('parsed').describe('"parsed" = decoded human-readable history (default), "signatures" = lightweight signature list, "raw" = full data with advanced Helius filters'),

--- a/helius-mcp/src/tools/wallet.ts
+++ b/helius-mcp/src/tools/wallet.ts
@@ -10,7 +10,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Identity ───
   server.tool(
     'getWalletIdentity',
-    'Identify known wallets (exchanges, protocols, institutions). Returns name, type, category, tags. Use this to check if a wallet belongs to a known entity like Binance, Coinbase, Jupiter, etc.',
+    'Identify known wallets (exchanges, protocols, institutions). Returns name, type, category, tags. Use this to check if a wallet belongs to a known entity like Binance, Coinbase, Jupiter, etc. Credit cost: 100 credits/call (Wallet API).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)')
     },
@@ -40,7 +40,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Batch Wallet Identity ───
   server.tool(
     'batchWalletIdentity',
-    'Look up identities for up to 100 Solana addresses in one request. Returns known names, types, and categories for recognized wallets (exchanges, protocols, institutions).',
+    'Look up identities for up to 100 Solana addresses in one request. Returns known names, types, and categories for recognized wallets (exchanges, protocols, institutions). Credit cost: 100 credits/call (Wallet API).',
     {
       addresses: z.array(z.string()).describe('Array of Solana wallet addresses (max 100)')
     },
@@ -86,7 +86,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Balances ───
   server.tool(
     'getWalletBalances',
-    'Get all token and NFT balances with USD values, sorted by value. Includes SOL, SPL, Token-2022, and optionally NFTs. Different from getTokenBalances — this uses the Wallet API with USD pricing built-in.',
+    'Get all token and NFT balances with USD values, sorted by value. Includes SOL, SPL, Token-2022, and optionally NFTs. Different from getTokenBalances — this uses the Wallet API with USD pricing built-in. Credit cost: 100 credits/call. For fungible tokens only (no SOL or NFTs needed) on small wallets, getTokenBalances is cheaper (10 credits/page via DAS).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       page: z.number().optional().default(1).describe('Page number (starts at 1)'),
@@ -158,7 +158,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet History ───
   server.tool(
     'getWalletHistory',
-    'Get transaction history with balance changes per transaction. Parsed, human-readable format from the Wallet API. Different from getTransactionHistory — returns balance changes per tx with simpler pagination.',
+    'Get transaction history with balance changes per transaction. Parsed, human-readable format from the Wallet API. Different from getTransactionHistory — returns balance changes per tx with simpler pagination. Credit cost: 100 credits/call. Requires Developer+ plan (not available on Free plan).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       limit: z.number().optional().default(100).describe('Number of results (max 100)'),
@@ -231,7 +231,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Transfers ───
   server.tool(
     'getWalletTransfers',
-    'Get all token transfers with sender/recipient info, direction (in/out), and amounts. Focused on transfers only (not all tx types). Shows counterparty addresses and transfer direction.',
+    'Get all token transfers with sender/recipient info, direction (in/out), and amounts. Focused on transfers only (not all tx types). Shows counterparty addresses and transfer direction. Credit cost: 100 credits/call (Wallet API).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       limit: z.number().optional().default(50).describe('Number of results (max 100)'),
@@ -287,7 +287,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Funded By ───
   server.tool(
     'getWalletFundedBy',
-    'Find the original funding source of a wallet (first SOL transfer). Shows funder identity if known (e.g. which exchange funded this wallet). Useful for wallet provenance and tracing.',
+    'Find the original funding source of a wallet (first SOL transfer). Shows funder identity if known (e.g. which exchange funded this wallet). Useful for wallet provenance and tracing. Credit cost: 100 credits/call (Wallet API).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)')
     },

--- a/helius-mcp/src/tools/webhooks.ts
+++ b/helius-mcp/src/tools/webhooks.ts
@@ -9,7 +9,7 @@ import { mcpText, mcpError, validateEnum, handleToolError, http404Error, http400
 export function registerWebhookTools(server: McpServer) {
   server.tool(
     'getAllWebhooks',
-    'List all active webhooks for your Helius account. Shows webhook IDs, URLs, and monitored addresses.',
+    'List all active webhooks for your Helius account. Shows webhook IDs, URLs, and monitored addresses. Credit cost: 100 credits/call (management operation).',
     {},
     async () => {
       if (!hasApiKey()) return noApiKeyResponse();
@@ -41,7 +41,7 @@ export function registerWebhookTools(server: McpServer) {
 
   server.tool(
     'getWebhookByID',
-    'Get detailed information about a specific webhook by its ID.',
+    'Get detailed information about a specific webhook by its ID. Credit cost: 100 credits/call (management operation).',
     {
       webhookID: z.string().describe('Webhook ID')
     },

--- a/helius-mcp/src/tools/webhooks.ts
+++ b/helius-mcp/src/tools/webhooks.ts
@@ -81,7 +81,7 @@ export function registerWebhookTools(server: McpServer) {
 
   server.tool(
     'createWebhook',
-    'Create a webhook to monitor Solana events in real-time with powerful filtering. Use this to track NFT sales, token swaps, staking, and 150+ transaction types. Webhooks send HTTP POST with parsed transaction data to your URL. Enhanced webhooks include human-readable descriptions.',
+    'Create a webhook to monitor Solana events in real-time with powerful filtering. Use this to track NFT sales, token swaps, staking, and 150+ transaction types. Webhooks send HTTP POST with parsed transaction data to your URL. Enhanced webhooks include human-readable descriptions. Credit cost: 100 credits to create (management operation). Each event delivered subsequently costs 1 credit.',
     {
       webhookURL: z.string().describe('Your webhook URL endpoint'),
       webhookType: z.string().describe('Webhook type - use "enhanced" for parsed transaction data with descriptions'),
@@ -118,7 +118,7 @@ export function registerWebhookTools(server: McpServer) {
 
   server.tool(
     'updateWebhook',
-    'Update webhook configuration including URL, monitored addresses, or transaction type filters. Use this to add/remove addresses or change which transaction types trigger notifications.',
+    'Update webhook configuration including URL, monitored addresses, or transaction type filters. Use this to add/remove addresses or change which transaction types trigger notifications. Credit cost: 100 credits/call (management operation).',
     {
       webhookID: z.string().describe('Webhook ID to update'),
       webhookURL: z.string().optional().describe('New webhook URL'),
@@ -168,7 +168,7 @@ export function registerWebhookTools(server: McpServer) {
 
   server.tool(
     'deleteWebhook',
-    'Delete a webhook by its ID. This permanently removes the webhook and stops all notifications.',
+    'Delete a webhook by its ID. This permanently removes the webhook and stops all notifications. Credit cost: 100 credits/call (management operation).',
     {
       webhookID: z.string().describe('Webhook ID to delete')
     },


### PR DESCRIPTION
Currently, agents using the MCP have no visibility into the cost of each tool before calling it. This PR annotates 20 tool descriptions across the 9 different tool files with their credit costs