### PR TITLE
feat(mcp + cli): Add Solana Knowledge Tools

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -48,6 +48,7 @@ import {
 } from "../src/commands/zk.js";
 import { sendBroadcastCommand, sendRawCommand, sendSenderCommand, sendPollCommand, sendComputeUnitsCommand } from "../src/commands/send.js";
 import { wsAccountCommand, wsLogsCommand, wsSlotCommand, wsSignatureCommand, wsProgramCommand } from "../src/commands/ws.js";
+import { simdListCommand, simdGetCommand } from "../src/commands/simd.js";
 import { VERSION } from "../src/constants.js";
 
 const program = new Command();
@@ -768,5 +769,23 @@ wsCmd
   .description("Stream program account change notifications")
   .option("--json", "Output in JSON format")
   .action(function(this: any, programId: string) { wsProgramCommand(programId, opts(this)); });
+
+// ── SIMD (Solana Improvement Documents) ──
+
+const simdCmd = program
+  .command("simd")
+  .description("Browse Solana Improvement Documents (SIMDs)");
+
+simdCmd
+  .command("list")
+  .description("List all SIMD proposals")
+  .option("--json", "Output in JSON format")
+  .action(function(this: any) { simdListCommand(opts(this)); });
+
+simdCmd
+  .command("get <number>")
+  .description("Read a specific SIMD proposal by number")
+  .option("--json", "Output in JSON format")
+  .action(function(this: any, number: string) { simdGetCommand(number, opts(this)); });
 
 program.parse();

--- a/helius-cli/src/commands/simd.ts
+++ b/helius-cli/src/commands/simd.ts
@@ -1,0 +1,195 @@
+import chalk from "chalk";
+import ora from "ora";
+import { CLI_USER_AGENT } from "../http.js";
+import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+
+// ---------------------------------------------------------------------------
+// GitHub constants
+// ---------------------------------------------------------------------------
+
+const SIMD_REPO = "solana-foundation/solana-improvement-documents";
+const SIMD_API_URL = `https://api.github.com/repos/${SIMD_REPO}/contents/proposals`;
+const SIMD_RAW_BASE = `https://raw.githubusercontent.com/${SIMD_REPO}/main/proposals`;
+
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "User-Agent": CLI_USER_AGENT,
+    Accept: "application/vnd.github.v3+json",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers["Authorization"] = `token ${process.env.GITHUB_TOKEN}`;
+  }
+  return headers;
+}
+
+// ---------------------------------------------------------------------------
+// SIMD index
+// ---------------------------------------------------------------------------
+
+interface SimdEntry {
+  number: string;
+  slug: string;
+  filename: string;
+}
+
+async function fetchSimdIndex(): Promise<SimdEntry[]> {
+  const response = await fetch(SIMD_API_URL, { headers: githubHeaders() });
+  if (!response.ok) {
+    throw new Error(`GitHub API returned HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  const files = (await response.json()) as Array<{ name: string }>;
+  return files
+    .filter((f) => f.name.endsWith(".md"))
+    .map((f) => {
+      const match = f.name.match(/^(\d+)-(.+)\.md$/);
+      return match ? { number: match[1], slug: match[2], filename: f.name } : null;
+    })
+    .filter((x): x is SimdEntry => x !== null);
+}
+
+// ---------------------------------------------------------------------------
+// Extract title/status from SIMD front-matter
+// ---------------------------------------------------------------------------
+
+function extractFrontMatter(markdown: string): { title: string; status: string; authors: string } {
+  const fmMatch = markdown.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!fmMatch) return { title: "", status: "", authors: "" };
+  const fm = fmMatch[1];
+
+  const titleMatch = fm.match(/^title:\s*(.+)/m);
+  const statusMatch = fm.match(/^status:\s*(.+)/m);
+  const authorsMatch = fm.match(/^authors:\s*(.+)/m);
+
+  return {
+    title: titleMatch?.[1]?.replace(/^["']|["']$/g, "").trim() ?? "",
+    status: statusMatch?.[1]?.trim() ?? "",
+    authors: authorsMatch?.[1]?.trim() ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+interface SimdListOptions extends OutputOptions {}
+
+export async function simdListCommand(options: SimdListOptions = {}): Promise<void> {
+  const spinner = options.json ? null : ora();
+  try {
+    spinner?.start("Fetching SIMD index from GitHub...");
+    const index = await fetchSimdIndex();
+    spinner?.stop();
+
+    if (options.json) {
+      outputJson(index.map((e) => ({ number: e.number, slug: e.slug })));
+      return;
+    }
+
+    console.log(chalk.bold(`\nSolana Improvement Documents (${chalk.cyan(String(index.length))} proposals)\n`));
+
+    for (const entry of index) {
+      const title = entry.slug.replace(/-/g, " ");
+      console.log(`  ${chalk.cyan(`SIMD-${entry.number}`)}  ${title}`);
+    }
+
+    console.log(chalk.gray(`\nUse ${chalk.white("helius simd get <number>")} to read a specific proposal.\n`));
+  } catch (error) {
+    handleCommandError(error, options, spinner);
+  }
+}
+
+interface SimdGetOptions extends OutputOptions {}
+
+export async function simdGetCommand(number: string, options: SimdGetOptions = {}): Promise<void> {
+  const spinner = options.json ? null : ora();
+  try {
+    const paddedNumber = number.replace(/^0+/, "").padStart(4, "0");
+
+    spinner?.start(`Fetching SIMD-${paddedNumber}...`);
+
+    // Fetch index to find the filename
+    const index = await fetchSimdIndex();
+    const entry = index.find((e) => e.number === paddedNumber);
+
+    if (!entry) {
+      spinner?.stop();
+      // Show nearby proposals as hints
+      const nearby = index
+        .filter((e) => {
+          const n = parseInt(e.number, 10);
+          const target = parseInt(paddedNumber, 10);
+          return Math.abs(n - target) <= 10;
+        })
+        .map((e) => `  SIMD-${e.number}: ${e.slug.replace(/-/g, " ")}`)
+        .join("\n");
+
+      if (options.json) {
+        outputJson({ error: "NOT_FOUND", message: `SIMD-${paddedNumber} not found` });
+        process.exit(1);
+      }
+
+      console.log(chalk.yellow(`\nSIMD-${paddedNumber} not found.`));
+      if (nearby) {
+        console.log(chalk.gray("\nNearby proposals:"));
+        console.log(nearby);
+      }
+      console.log();
+      return;
+    }
+
+    // Fetch the raw markdown
+    const url = `${SIMD_RAW_BASE}/${entry.filename}`;
+    const response = await fetch(url, {
+      headers: { "User-Agent": CLI_USER_AGENT },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch SIMD: HTTP ${response.status}`);
+    }
+
+    const content = await response.text();
+    spinner?.stop();
+
+    if (options.json) {
+      const fm = extractFrontMatter(content);
+      outputJson({
+        number: entry.number,
+        slug: entry.slug,
+        title: fm.title,
+        status: fm.status,
+        authors: fm.authors,
+        content,
+        source: `https://github.com/${SIMD_REPO}/blob/main/proposals/${entry.filename}`,
+      });
+      return;
+    }
+
+    // Pretty-print the proposal
+    const fm = extractFrontMatter(content);
+    const title = fm.title || entry.slug.replace(/-/g, " ");
+
+    console.log(chalk.bold(`\n${"─".repeat(60)}`));
+    console.log(chalk.bold.cyan(`  SIMD-${entry.number}: ${title}`));
+    if (fm.status) {
+      const statusColor = fm.status.toLowerCase() === "accepted" ? chalk.green
+        : fm.status.toLowerCase() === "draft" ? chalk.yellow
+        : fm.status.toLowerCase() === "rejected" ? chalk.red
+        : chalk.gray;
+      console.log(`  ${chalk.gray("Status:")} ${statusColor(fm.status)}`);
+    }
+    if (fm.authors) {
+      console.log(`  ${chalk.gray("Authors:")} ${fm.authors}`);
+    }
+    console.log(chalk.bold(`${"─".repeat(60)}\n`));
+
+    // Print the body (strip front-matter)
+    const body = content.replace(/^---\s*\n[\s\S]*?\n---\s*\n/, "").trim();
+    console.log(body);
+
+    console.log(chalk.gray(`\n${"─".repeat(60)}`));
+    console.log(chalk.gray(`Source: https://github.com/${SIMD_REPO}/blob/main/proposals/${entry.filename}\n`));
+  } catch (error) {
+    handleCommandError(error, options, spinner);
+  }
+}

