### PR TITLE
chore(GitHub): Add `.claude` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage/
 # IDE
 .idea/
 .vscode/
+.claude/
 *.swp
 *.swo
 


### PR DESCRIPTION
Very quick PR to add `.claude/` to our `.gitignore` since it contains local Claude configs that are user- and machine-specific 