### PR TITLE
feat(mcp): reduce token usage across MCP server and SKILL.md

### DIFF
--- a/helius-mcp/src/index.ts
+++ b/helius-mcp/src/index.ts
@@ -14,56 +14,46 @@ const server = new McpServer(
     version: '0.3.0'
   },
   {
-    instructions: `These instructions provide fallback tool selection guidance. If you have more specific routing instructions from a Helius skill or system prompt, prefer those over this guide — they provide richer context including reference files and composition patterns.
+    instructions: `These instructions provide fallback tool selection guidance. If you have more specific routing instructions from a Helius skill or system prompt, prefer those.
 
-## Tool Selection Guide
+## Tool Routing
 
-### Balance / Portfolio
-- "SOL balance" → getBalance (1 credit, SOL only)
-- "token balances", "what tokens" → getTokenBalances (10 credits/page, SPL tokens with prices)
-- "portfolio", "all balances", "show my wallet", "what's in this wallet" → getWalletBalances (100 credits, full portfolio with USD values sorted by value, includes SOL + tokens + optional NFTs)
+| Intent | Tool | Credits |
+|--------|------|---------|
+| SOL balance | getBalance | 1 |
+| token balances | getTokenBalances | 10/pg |
+| full portfolio + USD | getWalletBalances | 100 |
+| parse tx by signature | parseTransactions | 100 |
+| transaction history | getTransactionHistory | ~110 |
+| balance deltas/tx | getWalletHistory | 100 |
+| sends/receives | getWalletTransfers | 100 |
+| asset by mint | getAsset | 10 |
+| wallet NFTs | getAssetsByOwner | 10 |
+| filtered asset search | searchAssets | 10 |
+| collection NFTs | getAssetsByGroup | 10 |
+| asset tx history (by mint) | getSignaturesForAsset | 10 |
+| edition prints of master NFT | getNftEditions | 10 |
+| raw account inspection | getAccountInfo | 1 |
+| token holders by mint | getTokenHolders | ~20 |
+| token account queries | getTokenAccounts | 10 |
+| program accounts / protocol state | getProgramAccounts | 10 |
+| plans/pricing | getHeliusPlanInfo | 0 |
+| plan comparison | compareHeliusPlans | 0 |
+| rate limits/credits | getRateLimitInfo | 0 |
+| API docs by topic | lookupHeliusDocs | 0 |
+| error diagnosis | troubleshootError | 0 |
+| project architecture | recommendStack | 0 |
+| wallet identity | getWalletIdentity | 100 |
+| funding source | getWalletFundedBy | 100 |
+| event notifications (any plan) | createWebhook | 100 |
+| live streaming (WS, Business+) | transactionSubscribe, accountSubscribe | — |
+| production streaming (gRPC, Pro) | laserstreamSubscribe | — |
+| Account setup | getStarted → generateKeypair → agenticSignup | — |
 
-### Transaction History
-- "show transactions", "transaction history", general history → getTransactionHistory (default choice, parsed human-readable, ~110 credits)
-- "balance changes per transaction", "+/- deltas" → getWalletHistory (100 credits, balance change deltas)
-- "who sent tokens to", "transfers", "sends/receives" → getWalletTransfers (100 credits, direction + counterparty info)
-
-### NFTs & Assets
-- Specific mint address → getAsset (by mint, 10 credits)
-- "NFTs in this wallet", "what NFTs" → getAssetsByOwner (by wallet, 10 credits)
-- Multi-filter search (creator, authority, name, compression) → searchAssets (10 credits)
-- "NFTs in this collection" → getAssetsByGroup (by collection, 10 credits)
-
-### Streaming (Real-time)
-- Enhanced WebSockets (Business+ plan) → transactionSubscribe / accountSubscribe
-- Laserstream gRPC (Professional plan) → laserstreamSubscribe
-
-### Docs & Info (10+ tools — use the right one)
-- "How much does Helius cost?" / pricing / plans → getHeliusPlanInfo (start here for ANY pricing question)
-- "Compare plans" / side-by-side → compareHeliusPlans (category-specific)
-- "Rate limits" / "credits per method" → getRateLimitInfo (live billing docs)
-- "How many credits does X cost?" → getHeliusCreditsInfo (credit cost table)
-- API docs / "how does X work?" → lookupHeliusDocs (by topic)
-- Error codes / debugging → troubleshootError (always use this first for errors)
-- Transaction sending / Jito / SWQoS → getSenderInfo
-- Webhook setup → getWebhookGuide
-- Streaming latency → getLatencyComparison
-- pump.fun tokens → getPumpFunGuide
-- Rule: For pricing/plans, start with getHeliusPlanInfo — NOT lookupHeliusDocs. For errors, use troubleshootError first.
-
-### Wallet Investigation
-- "Who is this wallet?" → getWalletIdentity (known entity lookup)
-- "Who funded this wallet?" → getWalletFundedBy (funding source)
-- Batch identity lookup → batchWalletIdentity
-
-### Project Planning / Architecture
-- User describes ANY Solana project, app, tool, or feature they want to build → recommendStack (call it immediately with their description — don't ask clarifying questions first)
-- This includes phrases like "I want to build/make/create...", "help me build...", "I need a...", or any description of a new Solana project (e.g. "tax reporting tool", "PnL tracker", "token sniper", "NFT gallery")
-- If the user hasn't set up an API key yet, recommendStack will append a setup hint — no need to call getStarted first
-- After recommendations → getHeliusPlanInfo for pricing, lookupHeliusDocs for API details
-
-### Account Setup (no API key yet)
-- generateKeypair → fund wallet → agenticSignup`
+Rules:
+- For pricing, start with getHeliusPlanInfo — NOT lookupHeliusDocs.
+- For errors, use troubleshootError first.
+- When a user describes ANY project they want to build ("I want to build/make/create...", "help me build...", "I need a..."), call recommendStack immediately with their description — do not ask clarifying questions first. After recommendations, use getHeliusPlanInfo for pricing and lookupHeliusDocs for API details.`
   }
 );
 