--- a/helius-cli/src/commands/simd.ts
+++ b/helius-cli/src/commands/simd.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
 import { CLI_USER_AGENT } from "../http.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
 
 // ---------------------------------------------------------------------------
 // GitHub constants
@@ -35,6 +35,9 @@ interface SimdEntry {
 async function fetchSimdIndex(): Promise<SimdEntry[]> {
   const response = await fetch(SIMD_API_URL, { headers: githubHeaders() });
   if (!response.ok) {
+    if (response.status === 403 || response.status === 429) {
+      throw new Error(`GitHub API rate limit exceeded (HTTP ${response.status}). Set GITHUB_TOKEN env var to increase the limit.`);
+    }
     throw new Error(`GitHub API returned HTTP ${response.status}: ${response.statusText}`);
   }
 
@@ -104,6 +107,14 @@ interface SimdGetOptions extends OutputOptions {}
 export async function simdGetCommand(number: string, options: SimdGetOptions = {}): Promise<void> {
   const spinner = options.json ? null : ora();
   try {
+    if (!/^\d+$/.test(number)) {
+      if (options.json) {
+        exitWithError("INVALID_INPUT", `Invalid SIMD number: "${number}". Must be numeric.`, undefined, true);
+      }
+      console.error(chalk.red(`Invalid SIMD number: "${number}". Must be a numeric value (e.g. 96, 0228).`));
+      process.exit(ExitCode.INVALID_INPUT);
+    }
+
     const paddedNumber = number.replace(/^0+/, "").padStart(4, "0");
 
     spinner?.start(`Fetching SIMD-${paddedNumber}...`);
@@ -125,8 +136,7 @@ export async function simdGetCommand(number: string, options: SimdGetOptions = {
         .join("\n");
 
       if (options.json) {
-        outputJson({ error: "NOT_FOUND", message: `SIMD-${paddedNumber} not found` });
-        process.exit(1);
+        exitWithError("NOT_FOUND", `SIMD-${paddedNumber} not found`, undefined, true);
       }
 
       console.log(chalk.yellow(`\nSIMD-${paddedNumber} not found.`));

--- a/helius-mcp/src/tools/index.ts
+++ b/helius-mcp/src/tools/index.ts
@@ -18,6 +18,7 @@ import { registerPlanTools } from './plans.js';
 import { registerDocsTools } from './docs.js';
 import { registerGuideTools } from './guides.js';
 import { registerRecommendTools } from './recommend.js';
+import { registerSolanaKnowledgeTools } from './solana-knowledge.js';
 
 export function registerTools(server: McpServer) {
   registerAuthTools(server);
@@ -39,4 +40,5 @@ export function registerTools(server: McpServer) {
   registerDocsTools(server);
   registerGuideTools(server);
   registerRecommendTools(server);
+  registerSolanaKnowledgeTools(server);
 }

--- a/helius-mcp/src/tools/solana-knowledge.ts
+++ b/helius-mcp/src/tools/solana-knowledge.ts
@@ -462,43 +462,62 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
         const queryLower = query.toLowerCase();
         const queryWords = queryLower.split(/\s+/).filter((w) => w.length > 2);
         const lines = content.split('\n');
-        const relevantSections: string[] = [];
-        let inRelevantSection = false;
-        let sectionDepth = 0;
-        let sectionLines: string[] = [];
 
-        for (const line of lines) {
-          const headerMatch = line.match(/^(#{1,4})\s+(.+)/);
-
-          if (headerMatch) {
-            const depth = headerMatch[1].length;
-            const title = headerMatch[2].toLowerCase();
-
-            // Flush previous relevant section
-            if (inRelevantSection && depth <= sectionDepth) {
-              relevantSections.push(sectionLines.join('\n'));
-              sectionLines = [];
-              inRelevantSection = false;
-            }
-
-            if (
-              title.includes(queryLower) ||
-              (queryWords.length > 0 && queryWords.every((word) => title.includes(word)))
-            ) {
-              inRelevantSection = true;
-              sectionDepth = depth;
-              sectionLines.push(line);
-            } else if (inRelevantSection) {
-              sectionLines.push(line);
-            }
-          } else if (inRelevantSection) {
-            sectionLines.push(line);
-          }
+        // Phase 1: Locate all headers and compute section boundaries.
+        // Each section spans from its header to the next header of same or
+        // lesser depth (i.e. it includes all nested sub-sections).
+        const headers: Array<{ depth: number; title: string; lineIdx: number }> = [];
+        for (let i = 0; i < lines.length; i++) {
+          const m = lines[i].match(/^(#{1,4})\s+(.+)/);
+          if (m) headers.push({ depth: m[1].length, title: m[2], lineIdx: i });
         }
 
-        // Flush last section
-        if (inRelevantSection && sectionLines.length > 0) {
-          relevantSections.push(sectionLines.join('\n'));
+        const sectionRanges: Array<{ depth: number; title: string; start: number; end: number }> = [];
+        for (let i = 0; i < headers.length; i++) {
+          let endLineIdx = lines.length;
+          for (let j = i + 1; j < headers.length; j++) {
+            if (headers[j].depth <= headers[i].depth) {
+              endLineIdx = headers[j].lineIdx;
+              break;
+            }
+          }
+          sectionRanges.push({
+            depth: headers[i].depth,
+            title: headers[i].title,
+            start: headers[i].lineIdx,
+            end: endLineIdx,
+          });
+        }
+
+        // Phase 2: Match sections against query (header OR body), dedup
+        // overlapping ranges so a parent section subsumes its children.
+        // Body-only matches are restricted to depth >= 2 so the root-level
+        // section (which spans the entire document) doesn't swallow everything.
+        const matched: Array<{ start: number; end: number }> = [];
+        const relevantSections: string[] = [];
+
+        for (const sec of sectionRanges) {
+          const titleLower = sec.title.toLowerCase();
+          const sectionText = lines.slice(sec.start, sec.end).join('\n');
+          const textLower = sectionText.toLowerCase();
+
+          const headerHit =
+            titleLower.includes(queryLower) ||
+            (queryWords.length > 0 && queryWords.every((w) => titleLower.includes(w)));
+
+          const bodyHit =
+            sec.depth >= 2 &&
+            (textLower.includes(queryLower) ||
+              (queryWords.length > 0 && queryWords.every((w) => textLower.includes(w))));
+
+          if (headerHit || bodyHit) {
+            // Skip if already covered by a wider matched section
+            const alreadyCovered = matched.some((r) => r.start <= sec.start && r.end >= sec.end);
+            if (!alreadyCovered) {
+              matched.push({ start: sec.start, end: sec.end });
+              relevantSections.push(sectionText);
+            }
+          }
         }
 
         if (relevantSections.length === 0) {

--- a/helius-mcp/src/tools/solana-knowledge.ts
+++ b/helius-mcp/src/tools/solana-knowledge.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { MCP_USER_AGENT } from '../http.js';
+import { mcpText, mcpError, handleToolError } from '../utils/errors.js';
 
 // ---------------------------------------------------------------------------
 // Cache
@@ -62,6 +63,9 @@ async function getSimdIndex(): Promise<NonNullable<typeof simdIndex>> {
   });
 
   if (!response.ok) {
+    if (response.status === 403 || response.status === 429) {
+      throw new Error(`GitHub API rate limit exceeded (HTTP ${response.status}). Set GITHUB_TOKEN env var to increase the limit.`);
+    }
     throw new Error(`Failed to fetch SIMD index: HTTP ${response.status}`);
   }
 
@@ -304,14 +308,9 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
             .map((e) => `  SIMD-${e.number}: ${e.slug}`)
             .join('\n');
 
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `SIMD-${paddedNumber} not found.\n\n${nearby ? `Nearby proposals:\n${nearby}` : `Total proposals available: ${index.length}`}`,
-              },
-            ],
-          };
+          return mcpText(
+            `SIMD-${paddedNumber} not found.\n\n${nearby ? `Nearby proposals:\n${nearby}` : `Total proposals available: ${index.length}`}`
+          );
         }
 
         const url = `${SIMD_RAW_BASE}/${entry.filename}`;
@@ -326,13 +325,9 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
           `Source: https://github.com/${SIMD_REPO}/blob/main/proposals/${entry.filename}`,
         ].join('\n');
 
-        return { content: [{ type: 'text' as const, text: result }] };
+        return mcpText(result);
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        return {
-          content: [{ type: 'text' as const, text: `Error fetching SIMD: ${errorMsg}` }],
-          isError: true,
-        };
+        return handleToolError(error, 'Error fetching SIMD');
       }
     }
   );
@@ -348,7 +343,7 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
       try {
         const index = await getSimdIndex();
         if (index.length === 0) {
-          throw new Error('Could not fetch SIMD index');
+          return mcpText('No SIMD proposals found in the repository.');
         }
 
         const lines = [
@@ -361,13 +356,9 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
           ...index.map((e) => `| ${e.number} | ${e.slug.replace(/-/g, ' ')} |`),
         ];
 
-        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+        return mcpText(lines.join('\n'));
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        return {
-          content: [{ type: 'text' as const, text: `Error listing SIMDs: ${errorMsg}` }],
-          isError: true,
-        };
+        return handleToolError(error, 'Error listing SIMDs');
       }
     }
   );
@@ -397,6 +388,10 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
     },
     async ({ path, repo, branch }) => {
       try {
+        if (path.includes('..')) {
+          return mcpText('Invalid path: must not contain ".." segments.');
+        }
+
         const repoMap: Record<string, { fullName: string; defaultBranch: string }> = {
           agave: { fullName: 'anza-xyz/agave', defaultBranch: 'master' },
           firedancer: { fullName: 'firedancer-io/firedancer', defaultBranch: 'main' },
@@ -426,18 +421,19 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
           `Source: https://github.com/${repoFullName}/blob/${resolvedBranch}/${path}`,
         ].join('\n');
 
-        return { content: [{ type: 'text' as const, text: result }] };
+        return mcpText(result);
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Error reading source file: ${errorMsg}\n\nTips:\n- Check the path is correct (e.g., "svm/src/lib.rs")\n- Browse https://github.com/anza-xyz/agave to find the right path\n- The default branch is "master"`,
-            },
-          ],
-          isError: true,
-        };
+        const repoInfo = { agave: 'anza-xyz/agave', firedancer: 'firedancer-io/firedancer' }[repo] ?? 'anza-xyz/agave';
+        const defaultBr = repo === 'firedancer' ? 'main' : 'master';
+        return handleToolError(error, 'Error reading source file', [
+          {
+            match: (msg) => msg.includes('404'),
+            respond: () =>
+              mcpText(
+                `**File not found:** \`${path}\`\n\nTips:\n- Check the path is correct\n- Browse https://github.com/${repoInfo} to find the right path\n- The default branch for ${repo} is "${defaultBr}"`
+              ),
+          },
+        ]);
       }
     }
   );
