### PR TITLE
fix(cli): Improve Signup UX

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -163,6 +163,7 @@ const configCmd = program
 configCmd
   .command("show")
   .description("Show current configuration")
+  .option("--reveal", "Show full API key (not truncated)")
   .option("--json", "Output in JSON format")
   .action(function(this: any) { configShowCommand(opts(this)); });
 

--- a/helius-cli/src/commands/config-cmd.ts
+++ b/helius-cli/src/commands/config-cmd.ts
@@ -3,11 +3,19 @@ import { formatEnumLabel } from "../lib/formatters.js";
 import { load, setApiKey, setNetwork, setProjectId, clearConfig } from "../lib/config.js";
 import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
 
-export function configShowCommand(options: OutputOptions = {}): void {
+interface ConfigShowOptions extends OutputOptions {
+  reveal?: boolean;
+}
+
+export function configShowCommand(options: ConfigShowOptions = {}): void {
   const config = load();
+  const displayKey = config.apiKey
+    ? (options.reveal ? config.apiKey : config.apiKey.slice(0, 8) + "...")
+    : null;
+
   if (options.json) {
     outputJson({
-      apiKey: config.apiKey ? config.apiKey.slice(0, 8) + "..." : null,
+      apiKey: displayKey,
       network: config.network || "mainnet",
       projectId: config.projectId || null,
       loggedIn: !!config.jwt,
@@ -16,10 +24,13 @@ export function configShowCommand(options: OutputOptions = {}): void {
   }
 
   console.log(chalk.bold("\nHelius CLI Configuration:\n"));
-  console.log(`  ${chalk.gray("API Key:")}     ${config.apiKey ? chalk.cyan(config.apiKey.slice(0, 8) + "...") : chalk.yellow("not set")}`);
+  console.log(`  ${chalk.gray("API Key:")}     ${displayKey ? chalk.cyan(displayKey) : chalk.yellow("not set")}`);
   console.log(`  ${chalk.gray("Network:")}     ${chalk.cyan(formatEnumLabel(config.network || "mainnet"))}`);
   console.log(`  ${chalk.gray("Project ID:")}  ${config.projectId ? chalk.cyan(config.projectId) : chalk.yellow("not set")}`);
   console.log(`  ${chalk.gray("Logged in:")}   ${config.jwt ? chalk.green("yes") : chalk.yellow("no")}`);
+  if (config.apiKey && !options.reveal) {
+    console.log(chalk.gray("\n  Use --reveal to show the full API key."));
+  }
   console.log();
 }
 

--- a/helius-cli/src/commands/keygen.ts
+++ b/helius-cli/src/commands/keygen.ts
@@ -48,7 +48,7 @@ export async function keygenCommand(options: KeygenOptions): Promise<void> {
   console.log(`Address: ${chalk.cyan(address)}`);
   console.log("");
   console.log(chalk.yellow("To use this wallet, fund it with:"));
-  console.log(`  • ${chalk.cyan("~0.01 SOL")} for transaction fees`);
+  console.log(`  • ${chalk.cyan("~0.001 SOL")} for transaction fees`);
   console.log(`  • USDC for your chosen plan:`);
   console.log(`      ${"basic".padEnd(15)}${chalk.cyan("$1")} (one-time)`);
   for (const [key, plan] of Object.entries(PLAN_CATALOG)) {

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -102,7 +102,13 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
         }
       }
       if (result.apiKey) {
-        console.log(chalk.green(`\nAPI key saved to ${SHARED_CONFIG_PATH}`));
+        console.log(`\nAPI Key: ${chalk.cyan(result.apiKey)}`);
+        console.log(chalk.green(`Saved to ${SHARED_CONFIG_PATH}`));
+      }
+      if (result.endpoints) {
+        console.log(chalk.bold("\nRPC Endpoints:"));
+        console.log(`  Mainnet: ${chalk.blue(result.endpoints.mainnet)}`);
+        console.log(`  Devnet:  ${chalk.blue(result.endpoints.devnet)}`);
       }
       console.log(chalk.gray("\nNo payment required. Use `helius projects` to view details."));
       return;

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -1,11 +1,12 @@
 import chalk from "chalk";
 import ora from "ora";
-import { loadKeypairFromFile } from "../lib/wallet.js";
+import { loadKeypairFromFile, getAddress } from "../lib/wallet.js";
 import { agenticSignup, listProjects } from "../lib/api.js";
 import { setJwt, setApiKey, setSharedApiKey, setProjectId, SHARED_CONFIG_PATH } from "../lib/config.js";
-import { keypairExists } from "./keygen.js";
+import { keypairExists, keygenCommand } from "./keygen.js";
 import { formatEnumLabel } from "../lib/formatters.js";
 import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { checkSolBalance, checkUsdcBalance } from "helius-sdk/auth/checkBalances";
 
 interface SignupOptions extends OutputOptions {
   keypair: string;
@@ -32,14 +33,15 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
   const spinner = options.json ? null : ora();
 
   try {
-    // Check keypair exists
+    // Auto-generate keypair if none exists
     if (!keypairExists(options.keypair)) {
       if (options.json) {
+        // In JSON mode, don't do interactive keygen — just error
         exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, true);
       }
-      console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
-      console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));
-      process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+      console.log(chalk.yellow("No keypair found. Generating one automatically...\n"));
+      await keygenCommand({ output: options.keypair });
+      console.log();
     }
 
     // Load keypair

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -6,7 +6,8 @@ import { setJwt, setApiKey, setSharedApiKey, setProjectId, SHARED_CONFIG_PATH } 
 import { keypairExists, keygenCommand } from "./keygen.js";
 import { formatEnumLabel } from "../lib/formatters.js";
 import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
-import { checkSolBalance, checkUsdcBalance } from "helius-sdk/auth/checkBalances";
+import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
+import { PLAN_CATALOG } from "../lib/checkout.js";
 
 interface SignupOptions extends OutputOptions {
   keypair: string;
@@ -57,13 +58,28 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     const solAmount = Number(solBalance) / 1_000_000_000;
     const usdcAmount = Number(usdcBalance) / 1_000_000;
     const solOk = solBalance >= 1_000_000n;    // ~0.001 SOL
-    const usdcOk = usdcBalance >= 1_000_000n;  // 1 USDC minimum
+
+    // Compute required USDC based on selected plan
+    const planKey = options.plan?.toLowerCase();
+    const catalogEntry = planKey ? PLAN_CATALOG[planKey] : null;
+    let requiredUsdcRaw: bigint;
+    let requiredUsdcLabel: string;
+    if (catalogEntry) {
+      const period = options.period?.toLowerCase();
+      const priceInCents = period === "yearly" ? catalogEntry.yearlyPrice : catalogEntry.monthlyPrice;
+      requiredUsdcRaw = BigInt(priceInCents) * 10_000n; // cents → USDC raw (6 decimals)
+      requiredUsdcLabel = `${priceInCents / 100} USDC`;
+    } else {
+      requiredUsdcRaw = 1_000_000n; // $1 basic plan
+      requiredUsdcLabel = "1 USDC";
+    }
+    const usdcOk = usdcBalance >= requiredUsdcRaw;
 
     if (!solOk || !usdcOk) {
       spinner?.fail("Insufficient balance");
       const missing: string[] = [];
       if (!solOk) missing.push(`~0.001 SOL (have ${solAmount.toFixed(6)})`);
-      if (!usdcOk) missing.push(`1 USDC (have ${usdcAmount.toFixed(2)})`);
+      if (!usdcOk) missing.push(`${requiredUsdcLabel} (have ${usdcAmount.toFixed(2)})`);
 
       if (options.json) {
         exitWithError("INSUFFICIENT_FUNDS", `Need more funds: ${missing.join(", ")}`, undefined, true);

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -47,7 +47,35 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     // Load keypair
     spinner?.start("Loading keypair...");
     const keypair = await loadKeypairFromFile(options.keypair);
-    spinner?.succeed("Wallet loaded");
+    const walletAddress = await getAddress(keypair);
+    spinner?.succeed(`Wallet loaded: ${walletAddress}`);
+
+    // Check balance before attempting payment
+    spinner?.start("Checking wallet balance...");
+    const solBalance = await checkSolBalance(walletAddress);
+    const usdcBalance = await checkUsdcBalance(walletAddress);
+    const solAmount = Number(solBalance) / 1_000_000_000;
+    const usdcAmount = Number(usdcBalance) / 1_000_000;
+    const solOk = solBalance >= 1_000_000n;    // ~0.001 SOL
+    const usdcOk = usdcBalance >= 1_000_000n;  // 1 USDC minimum
+
+    if (!solOk || !usdcOk) {
+      spinner?.fail("Insufficient balance");
+      const missing: string[] = [];
+      if (!solOk) missing.push(`~0.001 SOL (have ${solAmount.toFixed(6)})`);
+      if (!usdcOk) missing.push(`1 USDC (have ${usdcAmount.toFixed(2)})`);
+
+      if (options.json) {
+        exitWithError("INSUFFICIENT_FUNDS", `Need more funds: ${missing.join(", ")}`, undefined, true);
+      }
+      console.error(chalk.red(`\nInsufficient funds. Send the following to ${chalk.cyan(walletAddress)}:`));
+      for (const m of missing) {
+        console.error(`  • ${m}`);
+      }
+      console.error(chalk.gray("\nThen run `helius signup` again."));
+      process.exit(!solOk ? ExitCode.INSUFFICIENT_SOL : ExitCode.INSUFFICIENT_USDC);
+    }
+    spinner?.succeed(`Balance OK: ${solAmount.toFixed(4)} SOL, ${usdcAmount.toFixed(2)} USDC`);
 
     // Run agenticSignup (handles all plan paths)
     const planLabel = options.plan || "basic";


### PR DESCRIPTION
This PR implements several quick wins to improve the signup UX. Namely,
- Fix SOL amount inconsistency (~0.01 -> ~0.001) in keygen
- `helius signup` now auto-generates a keypair if none exists instead of erroring
- `helius signup` checks SOL/USDC balance before attempting payment, shows exactly what's missing
- `helius signup` now shows full API key + RPC endpoints for existing accounts (previously just said "saved")
- `helius config show --reveal` shows the full API key instead of truncating