--- a/helius-mcp/src/tools/assets.ts
+++ b/helius-mcp/src/tools/assets.ts
@@ -9,7 +9,7 @@ export function registerAssetTools(server: McpServer) {
   // Get Assets by Owner (NFTs and tokens via DAS)
   server.tool(
     'getAssetsByOwner',
-    'BEST FOR: listing NFTs/digital assets owned by a wallet. PREFER getTokenBalances for fungible token balances. PREFER getAsset when you have a specific mint address. Get all NFTs and digital assets owned by a Solana wallet using the DAS (Digital Asset Standard) API. Returns asset names, types (NFT, cNFT, Fungible, etc.), and mint addresses. Supports both regular NFTs and compressed NFTs (cNFTs). Use this to see what NFTs/collectibles a wallet owns. For fungible token balances, use getTokenBalances instead. DAS API (10 credits/call).',
+    'BEST FOR: listing NFTs/digital assets owned by a wallet. PREFER getTokenBalances for fungible tokens, getAsset for a specific mint. Get all NFTs and digital assets owned by a wallet. Returns asset names, types, and mint addresses. Supports regular NFTs and cNFTs. Credit cost: 10 credits (DAS API).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       limit: z.number().optional().default(20).describe('Number of assets to return (default 20). Increase for wallets with many NFTs.'),
@@ -269,7 +269,7 @@ export function registerAssetTools(server: McpServer) {
   // Search Assets — unified search with smart routing for creator/authority/general queries
   server.tool(
     'searchAssets',
-    'BEST FOR: filtered multi-criteria asset search (creator, authority, name, compression). PREFER getAssetsByOwner for simple wallet NFT listing. PREFER getAssetsByGroup for collection browsing. Advanced search for digital assets (NFTs, tokens) with multiple filters. Search by owner, creator, authority, name, compression status, burnt status, or frozen status. Also replaces getAssetsByCreator and getAssetsByAuthority — pass creatorAddress (with optional onlyVerified) to find assets by creator, or authorityAddress to find assets controlled by an authority. DAS API (10 credits/call).',
+    'BEST FOR: filtered multi-criteria asset search. PREFER getAssetsByOwner for simple wallet NFT listing, getAssetsByGroup for collection browsing. Search digital assets by owner, creator, authority, name, compression, burnt, or frozen status. Also supports getAssetsByCreator and getAssetsByAuthority queries. Credit cost: 10 credits (DAS API).',
     {
       ownerAddress: z.string().optional().describe('Filter by owner wallet address'),
       creatorAddress: z.string().optional().describe('Filter by creator address'),

--- a/helius-mcp/src/tools/balance.ts
+++ b/helius-mcp/src/tools/balance.ts
@@ -9,7 +9,7 @@ export function registerBalanceTools(server: McpServer) {
   // Get SOL Balance
   server.tool(
     'getBalance',
-    'BEST FOR: SOL-only balance checks (cheapest option). PREFER getTokenBalances for SPL tokens or getWalletBalances for a full portfolio with USD values. Get native SOL balance for a Solana wallet address. Returns balance in both SOL and lamports (1 SOL = 1 billion lamports). Use this for checking how much SOL a wallet has. For token balances, use getTokenBalances instead. Credit cost: 1 credit (standard RPC).',
+    'BEST FOR: SOL-only balance checks. PREFER getTokenBalances for SPL tokens, getWalletBalances for full portfolio with USD. Get native SOL balance for a wallet. Returns balance in SOL and lamports. Credit cost: 1 credit.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded, e.g. Gh4tdJhLP1s55xGfghHHvPNPPrNtaDjc6dzZJ374DGHJ)')
     },
@@ -32,7 +32,7 @@ export function registerBalanceTools(server: McpServer) {
   // Get Token Balances
   server.tool(
     'getTokenBalances',
-    'BEST FOR: listing individual SPL token holdings with prices. PREFER getBalance for SOL-only. PREFER getWalletBalances for a complete portfolio sorted by USD value (includes SOL). Get all SPL token balances for a Solana wallet with full token info: names, symbols, properly formatted amounts with decimals, and USD prices (when available). Includes fungible tokens like USDC, BONK, JUP, etc. Does NOT include NFTs — use getAssetsByOwner for NFTs. For native SOL balance, use getBalance instead. Automatically paginates to fetch all tokens using parallel requests for speed. Uses DAS API (10 credits per page, ~10 items/page). A wallet with 50 tokens costs ~50 credits; 100+ tokens may cost 100+ credits. For a flat-rate portfolio view with USD values sorted by total value and optional NFTs, use getWalletBalances instead (100 credits flat, includes SOL).',
+    'BEST FOR: listing SPL token holdings with prices. PREFER getBalance for SOL-only, getWalletBalances for full portfolio with USD and SOL. Get all SPL token balances for a wallet with names, symbols, amounts, and USD prices. Auto-paginates. Credit cost: 10 credits/page (DAS API).',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)')
     },

--- a/helius-mcp/src/tools/docs.ts
+++ b/helius-mcp/src/tools/docs.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { fetchDoc, fetchDocs, getDocsIndex, extractSections, DOCS_INDEX } from '../utils/docs.js';
+import { fetchDoc, fetchDocs, getDocsIndex, extractSections, truncateDoc, DOCS_INDEX } from '../utils/docs.js';
 
 export function registerDocsTools(server: McpServer) {
   /**
@@ -8,7 +8,7 @@ export function registerDocsTools(server: McpServer) {
    */
   server.tool(
     'lookupHeliusDocs',
-    'BEST FOR: API documentation and technical details. Use for "how does X work?" questions. NOT for pricing — use getHeliusPlanInfo instead. NOT for error codes — use troubleshootError instead. Fetch official Helius documentation for accurate, up-to-date information. Use this when you need precise details about APIs, rate limits, or features. Returns the official llms.txt documentation which is optimized for AI consumption.',
+    'BEST FOR: API documentation and technical details. NOT for pricing (use getHeliusPlanInfo) or errors (use troubleshootError). Fetch official Helius documentation by topic. Use `section` parameter to fetch only relevant sections and save tokens.',
     {
       topic: z
         .enum([
@@ -67,14 +67,16 @@ export function registerDocsTools(server: McpServer) {
           }
         }
 
-        // Return full documentation
+        // Return full documentation (truncated to save tokens)
         const result = [
           `# Helius Docs: ${topic}`,
           '',
-          content,
+          truncateDoc(content),
           '',
           '---',
           `Source: https://www.helius.dev/docs`,
+          '',
+          '*Tip: Use the `section` parameter (e.g., section: "rate limits") to fetch only what you need and save tokens.*',
         ].join('\n');
 
         return { content: [{ type: 'text' as const, text: result }] };
@@ -105,25 +107,11 @@ export function registerDocsTools(server: McpServer) {
       const lines = [
         '# Available Helius Documentation Topics',
         '',
-        'Use `lookupHeliusDocs` with any of these topics to fetch official documentation:',
+        'Use `lookupHeliusDocs` with any of these topics. Add `section` to filter.',
         '',
         '| Topic | Description |',
         '|-------|-------------|',
         ...index.map((doc) => `| \`${doc.key}\` | ${doc.description} |`),
-        '',
-        '## Usage Examples',
-        '',
-        '```',
-        '// Get overview with plans, credits, rate limits',
-        'lookupHeliusDocs({ topic: "overview" })',
-        '',
-        '// Get DAS API documentation',
-        'lookupHeliusDocs({ topic: "das" })',
-        '',
-        '// Get specific section from docs',
-        'lookupHeliusDocs({ topic: "overview", section: "credits" })',
-        'lookupHeliusDocs({ topic: "das", section: "rate limits" })',
-        '```',
       ];
 
       return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
@@ -135,7 +123,7 @@ export function registerDocsTools(server: McpServer) {
    */
   server.tool(
     'getHeliusCreditsInfo',
-    'BEST FOR: credit cost lookup table. PREFER getRateLimitInfo for per-method rate limits and costs. PREFER getHeliusPlanInfo for plan pricing. Get official Helius credit costs from documentation. Fetches the latest pricing information directly from Helius docs.',
+    'BEST FOR: credit cost lookup table. PREFER getRateLimitInfo for per-method rate limits, getHeliusPlanInfo for plan pricing. Get official Helius credit costs from documentation.',
     {},
     async () => {
       try {

--- a/helius-mcp/src/tools/enhanced-websockets.ts
+++ b/helius-mcp/src/tools/enhanced-websockets.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { getEnhancedWebSocketUrl } from '../utils/helius.js';
 import { mcpText, mcpError, validateEnum, handleToolError, warnInvalidAddresses, warnInvalidAddress, warnAddressConflicts } from '../utils/errors.js';
-import { fetchDoc } from '../utils/docs.js';
+import { fetchDoc, extractSections, truncateDoc } from '../utils/docs.js';
 
 export function registerEnhancedWebSocketTools(server: McpServer) {
 
@@ -219,12 +219,18 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
         );
       }
 
+      const capabilities = extractSections(content, ['capabilities', 'features'], { includeLooseMatches: false });
+      const subscriptions = extractSections(content, ['subscriptions', 'endpoints'], { includeLooseMatches: false });
+      const plans = extractSections(content, ['plan requirements', 'plans'], { includeLooseMatches: false });
+      const sections = [capabilities, subscriptions, plans].filter(Boolean).join('\n\n');
+      const body = sections || truncateDoc(content);
+
       const result = [
         '# Helius Enhanced WebSockets (Official)',
         '',
         `**Endpoint:** \`${wsUrl}\``,
         '',
-        content,
+        body,
         '',
         '---',
         'Source: https://www.helius.dev/docs/enhanced-websockets (fetched live)',

--- a/helius-mcp/src/tools/guides.ts
+++ b/helius-mcp/src/tools/guides.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { fetchDoc, fetchDocs } from '../utils/docs.js';
+import { fetchDoc, fetchDocs, extractSections, truncateDoc } from '../utils/docs.js';
 
 // Error codes and their meanings — no canonical llms.txt equivalent
 const ERROR_CODES: Record<string, { meaning: string; causes: string[]; fixes: string[] }> = {
@@ -132,15 +132,19 @@ export function registerGuideTools(server: McpServer) {
   // Tool 1: getRateLimitInfo — fetches live billing docs
   server.tool(
     'getRateLimitInfo',
-    'BEST FOR: credit costs and rate limits per API method. PREFER getHeliusPlanInfo for plan pricing/features overview. Get official Helius rate limits and credit costs per API method. Fetches live from the billing documentation so values are always accurate.',
+    'BEST FOR: per-method rate limits and credit costs. PREFER getHeliusPlanInfo for plan pricing/features. Get official Helius rate limits and credit costs per API method. Fetches live from billing docs.',
     {},
     async () => {
       try {
         const content = await fetchDoc('billing');
+        const rateLimits = extractSections(content, ['rate limits', 'standard rate limits'], { includeLooseMatches: false });
+        const creditCosts = extractSections(content, ['credit costs', 'credits system'], { includeLooseMatches: false });
+        const sections = [rateLimits, creditCosts].filter(Boolean).join('\n\n');
+        const body = sections || truncateDoc(content);
         const result = [
           '# Helius Rate Limits & Credits (Official)',
           '',
-          content,
+          body,
           '',
           '---',
           'Source: https://www.helius.dev/docs/billing (fetched live)',
@@ -164,10 +168,15 @@ export function registerGuideTools(server: McpServer) {
     async () => {
       try {
         const content = await fetchDoc('sender');
+        const howItWorks = extractSections(content, ['how it works', 'overview'], { includeLooseMatches: false });
+        const endpoints = extractSections(content, ['endpoints', 'api'], { includeLooseMatches: false });
+        const bestPractices = extractSections(content, ['best practices', 'tips'], { includeLooseMatches: false });
+        const sections = [howItWorks, endpoints, bestPractices].filter(Boolean).join('\n\n');
+        const body = sections || truncateDoc(content);
         const result = [
           '# Helius Sender (Official)',
           '',
-          content,
+          body,
           '',
           '---',
           'Source: https://www.helius.dev/docs (fetched live)',
@@ -191,10 +200,15 @@ export function registerGuideTools(server: McpServer) {
     async () => {
       try {
         const content = await fetchDoc('webhooks');
+        const setup = extractSections(content, ['setup', 'configuration'], { includeLooseMatches: false });
+        const types = extractSections(content, ['transaction types', 'event types'], { includeLooseMatches: false });
+        const delivery = extractSections(content, ['delivery', 'troubleshooting'], { includeLooseMatches: false });
+        const sections = [setup, types, delivery].filter(Boolean).join('\n\n');
+        const body = sections || truncateDoc(content);
         const result = [
           '# Helius Webhooks (Official)',
           '',
-          content,
+          body,
           '',
           '---',
           'Source: https://www.helius.dev/docs (fetched live)',
@@ -213,7 +227,7 @@ export function registerGuideTools(server: McpServer) {
   // Tool 4: troubleshootError — kept hardcoded (no llms.txt equivalent)
   server.tool(
     'troubleshootError',
-    'BEST FOR: diagnosing specific error codes. Always use this first when the user encounters an error, before attempting manual diagnosis. Get detailed explanation and fixes for common Helius/Solana RPC error codes. Covers JSON-RPC errors, HTTP status codes, and WebSocket close codes.',
+    'BEST FOR: diagnosing specific error codes — use this first for any error. Get detailed explanation and fixes for Helius/Solana error codes. Covers JSON-RPC errors, HTTP status codes, and WebSocket close codes.',
     {
       errorCode: z
         .string()
@@ -244,13 +258,14 @@ export function registerGuideTools(server: McpServer) {
         lines.push('3. Check your plan limits in dashboard');
         lines.push('4. Try the request with curl to isolate client issues');
         lines.push('5. Contact support with request ID if persistent');
-      }
 
-      lines.push('', '## Common Error Codes Reference', '');
-      lines.push('| Code | Meaning |');
-      lines.push('|------|---------|');
-      for (const [c, e] of Object.entries(ERROR_CODES)) {
-        lines.push(`| ${c} | ${e.meaning} |`);
+        // Only show full reference table when code is unknown
+        lines.push('', '## Common Error Codes Reference', '');
+        lines.push('| Code | Meaning |');
+        lines.push('|------|---------|');
+        for (const [c, e] of Object.entries(ERROR_CODES)) {
+          lines.push(`| ${c} | ${e.meaning} |`);
+        }
       }
 
       return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
@@ -279,7 +294,10 @@ export function registerGuideTools(server: McpServer) {
         };
 
         for (const [key, content] of docs.entries()) {
-          sections.push(`## ${labels[key] ?? key}`, '', content, '', '---', '');
+          const latency = extractSections(content, ['latency', 'performance'], { includeLooseMatches: false });
+          const speed = extractSections(content, ['speed', 'comparison'], { includeLooseMatches: false });
+          const combined = [latency, speed].filter(Boolean).join('\n\n');
+          sections.push(`## ${labels[key] ?? key}`, '', combined || truncateDoc(content), '', '---', '');
         }
 
         sections.push('Source: https://www.helius.dev/docs (fetched live)');
@@ -306,113 +324,37 @@ export function registerGuideTools(server: McpServer) {
         '',
         '## Why getAssetsByCreator Doesn\'t Work',
         '',
-        'When you call `getAssetsByCreator` with a pump.fun deployer wallet, it returns empty.',
-        '',
-        '**Reason**: DAS API\'s "creator" field refers to **Metaplex creators** metadata, not the wallet that deployed the token.',
-        '',
-        '- Pump.fun tokens don\'t use Metaplex creators array',
-        '- The deployer wallet is not stored in the same way',
-        '- DAS cannot index pump.fun deployers as "creators"',
+        'DAS API\'s "creator" field refers to **Metaplex creators** metadata, not the deployer wallet. Pump.fun tokens don\'t use the Metaplex creators array, so `getAssetsByCreator` returns empty.',
         '',
         '## How to Find Pump.fun Tokens',
         '',
-        '### Option 1: Listen to Migration Events',
-        '```',
-        '// Subscribe to pump.fun migration program',
-        'Program ID: 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P',
-        '',
-        '// Filter for "migrate" instruction',
-        '// This fires when a token graduates from bonding curve',
-        '```',
-        '',
-        '### Option 2: Query by Mint/Update Authority',
-        '',
-        'Instead of creator, try:',
-        '- `getAsset` with the specific mint address',
-        '- Filter by update authority or freeze authority',
-        '- Search by token metadata name/symbol patterns',
-        '',
-        '### Option 3: Historical Backfill',
-        '',
-        'For historical graduated tokens:',
-        '```',
-        '1. Query migration program transaction history',
-        '2. Parse the "migrate" instruction logs',
-        '3. Extract token mint addresses',
-        '4. Use getAsset to get full token details',
-        '```',
+        '1. **By mint address** — `getAsset` with the specific mint address (most direct)',
+        '2. **By authority** — `searchAssets` filtering by update/freeze authority',
+        '3. **Listen to migrations** — Subscribe to the migration program to catch graduates:',
+        '   - Migration Program: `6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P`',
+        '   - Use `transactionSubscribe` or `laserstreamSubscribe` with `accountInclude` set to this program',
+        '4. **Historical backfill** — Query migration program transaction history, parse "migrate" instructions, extract mint addresses',
         '',
         '## Tracking Migrations (Graduates)',
         '',
-        '### What is a Migration/Graduate?',
         'When a pump.fun token completes its bonding curve, it "graduates" and migrates to Raydium.',
         '',
-        '### Migration Program',
-        '```',
-        'Program: 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P',
-        'Instruction: migrate',
-        '```',
-        '',
-        '### Real-time Migration Tracking',
+        '**Real-time tracking:**',
         '```typescript',
-        '// Using Laserstream/gRPC',
-        'subscribe({',
-        '  transactions: {',
-        '    accountInclude: ["6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"],',
-        '  }',
-        '});',
-        '',
-        '// Or Enhanced WebSockets',
+        '// Laserstream or Enhanced WebSockets',
         'transactionSubscribe({',
         '  accountInclude: ["6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"],',
         '});',
         '```',
         '',
-        '### Historical Migrations',
+        '**Historical migrations:**',
         '```typescript',
-        '// Get past migrations',
         'const signatures = await connection.getSignaturesForAddress(',
         '  new PublicKey("6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P"),',
         '  { limit: 1000 }',
         ');',
-        '',
-        '// Parse each transaction for migrate instruction',
-        'for (const sig of signatures) {',
-        '  const tx = await parseTransactions([sig.signature]);',
-        '  // Extract token mint from parsed data',
-        '}',
+        '// Parse each transaction with parseTransactions to extract token mints',
         '```',
-        '',
-        '## Common Pump.fun Queries',
-        '',
-        '### Get Token Details',
-        '```typescript',
-        '// If you have the mint address',
-        'const asset = await helius.getAsset({ id: mintAddress });',
-        '```',
-        '',
-        '### Check if Token is Graduated',
-        '```typescript',
-        '// Graduated tokens will have Raydium LP',
-        '// Check for AMM/CPMM pool with the token',
-        '```',
-        '',
-        '### Get Token Holders',
-        '```typescript',
-        'const holders = await helius.getTokenAccounts({',
-        '  mint: mintAddress,',
-        '  limit: 100,',
-        '});',
-        '```',
-        '',
-        '## Feature Request Status',
-        '',
-        'Helius is aware of demand for:',
-        '- Native pump.fun migration filter in Events API',
-        '- Historical graduates backfill endpoint',
-        '- Creator-by-deployer-wallet queries',
-        '',
-        'Check docs.helius.dev for updates.',
       ];
 
       return { content: [{ type: 'text' as const, text: lines.join('\n') }] };

--- a/helius-mcp/src/tools/laserstream.ts
+++ b/helius-mcp/src/tools/laserstream.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { getLaserstreamUrl, getNetwork } from '../utils/helius.js';
 import { mcpText, mcpError, validateEnum, handleToolError, warnInvalidAddresses, warnAddressConflicts } from '../utils/errors.js';
-import { fetchDoc } from '../utils/docs.js';
+import { fetchDoc, extractSections, truncateDoc } from '../utils/docs.js';
 
 export function registerLaserstreamTools(server: McpServer) {
 
@@ -182,12 +182,18 @@ export function registerLaserstreamTools(server: McpServer) {
         );
       }
 
+      const capabilities = extractSections(content, ['capabilities', 'features'], { includeLooseMatches: false });
+      const regions = extractSections(content, ['regions', 'endpoints'], { includeLooseMatches: false });
+      const plans = extractSections(content, ['plan requirements', 'pricing'], { includeLooseMatches: false });
+      const sections = [capabilities, regions, plans].filter(Boolean).join('\n\n');
+      const body = sections || truncateDoc(content);
+
       const result = [
         '# Helius Laserstream (Official)',
         '',
         `**Endpoint:** \`${endpoint}\``,
         '',
-        content,
+        body,
         '',
         '---',
         'Source: https://www.helius.dev/docs/laserstream/grpc (fetched live)',

--- a/helius-mcp/src/tools/plans.ts
+++ b/helius-mcp/src/tools/plans.ts
@@ -69,7 +69,7 @@ export async function detectCurrentPlan(): Promise<string | undefined> {
 export function registerPlanTools(server: McpServer) {
   server.tool(
     'getHeliusPlanInfo',
-    'BEST FOR: pricing questions — "how much does Helius cost?", "what plan should I get?". Start here for any plan/pricing question. PREFER compareHeliusPlans for side-by-side category comparisons. PREFER getRateLimitInfo for credit costs per API method. Get detailed Helius plan information including pricing, credits, rate limits, and feature availability. Shows what features are available on each tier (Free, Developer, Business, Professional). Useful for understanding WebSocket limits, Laserstream access, and API rate limits per plan. Fetches live from official billing documentation.',
+    'BEST FOR: pricing and plan questions. PREFER compareHeliusPlans for side-by-side category comparisons, getRateLimitInfo for per-method credit costs. Get Helius plan pricing, credits, rate limits, and feature availability. Fetches live from billing docs.',
     {
       plan: z.enum(['free', 'developer', 'business', 'professional', 'all']).optional().default('all').describe('Specific plan to show details for, or "all" for comparison'),
     },
@@ -129,7 +129,7 @@ export function registerPlanTools(server: McpServer) {
 
   server.tool(
     'compareHeliusPlans',
-    'BEST FOR: side-by-side plan comparison in a specific category. Fetches live from official billing documentation. Compare Helius plans for a specific feature category (rate limits, features, or pricing).',
+    'BEST FOR: side-by-side plan comparison in a specific category. Compare Helius plans for rate limits, features, or pricing. Fetches live from billing docs.',
     {
       category: z.enum(['rates', 'features', 'pricing']).describe('Category to compare'),
     },

--- a/helius-mcp/src/tools/recommend.ts
+++ b/helius-mcp/src/tools/recommend.ts
@@ -5,7 +5,8 @@ import { hasApiKey } from '../utils/helius.js';
 import { getPreferences, savePreferences } from '../utils/config.js';
 import { HELIUS_PLANS, detectCurrentPlan } from './plans.js';
 import { PRODUCT_CATALOG, CatalogProduct } from './product-catalog.js';
-import { fetchDoc, extractSections } from '../utils/docs.js';
+// fetchDoc/extractSections no longer needed — live billing fetch removed
+
 
 // ─── Known MCP Tools (for validation script) ───
 
@@ -97,15 +98,8 @@ function groupCatalogByTier(): CatalogTier[] {
 // ─── Formatting ───
 
 function formatProduct(product: CatalogProduct): string {
-  const lines: string[] = [
-    `**${product.name}** \u2014 ${product.description}`,
-    `- Tools: ${product.mcpTools.map(t => '`' + t + '`').join(', ')}`,
-    `- Cost: ${product.creditCostPerCall}`,
-  ];
-  if (product.referenceFile) {
-    lines.push(`- Docs: \`${product.referenceFile}\``);
-  }
-  return lines.join('\n');
+  const docs = product.referenceFile ? ` | Docs: \`${product.referenceFile}\`` : '';
+  return `- **${product.name}** \u2014 ${product.description} (${product.creditCostPerCall})${docs}\n  Tools: ${product.mcpTools.map(t => '`' + t + '`').join(', ')}`;
 }
 
 function formatTier(tier: CatalogTier, detectedPlan?: string): string {
@@ -166,7 +160,6 @@ function formatCatalog(
   description: string,
   complexity: 'low' | 'medium' | 'high' | undefined,
   detectedPlan?: string,
-  livePlansSection?: string | null,
 ): string {
   const lines: string[] = ['# Helius Product Catalog', ''];
 
@@ -206,25 +199,13 @@ function formatCatalog(
     }
   }
 
-  // Live plans & pricing section from billing doc
-  if (livePlansSection) {
-    lines.push('', '---', '', '## Plans & Pricing', '', livePlansSection);
-  } else {
-    lines.push('', '---', '', '_For current plan pricing, use `getHeliusPlanInfo` or visit https://www.helius.dev/docs/billing_');
-  }
-
   lines.push(
     '',
     '---',
     '',
-    '## Estimate your monthly cost',
-    'credits/month = (calls per user per day) \u00d7 (credits per call) \u00d7 (active users) \u00d7 30',
-    'Use `getRateLimitInfo` for exact per-method credit costs.',
+    '_Use `getHeliusPlanInfo` for pricing and `lookupHeliusDocs` for API details._',
     '',
-    '## Next steps',
-    '1. Pick a tier \u2192 `getHeliusPlanInfo` for full plan details',
-    '2. Read the reference files listed above',
-    '3. Start building with the MCP tools listed',
+    '*Token tip: Use batch endpoints and `section` filters on `lookupHeliusDocs` to minimize per-call context usage.*',
   );
 
   return lines.join('\n');
@@ -250,15 +231,7 @@ const SCALE_TIERS: Record<string, string[]> = {
 export function registerRecommendTools(server: McpServer) {
   server.tool(
     'recommendStack',
-    'BEST FOR: ANY time a user describes a Solana project, app, or tool they want to build. ' +
-    'Call this immediately when the user says they want to build, make, or create something \u2014 ' +
-    'do not ask clarifying questions first. Examples: "I want to build a PnL tracker", ' +
-    '"make a tax reporting tool", "create a token sniper", "I need an NFT gallery". ' +
-    'PREFER getHeliusPlanInfo for pricing-only questions. ' +
-    'PREFER lookupHeliusDocs for specific API docs. Returns tiered architecture ' +
-    'recommendations: which Helius products to use, why, which MCP tools to call, ' +
-    'credit costs per call, minimum plan required, and reference files to read. ' +
-    'Supports saved preferences for budget and complexity level.',
+    'BEST FOR: project architecture when user describes a Solana app to build. PREFER getHeliusPlanInfo for pricing-only, lookupHeliusDocs for API docs. Get tiered architecture recommendations. Returns Helius products, MCP tools, credit costs, minimum plan, and reference files.',
     {
       description: z.string().describe('What the user wants to build, in their own words'),
       budget: z.enum(['free', 'developer', 'business', 'professional']).optional(),
@@ -326,17 +299,8 @@ export function registerRecommendTools(server: McpServer) {
         }
       }
 
-      // 7. Fetch live billing data for plans section
-      let livePlansSection: string | null = null;
-      try {
-        const billingDoc = await fetchDoc('billing');
-        livePlansSection = extractSections(billingDoc, ['standard plans', 'standard pricing'], { includeLooseMatches: false });
-      } catch {
-        // Silent fallback — live pricing is best-effort
-      }
-
-      // 8. Format output
-      let output = formatCatalog(availableTiers, upgradeTiers, description, effectiveComplexity, detectedPlan, livePlansSection);
+      // 7. Format output
+      let output = formatCatalog(availableTiers, upgradeTiers, description, effectiveComplexity, detectedPlan);
 
       // 9. Soft hint: if no API key, append setup note
       if (!hasApiKey()) {

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -261,7 +261,7 @@ export function registerTransactionTools(server: McpServer) {
   // Parse Transactions (Enhanced API)
   server.tool(
     'parseTransactions',
-    'Parse one or more Solana transactions into human-readable format. Returns transaction type (SWAP, TRANSFER, NFT_SALE, etc.), source program (Jupiter, Raydium, Magic Eden, etc.), SOL and token transfers with token names and proper decimal formatting, fees (in both SOL and lamports), timestamp, program IDs involved, and a plain-English description. Use showRaw=true to see all program IDs, instruction accounts, instruction data bytes, inner instructions, and auto-decoded ComputeBudget instructions (CU limit, priority fee, heap frame). Credit cost: 100 credits/call (Enhanced Transactions API). To fetch and parse wallet transaction history, use getTransactionHistory instead.',
+    'BEST FOR: decoding specific transaction(s) by signature. Parse one or more Solana transactions into human-readable format. Returns type, source, transfers, fees, timestamp, and description. Use showRaw=true for full instruction data. Credit cost: 100 credits/call.',
     {
       signatures: z.array(z.string()).describe('Array of transaction signatures (base58 encoded). Can be 1 or more.'),
       showRaw: z.boolean().optional().default(false).describe('Include raw instruction data: program IDs, accounts, inner instructions. Useful for debugging or tracing fund flows.')
@@ -351,7 +351,7 @@ export function registerTransactionTools(server: McpServer) {
           outputLines.push('', `**Description:** ${tx.description}`);
         }
 
-        // Extract unique program IDs from instructions
+        // Extract unique program IDs from instructions (only show when ≤5 to reduce noise)
         if (tx.instructions && tx.instructions.length > 0) {
           const programIds = new Set<string>();
           const collectProgramIds = (instructions: RawInstruction[]) => {
@@ -362,10 +362,12 @@ export function registerTransactionTools(server: McpServer) {
           };
           collectProgramIds(tx.instructions);
 
-          outputLines.push('', '**Programs Involved:**');
-          programIds.forEach(pid => {
-            outputLines.push(`- ${pid}`);
-          });
+          if (programIds.size <= 5) {
+            outputLines.push('', '**Programs Involved:**');
+            programIds.forEach(pid => {
+              outputLines.push(`- ${pid}`);
+            });
+          }
         }
 
         // Swap summary from events.swap
@@ -395,13 +397,16 @@ export function registerTransactionTools(server: McpServer) {
           });
         }
 
+        // Skip SOL transfers when there's only 1 and a description already covers it
         if (tx.nativeTransfers && tx.nativeTransfers.length > 0) {
-          outputLines.push('', '**SOL Transfers:**');
-          tx.nativeTransfers.forEach((t) => {
-            const from = t.fromUserAccount || 'unknown';
-            const to = t.toUserAccount || 'unknown';
-            outputLines.push(`- ${from} → ${to}: ${formatSol(t.amount)} (${t.amount.toLocaleString()} lamports)`);
-          });
+          if (tx.nativeTransfers.length > 1 || !tx.description) {
+            outputLines.push('', '**SOL Transfers:**');
+            tx.nativeTransfers.forEach((t) => {
+              const from = t.fromUserAccount || 'unknown';
+              const to = t.toUserAccount || 'unknown';
+              outputLines.push(`- ${from} → ${to}: ${formatSol(t.amount)} (${t.amount.toLocaleString()} lamports)`);
+            });
+          }
         }
 
         // Show raw instruction data if requested
@@ -459,7 +464,7 @@ export function registerTransactionTools(server: McpServer) {
           const significantChanges = tx.accountData
             .filter(a => a.nativeBalanceChange !== 0)
             .sort((a, b) => Math.abs(b.nativeBalanceChange) - Math.abs(a.nativeBalanceChange))
-            .slice(0, 10);
+            .slice(0, 5);
 
           if (significantChanges.length > 0) {
             outputLines.push('', '**Account Balance Changes:**');
@@ -494,7 +499,7 @@ export function registerTransactionTools(server: McpServer) {
   // Get Transaction History (unified: parsed, signatures, or raw mode)
   server.tool(
     'getTransactionHistory',
-    'BEST FOR: general-purpose transaction history (default choice for "show transactions"). PREFER getWalletTransfers for sends/receives specifically. PREFER getWalletHistory for balance changes per transaction. Get transaction history for a Solana wallet. Supports three modes: "parsed" (default) returns human-readable decoded data with types, descriptions, actions, and fees. "signatures" returns a lightweight list of transaction signatures with slot/time/status. "raw" returns full raw data with advanced Helius filters (time/slot ranges, status, token accounts). All modes support sortOrder="asc" for finding wallet funding sources — no pagination needed. By default only successful transactions are shown; set status="any" or status="failed" to include failed ones. Credit cost varies by mode: "parsed" ~110 credits/call (signatures fetch + Enhanced API enrichment); "signatures" and "raw" ~10 credits/call.',
+    'BEST FOR: general-purpose transaction history. PREFER getWalletTransfers for sends/receives, getWalletHistory for balance deltas. Get transaction history for a wallet. Modes: "parsed" (~110 credits), "signatures" (~10 credits), "raw" (~10 credits). Supports sortOrder, status filters, and time/slot ranges.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       mode: z.string().optional().default('parsed').describe('"parsed" = decoded human-readable history (default), "signatures" = lightweight signature list, "raw" = full data with advanced Helius filters'),

--- a/helius-mcp/src/tools/wallet.ts
+++ b/helius-mcp/src/tools/wallet.ts
@@ -10,7 +10,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Identity ───
   server.tool(
     'getWalletIdentity',
-    'BEST FOR: identifying a single known wallet (exchange, protocol, institution). PREFER batchWalletIdentity for multiple addresses. Identify known wallets (exchanges, protocols, institutions). Returns name, type, category, tags. Use this to check if a wallet belongs to a known entity like Binance, Coinbase, Jupiter, etc. Credit cost: 100 credits/call (Wallet API).',
+    'BEST FOR: identifying a single known wallet. PREFER batchWalletIdentity for multiple addresses. Identify known wallets (exchanges, protocols, institutions). Returns name, type, category, tags. Credit cost: 100 credits.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)')
     },
@@ -40,7 +40,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Batch Wallet Identity ───
   server.tool(
     'batchWalletIdentity',
-    'BEST FOR: identifying multiple wallets at once (up to 100). PREFER getWalletIdentity for a single address. Look up identities for up to 100 Solana addresses in one request. Returns known names, types, and categories for recognized wallets (exchanges, protocols, institutions). Credit cost: 100 credits/call (Wallet API).',
+    'BEST FOR: identifying multiple wallets at once (up to 100). PREFER getWalletIdentity for a single address. Look up identities for up to 100 Solana addresses. Returns names, types, and categories. Credit cost: 100 credits.',
     {
       addresses: z.array(z.string()).describe('Array of Solana wallet addresses (max 100)')
     },
@@ -86,7 +86,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Balances ───
   server.tool(
     'getWalletBalances',
-    'BEST FOR: complete portfolio view — "show my wallet", "portfolio", "all balances with USD". Includes SOL + tokens + optional NFTs sorted by value. PREFER getBalance for SOL-only. PREFER getTokenBalances for cheaper per-token lookups. Get all token and NFT balances with USD values, sorted by value. Includes SOL, SPL, Token-2022, and optionally NFTs. Different from getTokenBalances — this uses the Wallet API with USD pricing built-in. Credit cost: 100 credits/call. For fungible tokens only (no SOL or NFTs needed) on small wallets, getTokenBalances is cheaper (10 credits/page via DAS).',
+    'BEST FOR: complete portfolio view with USD values. PREFER getBalance for SOL-only, getTokenBalances for cheaper per-token lookups. Get all token and NFT balances with USD values, sorted by value. Includes SOL, SPL, Token-2022, and optionally NFTs. Credit cost: 100 credits.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       page: z.number().optional().default(1).describe('Page number (starts at 1)'),
@@ -158,7 +158,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet History ───
   server.tool(
     'getWalletHistory',
-    'BEST FOR: balance change deltas per transaction (+/-). PREFER getTransactionHistory for general decoded transaction history. PREFER getWalletTransfers for sends/receives with counterparty info. Get transaction history with balance changes per transaction. Parsed, human-readable format from the Wallet API. Different from getTransactionHistory — returns balance changes per tx with simpler pagination. Credit cost: 100 credits/call. Requires Developer+ plan (not available on Free plan).',
+    'BEST FOR: balance change deltas per transaction. PREFER getTransactionHistory for general history, getWalletTransfers for sends/receives. Get transaction history with balance changes per transaction. Credit cost: 100 credits. Requires Developer+ plan.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       limit: z.number().optional().default(100).describe('Number of results (max 100)'),
@@ -231,7 +231,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Transfers ───
   server.tool(
     'getWalletTransfers',
-    'BEST FOR: tracking sends/receives with direction (in/out) and counterparty addresses. PREFER getTransactionHistory for general transaction history. PREFER getWalletHistory for balance change deltas. Get all token transfers with sender/recipient info, direction (in/out), and amounts. Focused on transfers only (not all tx types). Shows counterparty addresses and transfer direction. Credit cost: 100 credits/call (Wallet API).',
+    'BEST FOR: tracking sends/receives with direction and counterparty. PREFER getTransactionHistory for general history, getWalletHistory for balance deltas. Get all token transfers with sender/recipient info, direction (in/out), and amounts. Credit cost: 100 credits.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)'),
       limit: z.number().optional().default(50).describe('Number of results (max 100)'),
@@ -287,7 +287,7 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Funded By ───
   server.tool(
     'getWalletFundedBy',
-    'BEST FOR: wallet provenance — "who funded this wallet?". PREFER getWalletIdentity for identifying a wallet entity. Find the original funding source of a wallet (first SOL transfer). Shows funder identity if known (e.g. which exchange funded this wallet). Useful for wallet provenance and tracing. Credit cost: 100 credits/call (Wallet API).',
+    'BEST FOR: wallet provenance — who funded this wallet. PREFER getWalletIdentity for identifying a wallet entity. Find the original funding source of a wallet. Shows funder identity if known. Credit cost: 100 credits.',
     {
       address: z.string().describe('Solana wallet address (base58 encoded)')
     },

--- a/helius-mcp/src/utils/docs.ts
+++ b/helius-mcp/src/utils/docs.ts
@@ -218,6 +218,21 @@ export function extractSections(
 }
 
 /**
+ * Truncate a doc response to avoid blowing up the context window.
+ * Tries to cut at a section boundary for cleaner output.
+ */
+export const MAX_DOC_RESPONSE_CHARS = 15_000;
+
+export function truncateDoc(text: string, limit = MAX_DOC_RESPONSE_CHARS): string {
+  if (text.length <= limit) return text;
+  const truncated = text.slice(0, limit);
+  const lastSection = truncated.lastIndexOf('\n## ');
+  const cutPoint = lastSection > limit * 0.5 ? lastSection : limit;
+  return truncated.slice(0, cutPoint) +
+    '\n\n---\n*Truncated. Use `lookupHeliusDocs` with a `section` filter for specific details.*';
+}
+
+/**
  * Search docs content for a specific term (searches cached docs only)
  */
 export function searchCachedDocs(searchTerm: string): Array<{ docKey: string; matches: string[] }> {

--- a/helius-plugin/skills/build/SKILL.md
+++ b/helius-plugin/skills/build/SKILL.md
@@ -9,45 +9,21 @@ You are an expert Solana developer building with Helius's infrastructure. Helius
 
 ## Prerequisites
 
-Before doing anything, verify these two things:
-
 ### 1. Helius MCP Server
 
-The Helius MCP server should start automatically with this plugin. Check that Helius MCP tools are available (e.g., `getBalance`, `getAssetsByOwner`, `parseTransactions`).
+The Helius MCP server should start automatically with this plugin. Check that Helius MCP tools are available (e.g., `getBalance`, `getAssetsByOwner`).
 
-If they are NOT available, **STOP**. Do NOT attempt to call Helius APIs via curl, CLI commands, or any other workaround. Tell the user:
-
-```
-The Helius MCP server isn't running. Try restarting Claude Code.
-If the problem persists, you can add it manually:
-claude mcp add helius npx helius-mcp@latest
-Then restart Claude so the tools become available.
-```
+If NOT available, **STOP** and tell the user: try restarting Claude Code, or manually add: `claude mcp add helius npx helius-mcp@latest` then restart.
 
 ### 2. API Key
 
-If any MCP tool returns an "API key not configured" error, guide the user through one of these paths:
+If any MCP tool returns "API key not configured":
 
-**Path A — Existing key (fastest):** If the user already has a Helius API key from https://dashboard.helius.dev, use the `setHeliusApiKey` MCP tool to configure it.
+**Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — New account (agentic signup):** Walk the user through ALL of these steps:
+**Path B — Agentic signup:** `generateKeypair` → user funds wallet (~0.001 SOL + 1 USDC for basic/$49+ for paid) → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
 
-1. **Generate a keypair** — call the `generateKeypair` MCP tool. It returns a wallet address.
-2. **Fund the wallet** — the user must send funds to that wallet address:
-   - **~0.001 SOL** for transaction fees
-   - **1 USDC** for the basic plan ($1), or more for paid plans ($49 Developer, $499 Business, $999 Professional)
-   - They can fund from any Solana wallet or exchange. The USDC mint on Solana is `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`.
-3. **Verify funding** — call `checkSignupBalance` to confirm SOL + USDC are sufficient.
-4. **Create the account** — call `agenticSignup` to process the USDC payment and create the Helius account. The API key is automatically configured.
-
-**IMPORTANT**: Do NOT skip or simplify these steps. The signup requires on-chain payment — the wallet MUST be funded before `agenticSignup` will succeed.
-
-**Path C — Helius CLI:** The same flow from the terminal:
-```bash
-npx helius-cli@latest keygen        # Step 1: generate keypair
-# Step 2: fund the wallet address shown above
-npx helius-cli@latest signup        # Step 3+4: verify balance and create account
-```
+**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
 
 ## Routing
 
@@ -55,160 +31,78 @@ Identify what the user is building, then read the relevant reference files befor
 
 ### Quick Disambiguation
 
-These intents overlap across multiple files. Route them correctly:
-
-- **"transaction history"** — Parsed, human-readable history → `references/enhanced-transactions.md`. Balance changes per tx → `references/wallet-api.md`. Trigger actions on new txs → `references/webhooks.md`.
-- **"real-time" / "streaming"** — WebSocket subscriptions (accountSubscribe, logsSubscribe, transactionSubscribe) → `references/websockets.md`. gRPC streaming (all accounts, all transactions, high-throughput indexing) → `references/laserstream.md`.
-- **"monitor wallet"** — Fire-and-forget notifications (webhook POSTs to your server) → `references/webhooks.md`. Live UI updates (persistent connection) → `references/websockets.md`. Investigate past activity → `references/wallet-api.md`.
-- **"how does X work on Solana"** — Protocol internals, SIMDs, source code → `getSIMD`, `readSolanaSourceFile`, `searchSolanaDocs`. Helius blog deep-dives → `fetchHeliusBlog`. Helius API docs → `lookupHeliusDocs`.
+| Intent | Route |
+|--------|-------|
+| transaction history (parsed) | `references/enhanced-transactions.md` |
+| transaction history (balance deltas) | `references/wallet-api.md` |
+| transaction triggers | `references/webhooks.md` |
+| real-time (WebSocket) | `references/websockets.md` |
+| real-time (gRPC/indexing) | `references/laserstream.md` |
+| monitor wallet (notifications) | `references/webhooks.md` |
+| monitor wallet (live UI) | `references/websockets.md` |
+| monitor wallet (past activity) | `references/wallet-api.md` |
+| Solana internals | MCP: `getSIMD`, `searchSolanaDocs`, `fetchHeliusBlog` |
 
 ### Transaction Sending & Swaps
 **Read**: `references/sender.md`, `references/priority-fees.md`
 **MCP tools**: `getPriorityFeeEstimate`, `getSenderInfo`, `parseTransactions`
-
-Use this when the user wants to:
-- Send transactions with optimal landing rates
-- Integrate with DFlow, Jupiter, Titan, or other swap APIs
-- Build trading bots, swap interfaces, or trading terminals
-- Optimize transaction submission
+**When**: sending transactions, swap APIs (DFlow, Jupiter, Titan), trading bots, swap interfaces, transaction optimization
 
 ### Asset & NFT Queries
 **Read**: `references/das.md`
 **MCP tools**: `getAssetsByOwner`, `getAsset`, `searchAssets`, `getAssetsByGroup`, `getAssetProof`, `getAssetProofBatch`, `getSignaturesForAsset`, `getNftEditions`
-
-Use this when the user wants to:
-- Query NFTs, compressed NFTs, or fungible tokens
-- Build NFT marketplaces, galleries, or launchpads
-- Search assets by collection, creator, or authority
-- Work with Merkle proofs for compressed NFTs
+**When**: NFT/cNFT/token queries, marketplaces, galleries, launchpads, collection/creator/authority search, Merkle proofs
 
 ### Real-Time Streaming
 **Read**: `references/laserstream.md` OR `references/websockets.md`
-**MCP tools**: `transactionSubscribe`, `accountSubscribe`, `getEnhancedWebSocketInfo`, `laserstreamSubscribe`, `getLaserstreamInfo`, `getLatencyComparison`
-
-Use this when the user wants to:
-- Monitor transactions or accounts in real time
-- Build live dashboards, alerting systems, trading apps
-- Stream block/slot data for indexing
-- Track specific program or account activity
-
-**Choosing between them**:
-- Enhanced WebSockets: simpler setup, WebSocket protocol, good for most real-time needs (Business+ plan)
-- Laserstream gRPC: lowest latency, historical replay, best for indexers and high-throughput (Professional plan)
-- Use `getLatencyComparison` MCP tool to show the user the tradeoffs
+**MCP tools**: `transactionSubscribe`, `accountSubscribe`, `laserstreamSubscribe`
+**When**: real-time monitoring, live dashboards, alerting, trading apps, block/slot streaming, indexing, program/account tracking
+Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) for lowest latency and replay.
 
 ### Event Pipelines (Webhooks)
 **Read**: `references/webhooks.md`
 **MCP tools**: `createWebhook`, `getAllWebhooks`, `getWebhookByID`, `updateWebhook`, `deleteWebhook`, `getWebhookGuide`
-
-Use this when the user wants to:
-- Get notified when specific on-chain events happen
-- Build event-driven backends
-- Monitor addresses for transfers, swaps, NFT sales, program upgrades, multi-sig activity
-- Set up Telegram or Discord notifications for on-chain activity
+**When**: on-chain event notifications, event-driven backends, address monitoring (transfers, swaps, NFT sales), Telegram/Discord alerts
 
 ### Wallet Analysis
 **Read**: `references/wallet-api.md`
 **MCP tools**: `getWalletIdentity`, `batchWalletIdentity`, `getWalletBalances`, `getWalletHistory`, `getWalletTransfers`, `getWalletFundedBy`
-
-Use this when the user wants to:
-- Look up who owns a wallet (exchanges, protocols, institutions, KOLs, scammers)
-- Get wallet portfolio or balance breakdowns in a human-readable format
-- Trace fund flows and transfer history
-- Build wallet analytics, bubblemaps, tax reporting software, or investigation tools
+**When**: wallet identity lookup, portfolio/balance breakdowns, fund flow tracing, wallet analytics, tax reporting, investigation tools
 
 ### Account & Token Data
 **MCP tools**: `getBalance`, `getTokenBalances`, `getAccountInfo`, `getTokenAccounts`, `getProgramAccounts`, `getTokenHolders`, `getBlock`, `getNetworkStatus`
-
-Use this when the user wants to:
-- Check balances (SOL or SPL tokens)
-- Inspect account data or program accounts
-- Get token holder distributions
-- Query block or network information
-
-These are straightforward data lookups. No reference file needed — just use the MCP tools directly.
+**When**: balance checks, account inspection, token holder distributions, block/network queries. No reference file needed.
 
 ### Transaction History & Parsing
 **Read**: `references/enhanced-transactions.md`
 **MCP tools**: `parseTransactions`, `getTransactionHistory`
-
-Use this when the user wants to:
-- Get human-readable transaction data from signatures
-- Build transaction explorers or comprehensive history views
-- Analyze past swaps, transfers, or NFT sales
-- Filter transaction history by type, time range, or slot range
+**When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
 **MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
-
-Use this when the user wants to:
-- Create a Helius account
-- Get or manage API keys
-- Check their plan, credits, or usage
-- Upgrade or manage billing
+**When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
 **MCP tools**: `lookupHeliusDocs`, `listHeliusDocTopics`, `getHeliusCreditsInfo`, `getRateLimitInfo`, `troubleshootError`, `getPumpFunGuide`
-
-Use this when the user wants to:
-- Look up specific API details, pricing, or rate limits
-- Troubleshoot errors
-- Understand credit costs
-- Work with pump.fun tokens
-
-For any documentation question, prefer `lookupHeliusDocs` with the relevant topic — it fetches live from official docs so it's always accurate.
+**When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
 **MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
-
-Use this when the user asks about pricing, plans, or rate limits.
+**When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research
 **MCP tools**: `getSIMD`, `listSIMDs`, `readSolanaSourceFile`, `searchSolanaDocs`, `fetchHeliusBlog`
+**When**: Solana protocol internals, SIMDs, validator source code, architecture research, Helius blog deep-dives. No API key needed.
 
-Use this when the user wants to:
-- Understand Solana protocol internals (consensus, runtime, transactions, fees, SVM)
-- Read or reference Solana Improvement Documents (SIMDs)
-- Look up validator source code from Agave or Firedancer
-- Research architecture, design decisions, or protocol changes
-- Get deep technical explanations from the Helius blog
-
-No API key needed — these tools fetch from public GitHub and Solana sources.
+### Project Planning & Architecture
+**MCP tools**: `getStarted` → `recommendStack` → `getHeliusPlanInfo`, `lookupHeliusDocs`
+**When**: planning new projects, choosing Helius products, comparing budget vs. production architectures, cost estimates.
+Call `getStarted` first when user describes a project. Call `recommendStack` directly for explicit product recommendations.
 
 ## Composing Multiple Domains
 
-Many real tasks span multiple domains. Here's how to compose them:
-
-### "Build a swap/trading app"
-1. Read `references/sender.md` + `references/priority-fees.md`
-2. Architecture: DFlow Trading API for routes, Sender for submission, Priority Fee API for fees, Enhanced WebSockets or LaserStream for confirmation tracking
-3. Use `getPriorityFeeEstimate` to get fees, then submit via Sender endpoints with Jito tips
-
-### "Build an NFT marketplace"
-1. Read `references/das.md` + `references/webhooks.md`
-2. Architecture: DAS API for browsing/searching, webhooks for sale/listing events, Enhanced Transactions for history
-3. Use `getAssetsByGroup` for collection pages, `searchAssets` for search, `createWebhook` for event monitoring
-
-### "Build a portfolio tracker"
-1. Read `references/wallet-api.md` + `references/websockets.md`
-2. Architecture: Wallet API for balances/history, DAS for NFTs, Enhanced WebSockets for live updates
-3. Use `getWalletBalances` for current state, `transactionSubscribe` for real-time changes
-
-### "Build an indexer"
-1. Read `references/laserstream.md` + `references/webhooks.md`
-2. Architecture: Laserstream for high-throughput ingestion, your database for storage, webhooks for notifications
-3. Use `laserstreamSubscribe` for the data firehose, `parseTransactions` for enrichment
-
-### "Track specific program activity"
-1. Read `references/websockets.md` or `references/laserstream.md`
-2. Use `transactionSubscribe` with `accountInclude` filter set to the program ID
-3. Parse results with `parseTransactions` for human-readable output
-
-### "Work with pump.fun tokens"
-1. Use `getPumpFunGuide` MCP tool for the full pattern
-2. DAS `getAsset` for individual token details, NOT `getAssetsByCreator` (it won't work for pump.fun)
-3. Track migrations via Laserstream or Enhanced WebSockets monitoring the migration program
+For multi-product architecture recommendations, use `recommendStack` with a project description.
 
 ## Rules
 
@@ -252,6 +146,13 @@ Follow these rules in ALL implementations:
 - Rust: `use helius::Helius` then `Helius::new("apiKey", Cluster::MainnetBeta)?`
 - For @solana/kit integration, use `helius.raw` for the underlying `Rpc` client
 - Check the agents.md in helius-sdk or helius-rust-sdk for complete SDK API references
+
+### Token Efficiency
+- Prefer `getBalance` (returns ~2 lines) over `getWalletBalances` (returns 50+ lines) when only SOL balance is needed
+- Use `lookupHeliusDocs` with the `section` parameter — full docs can be 10,000+ tokens; a targeted section is typically 500-2,000
+- Use batch endpoints (`getAsset` with `ids` array, `getAssetProofBatch`) instead of sequential single calls — one response vs. N responses in context
+- Use `getTransactionHistory` in `signatures` mode for lightweight listing (~5 lines/tx), then `parseTransactions` only on transactions of interest
+- Prefer `getTokenBalances` (compact per-token lines) over `getWalletBalances` (full portfolio with metadata) when you don't need USD values or SOL balance
 
 ### Common Pitfalls
 - **SDK parameter names differ from API names** — The REST API uses kebab-case (`before-signature`), the Enhanced SDK uses camelCase (`beforeSignature`), and the RPC SDK uses different names entirely (`paginationToken`). Always check `references/enhanced-transactions.md` for the parameter name mapping before writing pagination or filtering code.

--- a/helius-skills/helius/SKILL.md
+++ b/helius-skills/helius/SKILL.md
@@ -13,42 +13,19 @@ You are an expert Solana developer building with Helius's infrastructure. Helius
 
 ## Prerequisites
 
-Before doing anything, verify these two things:
-
 ### 1. Helius MCP Server
 
-**CRITICAL**: Check if Helius MCP tools are available (e.g., `getBalance`, `getAssetsByOwner`, `parseTransactions`). If they are NOT available, **STOP**. Do NOT attempt to call Helius APIs via curl, CLI commands, or any other workaround. Tell the user:
-
-```
-You need to install the Helius MCP server first:
-claude mcp add helius npx helius-mcp@latest
-Then restart Claude so the tools become available.
-```
+**CRITICAL**: Check if Helius MCP tools are available (e.g., `getBalance`, `getAssetsByOwner`). If NOT available, **STOP** and tell the user: `claude mcp add helius npx helius-mcp@latest` then restart Claude.
 
 ### 2. API Key
 
-If any MCP tool returns an "API key not configured" error, guide the user through one of these paths:
+If any MCP tool returns "API key not configured":
 
-**Path A — Existing key (fastest):** If the user already has a Helius API key from https://dashboard.helius.dev, use the `setHeliusApiKey` MCP tool to configure it.
+**Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — New account (agentic signup):** Walk the user through ALL of these steps:
+**Path B — Agentic signup:** `generateKeypair` → user funds wallet (~0.001 SOL + 1 USDC for basic/$49+ for paid) → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
 
-1. **Generate a keypair** — call the `generateKeypair` MCP tool. It returns a wallet address.
-2. **Fund the wallet** — the user must send funds to that wallet address:
-   - **~0.001 SOL** for transaction fees
-   - **1 USDC** for the basic plan ($1), or more for paid plans ($49 Developer, $499 Business, $999 Professional)
-   - They can fund from any Solana wallet or exchange. The USDC mint on Solana is `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`.
-3. **Verify funding** — call `checkSignupBalance` to confirm SOL + USDC are sufficient.
-4. **Create the account** — call `agenticSignup` to process the USDC payment and create the Helius account. The API key is automatically configured.
-
-**IMPORTANT**: Do NOT skip or simplify these steps. The signup requires on-chain payment — the wallet MUST be funded before `agenticSignup` will succeed.
-
-**Path C — Helius CLI:** The same flow from the terminal:
-```bash
-npx helius-cli@latest keygen        # Step 1: generate keypair
-# Step 2: fund the wallet address shown above
-npx helius-cli@latest signup        # Step 3+4: verify balance and create account
-```
+**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
 
 ## Routing
 
@@ -56,180 +33,78 @@ Identify what the user is building, then read the relevant reference files befor
 
 ### Quick Disambiguation
 
-These intents overlap across multiple files. Route them correctly:
-
-- **"transaction history"** — Parsed, human-readable history → `references/enhanced-transactions.md`. Balance changes per tx → `references/wallet-api.md`. Trigger actions on new txs → `references/webhooks.md`.
-- **"real-time" / "streaming"** — WebSocket subscriptions (accountSubscribe, logsSubscribe, transactionSubscribe) → `references/websockets.md`. gRPC streaming (all accounts, all transactions, high-throughput indexing) → `references/laserstream.md`.
-- **"monitor wallet"** — Fire-and-forget notifications (webhook POSTs to your server) → `references/webhooks.md`. Live UI updates (persistent connection) → `references/websockets.md`. Investigate past activity → `references/wallet-api.md`.
-- **"how does X work on Solana"** — Protocol internals, SIMDs, source code → `getSIMD`, `readSolanaSourceFile`, `searchSolanaDocs`. Helius blog deep-dives → `fetchHeliusBlog`. Helius API docs → `lookupHeliusDocs`.
+| Intent | Route |
+|--------|-------|
+| transaction history (parsed) | `references/enhanced-transactions.md` |
+| transaction history (balance deltas) | `references/wallet-api.md` |
+| transaction triggers | `references/webhooks.md` |
+| real-time (WebSocket) | `references/websockets.md` |
+| real-time (gRPC/indexing) | `references/laserstream.md` |
+| monitor wallet (notifications) | `references/webhooks.md` |
+| monitor wallet (live UI) | `references/websockets.md` |
+| monitor wallet (past activity) | `references/wallet-api.md` |
+| Solana internals | MCP: `getSIMD`, `searchSolanaDocs`, `fetchHeliusBlog` |
 
 ### Transaction Sending & Swaps
 **Read**: `references/sender.md`, `references/priority-fees.md`
 **MCP tools**: `getPriorityFeeEstimate`, `getSenderInfo`, `parseTransactions`
-
-Use this when the user wants to:
-- Send transactions with optimal landing rates
-- Integrate with DFlow, Jupiter, Titan, or other swap APIs
-- Build trading bots, swap interfaces, or trading terminals
-- Optimize transaction submission
+**When**: sending transactions, swap APIs (DFlow, Jupiter, Titan), trading bots, swap interfaces, transaction optimization
 
 ### Asset & NFT Queries
 **Read**: `references/das.md`
 **MCP tools**: `getAssetsByOwner`, `getAsset`, `searchAssets`, `getAssetsByGroup`, `getAssetProof`, `getAssetProofBatch`, `getSignaturesForAsset`, `getNftEditions`
-
-Use this when the user wants to:
-- Query NFTs, compressed NFTs, or fungible tokens
-- Build NFT marketplaces, galleries, or launchpads
-- Search assets by collection, creator, or authority
-- Work with Merkle proofs for compressed NFTs
+**When**: NFT/cNFT/token queries, marketplaces, galleries, launchpads, collection/creator/authority search, Merkle proofs
 
 ### Real-Time Streaming
 **Read**: `references/laserstream.md` OR `references/websockets.md`
-**MCP tools**: `transactionSubscribe`, `accountSubscribe`, `getEnhancedWebSocketInfo`, `laserstreamSubscribe`, `getLaserstreamInfo`, `getLatencyComparison`
-
-Use this when the user wants to:
-- Monitor transactions or accounts in real time
-- Build live dashboards, alerting systems, trading apps
-- Stream block/slot data for indexing
-- Track specific program or account activity
-
-**Choosing between them**:
-- Enhanced WebSockets: simpler setup, WebSocket protocol, good for most real-time needs (Business+ plan)
-- Laserstream gRPC: lowest latency, historical replay, best for indexers and high-throughput (Professional plan)
-- Use `getLatencyComparison` MCP tool to show the user the tradeoffs
+**MCP tools**: `transactionSubscribe`, `accountSubscribe`, `laserstreamSubscribe`
+**When**: real-time monitoring, live dashboards, alerting, trading apps, block/slot streaming, indexing, program/account tracking
+Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) for lowest latency and replay.
 
 ### Event Pipelines (Webhooks)
 **Read**: `references/webhooks.md`
 **MCP tools**: `createWebhook`, `getAllWebhooks`, `getWebhookByID`, `updateWebhook`, `deleteWebhook`, `getWebhookGuide`
-
-Use this when the user wants to:
-- Get notified when specific on-chain events happen
-- Build event-driven backends
-- Monitor addresses for transfers, swaps, NFT sales, program upgrades, multi-sig activity
-- Set up Telegram or Discord notifications for on-chain activity
+**When**: on-chain event notifications, event-driven backends, address monitoring (transfers, swaps, NFT sales), Telegram/Discord alerts
 
 ### Wallet Analysis
 **Read**: `references/wallet-api.md`
 **MCP tools**: `getWalletIdentity`, `batchWalletIdentity`, `getWalletBalances`, `getWalletHistory`, `getWalletTransfers`, `getWalletFundedBy`
-
-Use this when the user wants to:
-- Look up who owns a wallet (exchanges, protocols, institutions, KOLs, scammers)
-- Get wallet portfolio or balance breakdowns in a human-readable format
-- Trace fund flows and transfer history
-- Build wallet analytics, bubblemaps, tax reporting software, or investigation tools
+**When**: wallet identity lookup, portfolio/balance breakdowns, fund flow tracing, wallet analytics, tax reporting, investigation tools
 
 ### Account & Token Data
 **MCP tools**: `getBalance`, `getTokenBalances`, `getAccountInfo`, `getTokenAccounts`, `getProgramAccounts`, `getTokenHolders`, `getBlock`, `getNetworkStatus`
-
-Use this when the user wants to:
-- Check balances (SOL or SPL tokens)
-- Inspect account data or program accounts
-- Get token holder distributions
-- Query block or network information
-
-These are straightforward data lookups. No reference file needed — just use the MCP tools directly.
+**When**: balance checks, account inspection, token holder distributions, block/network queries. No reference file needed.
 
 ### Transaction History & Parsing
 **Read**: `references/enhanced-transactions.md`
 **MCP tools**: `parseTransactions`, `getTransactionHistory`
-
-Use this when the user wants to:
-- Get human-readable transaction data from signatures
-- Build transaction explorers or comprehensive history views
-- Analyze past swaps, transfers, or NFT sales
-- Filter transaction history by type, time range, or slot range
+**When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
 **MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
-
-Use this when the user wants to:
-- Create a Helius account
-- Get or manage API keys
-- Check their plan, credits, or usage
-- Upgrade or manage billing
+**When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
 **MCP tools**: `lookupHeliusDocs`, `listHeliusDocTopics`, `getHeliusCreditsInfo`, `getRateLimitInfo`, `troubleshootError`, `getPumpFunGuide`
-
-Use this when the user wants to:
-- Look up specific API details, pricing, or rate limits
-- Troubleshoot errors
-- Understand credit costs
-- Work with pump.fun tokens
-
-For any documentation question, prefer `lookupHeliusDocs` with the relevant topic — it fetches live from official docs so it's always accurate.
+**When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
 **MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
-
-Use this when the user asks about pricing, plans, or rate limits.
+**When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research
 **MCP tools**: `getSIMD`, `listSIMDs`, `readSolanaSourceFile`, `searchSolanaDocs`, `fetchHeliusBlog`
-
-Use this when the user wants to:
-- Understand Solana protocol internals (consensus, runtime, transactions, fees, SVM)
-- Read or reference Solana Improvement Documents (SIMDs)
-- Look up validator source code from Agave or Firedancer
-- Research architecture, design decisions, or protocol changes
-- Get deep technical explanations from the Helius blog
-
-No API key needed — these tools fetch from public GitHub and Solana sources.
+**When**: Solana protocol internals, SIMDs, validator source code, architecture research, Helius blog deep-dives. No API key needed.
 
 ### Project Planning & Architecture
 **MCP tools**: `getStarted` → `recommendStack` → `getHeliusPlanInfo`, `lookupHeliusDocs`
-
-Use this when the user wants to:
-- Plan a new Solana project from scratch
-- Understand which Helius products to use for their use case
-- Compare budget vs. production architecture options
-- Get cost estimates before choosing a plan
-
-**Routing:** Always call `getStarted` first when the user describes a project they
-want to build ("I want to build X"). `getStarted` checks setup state and surfaces
-`recommendStack` as the next step. Only call `recommendStack` directly when the
-user explicitly asks for product recommendations ("what Helius products do I need?").
-
-When calling `recommendStack`, pass the user's project description via the
-`description` parameter. If it matches a known template (portfolio tracker,
-trading bot, NFT marketplace, etc.), also provide `projectType` for a tailored
-recommendation. Otherwise, omit it for the general capability catalog.
+**When**: planning new projects, choosing Helius products, comparing budget vs. production architectures, cost estimates.
+Call `getStarted` first when user describes a project. Call `recommendStack` directly for explicit product recommendations.
 
 ## Composing Multiple Domains
 
-For a structured recommendation with cost/complexity tiers, use `getStarted` (which
-surfaces `recommendStack`). For manual composition, here are common patterns:
-
-### "Build a swap/trading app"
-1. Read `references/sender.md` + `references/priority-fees.md`
-2. Architecture: DFlow Trading API for routes, Sender for submission, Priority Fee API for fees, Enhanced WebSockets or LaserStream for confirmation tracking
-3. Use `getPriorityFeeEstimate` to get fees, then submit via Sender endpoints with Jito tips
-
-### "Build an NFT marketplace"
-1. Read `references/das.md` + `references/webhooks.md`
-2. Architecture: DAS API for browsing/searching, webhooks for sale/listing events, Enhanced Transactions for history
-3. Use `getAssetsByGroup` for collection pages, `searchAssets` for search, `createWebhook` for event monitoring
-
-### "Build a portfolio tracker"
-1. Read `references/wallet-api.md` + `references/websockets.md`
-2. Architecture: Wallet API for balances/history, DAS for NFTs, Enhanced WebSockets for live updates
-3. Use `getWalletBalances` for current state, `transactionSubscribe` for real-time changes
-
-### "Build an indexer"
-1. Read `references/laserstream.md` + `references/webhooks.md`
-2. Architecture: Laserstream for high-throughput ingestion, your database for storage, webhooks for notifications
-3. Use `laserstreamSubscribe` for the data firehose, `parseTransactions` for enrichment
-
-### "Track specific program activity"
-1. Read `references/websockets.md` or `references/laserstream.md`
-2. Use `transactionSubscribe` with `accountInclude` filter set to the program ID
-3. Parse results with `parseTransactions` for human-readable output
-
-### "Work with pump.fun tokens"
-1. Use `getPumpFunGuide` MCP tool for the full pattern
-2. DAS `getAsset` for individual token details, NOT `getAssetsByCreator` (it won't work for pump.fun)
-3. Track migrations via Laserstream or Enhanced WebSockets monitoring the migration program
+For multi-product architecture recommendations, use `recommendStack` with a project description.
 
 ## Rules
 
@@ -273,6 +148,13 @@ Follow these rules in ALL implementations:
 - Rust: `use helius::Helius` then `Helius::new("apiKey", Cluster::MainnetBeta)?`
 - For @solana/kit integration, use `helius.raw` for the underlying `Rpc` client
 - Check the agents.md in helius-sdk or helius-rust-sdk for complete SDK API references
+
+### Token Efficiency
+- Prefer `getBalance` (returns ~2 lines) over `getWalletBalances` (returns 50+ lines) when only SOL balance is needed
+- Use `lookupHeliusDocs` with the `section` parameter — full docs can be 10,000+ tokens; a targeted section is typically 500-2,000
+- Use batch endpoints (`getAsset` with `ids` array, `getAssetProofBatch`) instead of sequential single calls — one response vs. N responses in context
+- Use `getTransactionHistory` in `signatures` mode for lightweight listing (~5 lines/tx), then `parseTransactions` only on transactions of interest
+- Prefer `getTokenBalances` (compact per-token lines) over `getWalletBalances` (full portfolio with metadata) when you don't need USD values or SOL balance
 
 ### Common Pitfalls
 - **SDK parameter names differ from API names** — The REST API uses kebab-case (`before-signature`), the Enhanced SDK uses camelCase (`beforeSignature`), and the RPC SDK uses different names entirely (`paginationToken`). Always check `references/enhanced-transactions.md` for the parameter name mapping before writing pagination or filtering code.


### PR DESCRIPTION
## Summary
- Reduces per-session token overhead by ~5k-7k tokens through compressed server instructions (prose → table), compact tool descriptions (keep BEST FOR/PREFER routing, trim verbose tails), and compressed SKILL.md (282→163 lines)
- Reduces per-call overhead by 5k-20k tokens through `extractSections()` in 6 doc-fetching tools, `truncateDoc()` utility, slimmed `recommendStack` (removed live billing fetch), and trimmed guide outputs (`getPumpFunGuide` 112→35 lines, conditional `troubleshootError` reference table)
- Adds Token Efficiency rules to SKILL.md and section-filter hints to doc tool responses to guide AI toward cheaper patterns

## Merge conflict note
This PR overlaps with #32 on 4 files. Only `index.ts` and `transactions.ts:parseTransactions` description will actually conflict:
- **`index.ts`**: Our table format subsumes all entries #32 adds (parseTransactions, Accounts & Tokens section, streaming decision tree, webhook management)
- **`transactions.ts`**: Both PRs change the `parseTransactions` description line — our version uses the same `BEST FOR: decoding specific transaction(s) by signature` prefix as #32 but with a compact tail
- **`enhanced-websockets.ts`** and **`laserstream.ts`**: No conflict (different lines — we touch imports + info tool handlers, #32 touches subscribe tool descriptions)

## Files changed (14 files, +242/-543)

| File | Changes |
|------|---------|
| `helius-mcp/src/index.ts` | Compress server instructions to table format with PR #32 entries |
| `helius-mcp/src/utils/docs.ts` | Add `truncateDoc()` utility |
| `helius-mcp/src/tools/guides.ts` | Section extraction for 3 doc tools, trim troubleshootError, trim pumpFunGuide |
| `helius-mcp/src/tools/docs.ts` | Truncation in lookupHeliusDocs, token hint, trim listHeliusDocTopics |
| `helius-mcp/src/tools/enhanced-websockets.ts` | Section extraction for getEnhancedWebSocketInfo |
| `helius-mcp/src/tools/laserstream.ts` | Section extraction for getLaserstreamInfo |
| `helius-mcp/src/tools/recommend.ts` | Remove live billing fetch, compact formatProduct, token-efficiency hint |
| `helius-mcp/src/tools/transactions.ts` | Compact tool descriptions, trim parseTransactions output |
| `helius-mcp/src/tools/balance.ts` | Compact tool descriptions |
| `helius-mcp/src/tools/wallet.ts` | Compact tool descriptions |
| `helius-mcp/src/tools/assets.ts` | Compact tool descriptions |
| `helius-mcp/src/tools/plans.ts` | Compact tool descriptions |
| `helius-skills/helius/SKILL.md` | Compress routing, remove Composing section, add Token Efficiency rules |
| `helius-plugin/skills/build/SKILL.md` | Mirror SKILL.md changes (kept in sync per CLAUDE.md) |

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` (build + validate-catalog) passes — all 12 catalog products valid
- [x] SKILL.md files verified in sync (only expected frontmatter/MCP diffs)
- [x] All routing keywords preserved (marketplace, indexing, trading bot, etc.)
- [ ] Smoke test doc-fetching tools to verify `extractSections()` returns non-null for chosen keywords
- [ ] Verify `truncateDoc()` cuts cleanly on real llms.txt files
- [ ] Test ambiguous prompts to confirm tool selection still works with compact descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)