@@ -534,17 +530,12 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
               '---',
               'Source: https://solana.com/docs',
             ].join('\n');
-            return { content: [{ type: 'text' as const, text: result }] };
+            return mcpText(result);
           }
 
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `No matches for "${query}" in Solana docs. Try:\n- Broader terms (e.g., "accounts" instead of "account info")\n- Official API method names (e.g., "getAccountInfo")\n- Core concepts: accounts, transactions, programs, PDAs, CPI, fees, tokens`,
-              },
-            ],
-          };
+          return mcpText(
+            `No matches for "${query}" in Solana docs. Try:\n- Broader terms (e.g., "accounts" instead of "account info")\n- Official API method names (e.g., "getAccountInfo")\n- Core concepts: accounts, transactions, programs, PDAs, CPI, fees, tokens`
+          );
         }
 
         const MAX_CHARS = 40_000;
@@ -562,13 +553,9 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
           'Source: https://solana.com/docs',
         ].join('\n');
 
-        return { content: [{ type: 'text' as const, text: result }] };
+        return mcpText(result);
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        return {
-          content: [{ type: 'text' as const, text: `Error searching Solana docs: ${errorMsg}` }],
-          isError: true,
-        };
+        return handleToolError(error, 'Error searching Solana docs');
       }
     }
   );
@@ -634,19 +621,14 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
             lines.push('');
           }
 
-          return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+          return mcpText(lines.join('\n'));
         }
 
         // Fetch a specific post
         if (!slug) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: 'Please provide a slug. Use `fetchHeliusBlog` with action "list" to see available posts.',
-              },
-            ],
-          };
+          return mcpText(
+            'Please provide a slug. Use `fetchHeliusBlog` with action "list" to see available posts.'
+          );
         }
 
         const url = `https://www.helius.dev/blog/${slug}`;
@@ -662,18 +644,12 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
 
         const result = [`# ${title}`, '', displayContent, '', '---', `Source: ${url}`].join('\n');
 
-        return { content: [{ type: 'text' as const, text: result }] };
+        return mcpText(result);
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Error fetching blog: ${errorMsg}\n\nUse \`fetchHeliusBlog\` with action "list" to see available posts.`,
-            },
-          ],
-          isError: true,
-        };
+        return handleToolError(
+          error,
+          'Error fetching blog. Use `fetchHeliusBlog` with action "list" to see available posts'
+        );
       }
     }
   );

--- a/helius-mcp/src/tools/solana-knowledge.ts
+++ b/helius-mcp/src/tools/solana-knowledge.ts
@@ -1,0 +1,661 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { MCP_USER_AGENT } from '../http.js';
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+const cache: Map<string, { content: string; fetchedAt: number }> = new Map();
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+async function cachedFetch(url: string, headers?: Record<string, string>): Promise<string> {
+  const cached = cache.get(url);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.content;
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': MCP_USER_AGENT,
+      ...headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  const content = await response.text();
+  cache.set(url, { content, fetchedAt: Date.now() });
+  return content;
+}
+
+// ---------------------------------------------------------------------------
+// SIMD helpers
+// ---------------------------------------------------------------------------
+
+const SIMD_REPO = 'solana-foundation/solana-improvement-documents';
+const SIMD_API_URL = `https://api.github.com/repos/${SIMD_REPO}/contents/proposals`;
+const SIMD_RAW_BASE = `https://raw.githubusercontent.com/${SIMD_REPO}/main/proposals`;
+
+let simdIndex: Array<{ number: string; slug: string; filename: string }> | null = null;
+let simdIndexFetchedAt = 0;
+
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3+json',
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
+  }
+  return headers;
+}
+
+async function getSimdIndex(): Promise<NonNullable<typeof simdIndex>> {
+  if (simdIndex && Date.now() - simdIndexFetchedAt < CACHE_TTL_MS) {
+    return simdIndex;
+  }
+
+  const response = await fetch(SIMD_API_URL, {
+    headers: { 'User-Agent': MCP_USER_AGENT, ...githubHeaders() },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch SIMD index: HTTP ${response.status}`);
+  }
+
+  const files = (await response.json()) as Array<{ name: string }>;
+  simdIndex = files
+    .filter((f) => f.name.endsWith('.md'))
+    .map((f) => {
+      const match = f.name.match(/^(\d+)-(.+)\.md$/);
+      return match ? { number: match[1], slug: match[2], filename: f.name } : null;
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+
+  simdIndexFetchedAt = Date.now();
+  return simdIndex;
+}
+
+// ---------------------------------------------------------------------------
+// HTML-to-text helper (lightweight, no dependencies)
+// ---------------------------------------------------------------------------
+
+function htmlToText(html: string): string {
+  // Extract main article content (skip nav, header, footer)
+  let content = html;
+  // Use greedy match to capture everything between first opening and last closing tag
+  const articleMatch = html.match(/<article[^>]*>([\s\S]*)<\/article>/i);
+  if (articleMatch) {
+    content = articleMatch[1];
+  } else {
+    const mainMatch = html.match(/<main[^>]*>([\s\S]*)<\/main>/i);
+    if (mainMatch) {
+      content = mainMatch[1];
+    }
+  }
+
+  return (
+    content
+      // Strip non-content elements before conversion
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+      .replace(/<noscript[^>]*>[\s\S]*?<\/noscript>/gi, '')
+      .replace(/<svg[^>]*>[\s\S]*?<\/svg>/gi, '')
+      .replace(/<nav[^>]*>[\s\S]*?<\/nav>/gi, '')
+      .replace(/<footer[^>]*>[\s\S]*?<\/footer>/gi, '')
+      .replace(/<header[^>]*>[\s\S]*?<\/header>/gi, '')
+      // Convert headers
+      .replace(/<h1[^>]*>([\s\S]*?)<\/h1>/gi, '\n# $1\n')
+      .replace(/<h2[^>]*>([\s\S]*?)<\/h2>/gi, '\n## $1\n')
+      .replace(/<h3[^>]*>([\s\S]*?)<\/h3>/gi, '\n### $1\n')
+      .replace(/<h4[^>]*>([\s\S]*?)<\/h4>/gi, '\n#### $1\n')
+      // Convert code blocks
+      .replace(/<pre[^>]*><code[^>]*>([\s\S]*?)<\/code><\/pre>/gi, '\n```\n$1\n```\n')
+      .replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, '`$1`')
+      // Convert lists
+      .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, '- $1\n')
+      // Convert paragraphs and line breaks
+      .replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, '\n$1\n')
+      .replace(/<br\s*\/?>/gi, '\n')
+      // Convert links
+      .replace(/<a[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, '[$2]($1)')
+      // Convert bold/italic
+      .replace(/<(?:strong|b)[^>]*>([\s\S]*?)<\/(?:strong|b)>/gi, '**$1**')
+      .replace(/<(?:em|i)[^>]*>([\s\S]*?)<\/(?:em|i)>/gi, '*$1*')
+      // Strip remaining HTML tags
+      .replace(/<[^>]+>/g, '')
+      // Decode common HTML entities
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&nbsp;/g, ' ')
+      // Decode remaining numeric HTML entities (&#123; and &#xAB;)
+      .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+      .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+      // Clean up whitespace
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Blog index — curated list of the most technical Helius blog posts
+// ---------------------------------------------------------------------------
+
+const BLOG_INDEX: Record<string, { title: string; category: string }> = {
+  // SVM & Runtime
+  'solana-virtual-machine': { title: 'What is the Solana Virtual Machine (SVM)?', category: 'runtime' },
+  'solana-pda': { title: 'What are Solana PDAs? Explanation & Examples', category: 'runtime' },
+  'the-solana-programming-model-an-introduction-to-developing-on-solana': {
+    title: 'The Solana Programming Model',
+    category: 'runtime',
+  },
+  'solana-slots-blocks-and-epochs': { title: 'Understanding Slots, Blocks, and Epochs', category: 'runtime' },
+  'solana-arithmetic': { title: 'Solana Arithmetic: Best Practices for Financial Apps', category: 'runtime' },
+  'solana-commitment-levels': { title: 'What are Solana Commitment Levels?', category: 'runtime' },
+  'solana-vs-sui-transaction-lifecycle': {
+    title: 'At The Edge Of Determinism: Transaction Lifecycle',
+    category: 'runtime',
+  },
+  'asynchronous-program-execution': { title: 'Asynchronous Program Execution', category: 'runtime' },
+
+  // Consensus & Network
+  'consensus-on-solana': { title: 'Consensus on Solana', category: 'consensus' },
+  'alpenglow': { title: "Alpenglow: Solana's Great Consensus Rewrite", category: 'consensus' },
+  'turbine-block-propagation-on-solana': { title: 'Turbine: Block Propagation on Solana', category: 'consensus' },
+  'solana-gulf-stream': { title: "Solana's Gulf Stream", category: 'consensus' },
+  'all-you-need-to-know-about-solana-and-quic': {
+    title: 'QUIC Protocol and Spam Mitigation',
+    category: 'consensus',
+  },
+  'proof-of-history-proof-of-stake-proof-of-work-explained': {
+    title: 'Proof of History, Proof of Stake, Proof of Work',
+    category: 'consensus',
+  },
+  'cryptographic-tools-101-hash-functions-and-merkle-trees-explained': {
+    title: 'Cryptographic Tools 101',
+    category: 'consensus',
+  },
+  'what-is-firedancer': { title: 'What is Firedancer?', category: 'consensus' },
+
+  // Transactions & Fees
+  'priority-fees-understanding-solanas-transaction-fee-mechanics': {
+    title: 'Priority Fees: Understanding Fee Mechanics',
+    category: 'transactions',
+  },
+  'solana-fees-in-theory-and-practice': { title: 'Solana Fees in Theory and Practice', category: 'transactions' },
+  'solana-local-fee-markets': { title: 'The Truth about Solana Local Fee Markets', category: 'transactions' },
+  'how-to-land-transactions-on-solana': { title: 'How to Land Transactions on Solana', category: 'transactions' },
+  'how-to-deal-with-blockhash-errors-on-solana': {
+    title: 'How to Deal with Blockhash Errors',
+    category: 'transactions',
+  },
+  'solana-congestion-how-to-best-send-solana-transactions': {
+    title: 'Solana Congestion: How to Best Send Transactions',
+    category: 'transactions',
+  },
+  'solana-mev-an-introduction': { title: 'Solana MEV: An Introduction', category: 'transactions' },
+  'stake-weighted-quality-of-service-everything-you-need-to-know': {
+    title: 'Stake-Weighted Quality of Service',
+    category: 'transactions',
+  },
+  'solana-transactions': { title: 'Solana Transactions: Durable Nonces', category: 'transactions' },
+  'block-assembly-marketplace-bam': { title: 'Block Assembly Marketplace (BAM)', category: 'transactions' },
+
+  // Validators & Economics
+  'solana-validator-economics-a-primer': { title: 'Solana Validator Economics: A Primer', category: 'validators' },
+  'solana-nodes-a-primer-on-solana-rpcs-validators-and-rpc-providers': {
+    title: 'Solana Nodes: A Primer',
+    category: 'validators',
+  },
+  'solana-issuance-inflation-schedule': { title: "Is Solana's Inflation Too High?", category: 'validators' },
+  'bringing-slashing-to-solana': { title: 'Bringing Slashing to Solana', category: 'validators' },
+  'solana-decentralization-facts-and-figures': {
+    title: "Measuring Solana's Decentralization",
+    category: 'validators',
+  },
+  'solana-governance--a-comprehensive-analysis': {
+    title: 'Solana Governance: A Comprehensive Analysis',
+    category: 'validators',
+  },
+  'simd-228': { title: 'SIMD-228: A Critical Analysis', category: 'validators' },
+
+  // Data & Infrastructure
+  'solana-geyser-plugins-streaming-data-at-the-speed-of-light': {
+    title: 'Solana Geyser Plugins',
+    category: 'data',
+  },
+  'all-you-need-to-know-about-compression-on-solana': {
+    title: 'All You Need to Know About Compression',
+    category: 'data',
+  },
+  'zk-compression-keynote-breakpoint-2024': { title: 'ZK Compression Keynote', category: 'data' },
+  'how-solana-rpcs-work': { title: 'How Solana RPCs Work', category: 'data' },
+  'solana-rpc': { title: 'All You Need to Know About Solana RPCs', category: 'data' },
+  'solana-data-streaming': { title: 'Listening to Onchain Events on Solana', category: 'data' },
+  'doublezero-a-faster-internet': { title: 'DoubleZero: A Faster Internet', category: 'data' },
+  'solana-post-quantum-cryptography': { title: 'Post-Quantum Cryptography on Solana', category: 'data' },
+  'solana-shreds': { title: 'Winning the Millisecond Game: Shreds and LaserStream', category: 'data' },
+  'zero-slot': { title: 'Achieving Zero-Slot Execution with Sender and LaserStream', category: 'data' },
+
+  // Security
+  'a-hitchhikers-guide-to-solana-program-security': {
+    title: "A Hitchhiker's Guide to Solana Program Security",
+    category: 'security',
+  },
+  'solana-hacks': { title: 'Solana Hacks, Bugs, and Exploits: A Complete History', category: 'security' },
+  'solana-outages-complete-history': { title: 'A Complete History of Solana Outages', category: 'security' },
+
+  // Development Frameworks & Guides
+  'optimizing-solana-programs': { title: 'Optimizing Solana Programs', category: 'development' },
+  'sbpf-assembly': { title: 'How to Write Solana Programs with SBPF Assembly', category: 'development' },
+  'steel': { title: 'How to Write Solana Programs with Steel', category: 'development' },
+  'pinocchio': { title: 'How to Build Solana Programs with Pinocchio', category: 'development' },
+  'gill': { title: 'How to Build Solana Apps with Gill', category: 'development' },
+  'an-introduction-to-anchor-a-beginners-guide-to-building-solana-programs': {
+    title: 'An Introduction to Anchor',
+    category: 'development',
+  },
+  'how-to-start-building-with-the-solana-web3-js-2-0-sdk': {
+    title: 'Building with Solana Web3.js 2.0',
+    category: 'development',
+  },
+
+  // DeFi & Tokens
+  'what-is-token-2022': { title: 'What are Token Extensions?', category: 'tokens' },
+  'lsts-on-solana': { title: 'Liquid Staking and LSTs on Solana', category: 'tokens' },
+  'solanas-stablecoin-landscape': { title: "Solana's Stablecoin Landscape", category: 'tokens' },
+  'solana-real-world-assets': { title: 'Real World Assets on Solana', category: 'tokens' },
+};
+
+// ---------------------------------------------------------------------------
+// Tool registration
+// ---------------------------------------------------------------------------
+
+export function registerSolanaKnowledgeTools(server: McpServer) {
+  // =========================================================================
+  // Tool 1: getSIMD — Fetch a Solana Improvement Document by number
+  // =========================================================================
+  server.tool(
+    'getSIMD',
+    'Fetch a Solana Improvement Document (SIMD) proposal by number. Returns the full proposal markdown including motivation, design, specification, and security considerations. SIMDs are the formal governance mechanism for Solana protocol changes.',
+    {
+      number: z
+        .string()
+        .describe('SIMD number, e.g. "228" or "0096". Will be zero-padded automatically.'),
+    },
+    async ({ number }) => {
+      try {
+        const paddedNumber = number.replace(/^0+/, '').padStart(4, '0');
+        const index = await getSimdIndex();
+
+        const entry = index.find((e) => e.number === paddedNumber);
+        if (!entry) {
+          const nearby = index
+            .filter((e) => {
+              const n = parseInt(e.number, 10);
+              const target = parseInt(paddedNumber, 10);
+              return Math.abs(n - target) <= 10;
+            })
+            .map((e) => `  SIMD-${e.number}: ${e.slug}`)
+            .join('\n');
+
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `SIMD-${paddedNumber} not found.\n\n${nearby ? `Nearby proposals:\n${nearby}` : `Total proposals available: ${index.length}`}`,
+              },
+            ],
+          };
+        }
+
+        const url = `${SIMD_RAW_BASE}/${entry.filename}`;
+        const content = await cachedFetch(url);
+
+        const result = [
+          `# SIMD-${entry.number}: ${entry.slug}`,
+          '',
+          content,
+          '',
+          '---',
+          `Source: https://github.com/${SIMD_REPO}/blob/main/proposals/${entry.filename}`,
+        ].join('\n');
+
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: `Error fetching SIMD: ${errorMsg}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // =========================================================================
+  // Tool 2: listSIMDs — List available SIMD proposals
+  // =========================================================================
+  server.tool(
+    'listSIMDs',
+    'List all available Solana Improvement Document (SIMD) proposals. Returns proposal numbers and titles. Use getSIMD to fetch the full content of a specific proposal.',
+    {},
+    async () => {
+      try {
+        const index = await getSimdIndex();
+        if (index.length === 0) {
+          throw new Error('Could not fetch SIMD index');
+        }
+
+        const lines = [
+          '# Solana Improvement Documents (SIMDs)',
+          '',
+          `${index.length} proposals available. Use \`getSIMD\` with a number to read the full proposal.`,
+          '',
+          '| SIMD | Title |',
+          '|------|-------|',
+          ...index.map((e) => `| ${e.number} | ${e.slug.replace(/-/g, ' ')} |`),
+        ];
+
+        return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: `Error listing SIMDs: ${errorMsg}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // =========================================================================
+  // Tool 3: readSolanaSourceFile — Read a file from the Agave/Firedancer repo
+  // =========================================================================
+  server.tool(
+    'readSolanaSourceFile',
+    'Read a source file from the Agave (Solana validator) or Firedancer codebase on GitHub. Use this to look up how specific components are implemented (e.g., banking stage, vote program, BPF loader, SVM runtime). Provide the file path relative to the repo root.',
+    {
+      path: z
+        .string()
+        .describe(
+          'File path relative to repo root, e.g. "runtime/src/bank.rs", "programs/vote/src/vote_state/mod.rs", "svm/src/lib.rs"'
+        ),
+      repo: z
+        .enum(['agave', 'firedancer'])
+        .default('agave')
+        .describe(
+          'Which repo to read from. "agave" = anza-xyz/agave (Rust validator), "firedancer" = firedancer-io/firedancer (C validator)'
+        ),
+      branch: z
+        .string()
+        .optional()
+        .describe('Branch to read from. Defaults to "master" for agave, "main" for firedancer.'),
+    },
+    async ({ path, repo, branch }) => {
+      try {
+        const repoMap: Record<string, { fullName: string; defaultBranch: string }> = {
+          agave: { fullName: 'anza-xyz/agave', defaultBranch: 'master' },
+          firedancer: { fullName: 'firedancer-io/firedancer', defaultBranch: 'main' },
+        };
+
+        const repoInfo = repoMap[repo] ?? repoMap['agave'];
+        const repoFullName = repoInfo.fullName;
+        const resolvedBranch = branch ?? repoInfo.defaultBranch;
+        const url = `https://raw.githubusercontent.com/${repoFullName}/${resolvedBranch}/${path}`;
+        const content = await cachedFetch(url);
+
+        const MAX_CHARS = 50_000;
+        const truncated = content.length > MAX_CHARS;
+        const displayContent = truncated
+          ? content.slice(0, MAX_CHARS) +
+            `\n\n... [truncated at ${MAX_CHARS} chars, file is ${content.length} chars total]`
+          : content;
+
+        const result = [
+          `# ${repoFullName}/${path} (${resolvedBranch})`,
+          '',
+          '```',
+          displayContent,
+          '```',
+          '',
+          '---',
+          `Source: https://github.com/${repoFullName}/blob/${resolvedBranch}/${path}`,
+        ].join('\n');
+
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error reading source file: ${errorMsg}\n\nTips:\n- Check the path is correct (e.g., "svm/src/lib.rs")\n- Browse https://github.com/anza-xyz/agave to find the right path\n- The default branch is "master"`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // =========================================================================
+  // Tool 4: searchSolanaDocs — Fetch official Solana documentation
+  // =========================================================================
+  server.tool(
+    'searchSolanaDocs',
+    'Search the official Solana documentation (solana.com/docs). Covers core concepts (accounts, transactions, programs, PDAs, CPIs), RPC API reference, token standards, and development guides. Returns sections matching your query from the AI-optimized documentation.',
+    {
+      query: z
+        .string()
+        .describe(
+          'Search term or topic, e.g. "PDAs", "transaction format", "getAccountInfo", "token extensions", "cross program invocation"'
+        ),
+    },
+    async ({ query }) => {
+      try {
+        const content = await cachedFetch('https://solana.com/llms-full.txt');
+
+        const queryLower = query.toLowerCase();
+        const queryWords = queryLower.split(/\s+/).filter((w) => w.length > 2);
+        const lines = content.split('\n');
+        const relevantSections: string[] = [];
+        let inRelevantSection = false;
+        let sectionDepth = 0;
+        let sectionLines: string[] = [];
+
+        for (const line of lines) {
+          const headerMatch = line.match(/^(#{1,4})\s+(.+)/);
+
+          if (headerMatch) {
+            const depth = headerMatch[1].length;
+            const title = headerMatch[2].toLowerCase();
+
+            // Flush previous relevant section
+            if (inRelevantSection && depth <= sectionDepth) {
+              relevantSections.push(sectionLines.join('\n'));
+              sectionLines = [];
+              inRelevantSection = false;
+            }
+
+            if (
+              title.includes(queryLower) ||
+              (queryWords.length > 0 && queryWords.every((word) => title.includes(word)))
+            ) {
+              inRelevantSection = true;
+              sectionDepth = depth;
+              sectionLines.push(line);
+            } else if (inRelevantSection) {
+              sectionLines.push(line);
+            }
+          } else if (inRelevantSection) {
+            sectionLines.push(line);
+          }
+        }
+
+        // Flush last section
+        if (inRelevantSection && sectionLines.length > 0) {
+          relevantSections.push(sectionLines.join('\n'));
+        }
+
+        if (relevantSections.length === 0) {
+          // Fallback: return lines containing the query as individual matches
+          const matchingLines = lines.filter((l) => l.toLowerCase().includes(queryLower));
+          if (matchingLines.length > 0) {
+            const result = [
+              `# Solana Docs: "${query}"`,
+              '',
+              `No exact section match, but found ${matchingLines.length} lines containing "${query}":`,
+              '',
+              ...matchingLines.slice(0, 50),
+              '',
+              '---',
+              'Source: https://solana.com/docs',
+            ].join('\n');
+            return { content: [{ type: 'text' as const, text: result }] };
+          }
+
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `No matches for "${query}" in Solana docs. Try:\n- Broader terms (e.g., "accounts" instead of "account info")\n- Official API method names (e.g., "getAccountInfo")\n- Core concepts: accounts, transactions, programs, PDAs, CPI, fees, tokens`,
+              },
+            ],
+          };
+        }
+
+        const MAX_CHARS = 40_000;
+        let combined = relevantSections.join('\n\n---\n\n');
+        if (combined.length > MAX_CHARS) {
+          combined = combined.slice(0, MAX_CHARS) + '\n\n... [results truncated]';
+        }
+
+        const result = [
+          `# Solana Docs: "${query}"`,
+          '',
+          combined,
+          '',
+          '---',
+          'Source: https://solana.com/docs',
+        ].join('\n');
+
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: `Error searching Solana docs: ${errorMsg}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // =========================================================================
+  // Tool 5: fetchHeliusBlog — Fetch a Helius blog post
+  // =========================================================================
+  server.tool(
+    'fetchHeliusBlog',
+    'Fetch a technical blog post from Helius (helius.dev/blog). The Helius blog covers SVM internals, consensus, transactions, fees, MEV, validator economics, development frameworks, security, and more. Use "list" to see available posts or "fetch" to read one.',
+    {
+      action: z
+        .enum(['fetch', 'list'])
+        .describe('"fetch" to read a specific post, "list" to see available posts by category'),
+      slug: z
+        .string()
+        .optional()
+        .describe(
+          'Blog post slug (required for "fetch"), e.g. "solana-virtual-machine", "consensus-on-solana", "alpenglow"'
+        ),
+      category: z
+        .enum(['all', 'runtime', 'consensus', 'transactions', 'validators', 'data', 'security', 'development', 'tokens'])
+        .default('all')
+        .describe('Filter by category when listing posts'),
+    },
+    async ({ action, slug, category }) => {
+      try {
+        if (action === 'list') {
+          const entries = Object.entries(BLOG_INDEX);
+          const filtered =
+            category === 'all' ? entries : entries.filter(([, info]) => info.category === category);
+
+          // Group by category
+          const grouped: Record<string, Array<{ slug: string; title: string }>> = {};
+          for (const [s, info] of filtered) {
+            if (!grouped[info.category]) grouped[info.category] = [];
+            grouped[info.category].push({ slug: s, title: info.title });
+          }
+
+          const categoryLabels: Record<string, string> = {
+            runtime: 'SVM Runtime & Execution',
+            consensus: 'Consensus & Network Protocols',
+            transactions: 'Transactions, Fees & MEV',
+            validators: 'Validators & Economics',
+            data: 'Data Layer & Infrastructure',
+            security: 'Security & History',
+            development: 'Development Frameworks & Guides',
+            tokens: 'Tokens, DeFi & Standards',
+          };
+
+          const lines = [
+            '# Helius Blog — Technical Posts Index',
+            '',
+            `${filtered.length} posts available. Use \`fetchHeliusBlog\` with action "fetch" and a slug to read the full post.`,
+            '',
+          ];
+
+          for (const [cat, posts] of Object.entries(grouped)) {
+            lines.push(`## ${categoryLabels[cat] ?? cat}`);
+            for (const p of posts) {
+              lines.push(`- \`${p.slug}\` — ${p.title}`);
+            }
+            lines.push('');
+          }
+
+          return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+        }
+
+        // Fetch a specific post
+        if (!slug) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Please provide a slug. Use `fetchHeliusBlog` with action "list" to see available posts.',
+              },
+            ],
+          };
+        }
+
+        const url = `https://www.helius.dev/blog/${slug}`;
+        const html = await cachedFetch(url);
+        const text = htmlToText(html);
+
+        const MAX_CHARS = 50_000;
+        const truncated = text.length > MAX_CHARS;
+        const displayContent = truncated ? text.slice(0, MAX_CHARS) + '\n\n... [truncated]' : text;
+
+        const blogInfo = BLOG_INDEX[slug];
+        const title = blogInfo?.title ?? slug;
+
+        const result = [`# ${title}`, '', displayContent, '', '---', `Source: ${url}`].join('\n');
+
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error fetching blog: ${errorMsg}\n\nUse \`fetchHeliusBlog\` with action "list" to see available posts.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/helius-plugin/skills/build/SKILL.md
+++ b/helius-plugin/skills/build/SKILL.md
@@ -60,6 +60,7 @@ These intents overlap across multiple files. Route them correctly:
 - **"transaction history"** — Parsed, human-readable history → `references/enhanced-transactions.md`. Balance changes per tx → `references/wallet-api.md`. Trigger actions on new txs → `references/webhooks.md`.
 - **"real-time" / "streaming"** — WebSocket subscriptions (accountSubscribe, logsSubscribe, transactionSubscribe) → `references/websockets.md`. gRPC streaming (all accounts, all transactions, high-throughput indexing) → `references/laserstream.md`.
 - **"monitor wallet"** — Fire-and-forget notifications (webhook POSTs to your server) → `references/webhooks.md`. Live UI updates (persistent connection) → `references/websockets.md`. Investigate past activity → `references/wallet-api.md`.
+- **"how does X work on Solana"** — Protocol internals, SIMDs, source code → `getSIMD`, `readSolanaSourceFile`, `searchSolanaDocs`. Helius blog deep-dives → `fetchHeliusBlog`. Helius API docs → `lookupHeliusDocs`.
 
 ### Transaction Sending & Swaps
 **Read**: `references/sender.md`, `references/priority-fees.md`
@@ -162,6 +163,18 @@ For any documentation question, prefer `lookupHeliusDocs` with the relevant topi
 **MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 
 Use this when the user asks about pricing, plans, or rate limits.
+
+### Solana Knowledge & Research
+**MCP tools**: `getSIMD`, `listSIMDs`, `readSolanaSourceFile`, `searchSolanaDocs`, `fetchHeliusBlog`
+
+Use this when the user wants to:
+- Understand Solana protocol internals (consensus, runtime, transactions, fees, SVM)
+- Read or reference Solana Improvement Documents (SIMDs)
+- Look up validator source code from Agave or Firedancer
+- Research architecture, design decisions, or protocol changes
+- Get deep technical explanations from the Helius blog
+
+No API key needed — these tools fetch from public GitHub and Solana sources.
 
 ## Composing Multiple Domains
 

--- a/helius-skills/helius/SKILL.md
+++ b/helius-skills/helius/SKILL.md
@@ -61,6 +61,7 @@ These intents overlap across multiple files. Route them correctly:
 - **"transaction history"** — Parsed, human-readable history → `references/enhanced-transactions.md`. Balance changes per tx → `references/wallet-api.md`. Trigger actions on new txs → `references/webhooks.md`.
 - **"real-time" / "streaming"** — WebSocket subscriptions (accountSubscribe, logsSubscribe, transactionSubscribe) → `references/websockets.md`. gRPC streaming (all accounts, all transactions, high-throughput indexing) → `references/laserstream.md`.
 - **"monitor wallet"** — Fire-and-forget notifications (webhook POSTs to your server) → `references/webhooks.md`. Live UI updates (persistent connection) → `references/websockets.md`. Investigate past activity → `references/wallet-api.md`.
+- **"how does X work on Solana"** — Protocol internals, SIMDs, source code → `getSIMD`, `readSolanaSourceFile`, `searchSolanaDocs`. Helius blog deep-dives → `fetchHeliusBlog`. Helius API docs → `lookupHeliusDocs`.
 
 ### Transaction Sending & Swaps
 **Read**: `references/sender.md`, `references/priority-fees.md`
@@ -163,6 +164,18 @@ For any documentation question, prefer `lookupHeliusDocs` with the relevant topi
 **MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 
 Use this when the user asks about pricing, plans, or rate limits.
+
+### Solana Knowledge & Research
+**MCP tools**: `getSIMD`, `listSIMDs`, `readSolanaSourceFile`, `searchSolanaDocs`, `fetchHeliusBlog`
+
+Use this when the user wants to:
+- Understand Solana protocol internals (consensus, runtime, transactions, fees, SVM)
+- Read or reference Solana Improvement Documents (SIMDs)
+- Look up validator source code from Agave or Firedancer
+- Research architecture, design decisions, or protocol changes
+- Get deep technical explanations from the Helius blog
+
+No API key needed — these tools fetch from public GitHub and Solana sources.
 
 ### Project Planning & Architecture
 **MCP tools**: `getStarted` → `recommendStack` → `getHeliusPlanInfo`, `lookupHeliusDocs`


### PR DESCRIPTION
This PR adds Solana knowledge tools to the MCP so we can fetch SIMDs, read files from Agave & FD's GitHub repos, search the official Solana docs, and fetch some of our Helius blog posts. We also added a new `helius simd` command to the CLI to streamline fetching SIMDs