### PR TITLE
feat(mcp): add transferSol and transferToken tools

### DIFF
--- a/helius-mcp/README.md
+++ b/helius-mcp/README.md
@@ -56,6 +56,8 @@ Ask questions in plain English — the right tool is selected automatically:
 
 **Transactions (1):** parseTransactions
 
+**Transfers (2):** transferSol, transferToken
+
 **Priority Fees (1):** getPriorityFeeEstimate
 
 **Webhooks (5):** getAllWebhooks, getWebhookByID, createWebhook, updateWebhook, deleteWebhook

--- a/helius-mcp/package.json
+++ b/helius-mcp/package.json
@@ -38,6 +38,9 @@
   "homepage": "https://github.com/helius-labs/core-ai#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@solana-program/system": "^0.10.0",
+    "@solana-program/token": "^0.9.0",
+    "@solana/kit": "^5.0.0",
     "bs58": "^6.0.0",
     "helius-sdk": "^2.2.2",
     "zod": "^3.23.0"

--- a/helius-mcp/pnpm-lock.yaml
+++ b/helius-mcp/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.25.2(hono@4.11.4)(zod@3.25.76)
+      '@solana-program/system':
+        specifier: ^0.10.0
+        version: 0.10.0(@solana/kit@5.4.0(typescript@5.9.3))
+      '@solana-program/token':
+        specifier: ^0.9.0
+        version: 0.9.0(@solana/kit@5.4.0(typescript@5.9.3))
+      '@solana/kit':
+        specifier: ^5.0.0
+        version: 5.4.0(typescript@5.9.3)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0

--- a/helius-mcp/src/index.ts
+++ b/helius-mcp/src/index.ts
@@ -74,6 +74,11 @@ Choose based on your use case:
 - If the user hasn't set up an API key yet, recommendStack will append a setup hint — no need to call getStarted first
 - After recommendations → getHeliusPlanInfo for pricing, lookupHeliusDocs for API details
 
+### Transfers / Sending
+- "send SOL", "transfer SOL" → transferSol (~3 credits)
+- "send tokens", "transfer USDC/BONK/etc" → transferToken (~13 credits)
+- Both require a configured keypair (generateKeypair) and use Helius Sender
+
 ### Account Setup (no API key yet)
 - generateKeypair → fund wallet → agenticSignup`
   }

--- a/helius-mcp/src/tools/accounts.ts
+++ b/helius-mcp/src/tools/accounts.ts
@@ -69,7 +69,7 @@ export function registerAccountTools(server: McpServer) {
             return mcpText(`**Error:** Maximum 100 accounts per request. You provided ${addresses.length}.`);
           }
 
-          const result = await (helius as any).getMultipleAccounts(addresses, { encoding }).send();
+          const result = await (helius as any).getMultipleAccounts(addresses, { encoding });
           const accounts = result?.value || [];
           const lines = [`**Multiple Accounts** (${addresses.length} requested)`, ''];
 
@@ -95,7 +95,7 @@ export function registerAccountTools(server: McpServer) {
         }
 
         // --- Single account mode ---
-        const result = await (helius as any).getAccountInfo(address, { encoding }).send();
+        const result = await (helius as any).getAccountInfo(address, { encoding });
         const account = result?.value;
 
         if (!account) {

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -439,9 +439,9 @@ export function registerAuthTools(server: McpServer) {
           );
         }
 
-        let signerResult: { secretKey: Uint8Array; walletAddress: string };
+        let signerData: { secretKey: Uint8Array; walletAddress: string };
         try {
-          signerResult = await loadSignerOrFail();
+          signerData = await loadSignerOrFail();
         } catch {
           return mcpError('No keypair found. Call `generateKeypair` first.');
         }
@@ -457,7 +457,7 @@ export function registerAuthTools(server: McpServer) {
         }
 
         const projectId = projects[0].id;
-        const result = await executeCheckout(signerResult.secretKey, jwt, {
+        const result = await executeCheckout(signerData.secretKey, jwt, {
           plan,
           period,
           refId: projectId,
@@ -628,9 +628,9 @@ export function registerAuthTools(server: McpServer) {
     },
     async ({ paymentIntentId }) => {
       try {
-        let renewalSigner: { secretKey: Uint8Array; walletAddress: string };
+        let signerData: { secretKey: Uint8Array; walletAddress: string };
         try {
-          renewalSigner = await loadSignerOrFail();
+          signerData = await loadSignerOrFail();
         } catch {
           return mcpError('No keypair found. Call `generateKeypair` first.');
         }
@@ -640,7 +640,7 @@ export function registerAuthTools(server: McpServer) {
           return mcpError('Not authenticated. Call `agenticSignup` or authenticate first.');
         }
 
-        const result = await executeRenewal(renewalSigner.secretKey, jwt, paymentIntentId, MCP_USER_AGENT);
+        const result = await executeRenewal(signerData.secretKey, jwt, paymentIntentId, MCP_USER_AGENT);
 
         if (result.status !== 'completed') {
           return mcpError(

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -14,9 +14,9 @@ import {
   setApiKey,
   hasApiKey,
   setSessionSecretKey,
-  getSessionSecretKey,
   setSessionWalletAddress,
   getSessionWalletAddress,
+  loadSignerOrFail,
 } from '../utils/helius.js';
 import { mcpText, mcpError, handleToolError } from '../utils/errors.js';
 import { fetchDoc, extractSections } from '../utils/docs.js';
@@ -273,25 +273,15 @@ export function registerAuthTools(server: McpServer) {
     },
     async ({ plan, period, email, firstName, lastName, couponCode }) => {
       try {
-        let secretKey = getSessionSecretKey();
-
-        // Fall back to disk keypair if no session key
-        if (!secretKey) {
-          secretKey = loadKeypairFromDisk();
-          if (secretKey) {
-            const walletKeypair = loadKeypair(secretKey);
-            const address = await getAddress(walletKeypair);
-            setSessionSecretKey(secretKey);
-            setSessionWalletAddress(address);
-          }
-        }
-
-        if (!secretKey) {
+        let signerData: { secretKey: Uint8Array; walletAddress: string };
+        try {
+          signerData = await loadSignerOrFail();
+        } catch {
           return mcpError('No signup keypair found. Call `generateKeypair` first to create a wallet, fund it, then call this tool.');
         }
 
         const result = await agenticSignup({
-          secretKey,
+          secretKey: signerData.secretKey,
           userAgent: MCP_USER_AGENT,
           plan,
           period,
@@ -449,17 +439,10 @@ export function registerAuthTools(server: McpServer) {
           );
         }
 
-        let secretKey = getSessionSecretKey();
-        if (!secretKey) {
-          secretKey = loadKeypairFromDisk();
-          if (secretKey) {
-            const walletKeypair = loadKeypair(secretKey);
-            const address = await getAddress(walletKeypair);
-            setSessionSecretKey(secretKey);
-            setSessionWalletAddress(address);
-          }
-        }
-        if (!secretKey) {
+        let signerResult: { secretKey: Uint8Array; walletAddress: string };
+        try {
+          signerResult = await loadSignerOrFail();
+        } catch {
           return mcpError('No keypair found. Call `generateKeypair` first.');
         }
 
@@ -474,7 +457,7 @@ export function registerAuthTools(server: McpServer) {
         }
 
         const projectId = projects[0].id;
-        const result = await executeCheckout(secretKey, jwt, {
+        const result = await executeCheckout(signerResult.secretKey, jwt, {
           plan,
           period,
           refId: projectId,
@@ -645,17 +628,10 @@ export function registerAuthTools(server: McpServer) {
     },
     async ({ paymentIntentId }) => {
       try {
-        let secretKey = getSessionSecretKey();
-        if (!secretKey) {
-          secretKey = loadKeypairFromDisk();
-          if (secretKey) {
-            const walletKeypair = loadKeypair(secretKey);
-            const address = await getAddress(walletKeypair);
-            setSessionSecretKey(secretKey);
-            setSessionWalletAddress(address);
-          }
-        }
-        if (!secretKey) {
+        let renewalSigner: { secretKey: Uint8Array; walletAddress: string };
+        try {
+          renewalSigner = await loadSignerOrFail();
+        } catch {
           return mcpError('No keypair found. Call `generateKeypair` first.');
         }
 
@@ -664,7 +640,7 @@ export function registerAuthTools(server: McpServer) {
           return mcpError('Not authenticated. Call `agenticSignup` or authenticate first.');
         }
 
-        const result = await executeRenewal(secretKey, jwt, paymentIntentId, MCP_USER_AGENT);
+        const result = await executeRenewal(renewalSigner.secretKey, jwt, paymentIntentId, MCP_USER_AGENT);
 
         if (result.status !== 'completed') {
           return mcpError(

--- a/helius-mcp/src/tools/blocks.ts
+++ b/helius-mcp/src/tools/blocks.ts
@@ -28,7 +28,7 @@ export function registerBlockTools(server: McpServer) {
           transactionDetails,
           maxSupportedTransactionVersion: 0,
           rewards: true
-        }).send();
+        });
 
         if (!block) {
           return mcpText(`**Block at Slot ${slot.toLocaleString()}**\n\nBlock not found. It may have been skipped or not yet confirmed.`);

--- a/helius-mcp/src/tools/index.ts
+++ b/helius-mcp/src/tools/index.ts
@@ -19,6 +19,7 @@ import { registerDocsTools } from './docs.js';
 import { registerGuideTools } from './guides.js';
 import { registerRecommendTools } from './recommend.js';
 import { registerSolanaKnowledgeTools } from './solana-knowledge.js';
+import { registerTransferTools } from './transfers.js';
 
 export function registerTools(server: McpServer) {
   registerAuthTools(server);
@@ -41,4 +42,5 @@ export function registerTools(server: McpServer) {
   registerGuideTools(server);
   registerRecommendTools(server);
   registerSolanaKnowledgeTools(server);
+  registerTransferTools(server);
 }

--- a/helius-mcp/src/tools/network.ts
+++ b/helius-mcp/src/tools/network.ts
@@ -16,10 +16,11 @@ export function registerNetworkTools(server: McpServer) {
         const helius = getHeliusClient();
 
         // Fire all requests in parallel — Kit returns bigint for numeric fields
+        // wrapAutoSend in the SDK already calls .send() on pending RPC requests
         const [epochInfo, supplyResult, version] = await Promise.all([
-          (helius as any).getEpochInfo().send(),
-          (helius as any).getSupply().send(),
-          (helius as any).getVersion().send(),
+          (helius as any).getEpochInfo(),
+          (helius as any).getSupply(),
+          (helius as any).getVersion(),
         ]);
 
         const lines = ['**Solana Network Status**', ''];

--- a/helius-mcp/src/tools/product-catalog.ts
+++ b/helius-mcp/src/tools/product-catalog.ts
@@ -113,6 +113,15 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     referenceFile: 'references/laserstream.md',
     description: 'Lowest-latency gRPC streaming with 24h historical replay for production indexers, trading infrastructure, and data pipelines. Subscribe to all transactions, accounts, blocks, or entries on mainnet.',
   },
+  'token-transfers': {
+    name: 'Token Transfers',
+    mcpTools: ['transferSol', 'transferToken'],
+    creditCostPerCall: '~3-13 credits + on-chain fees',
+    minimumPlan: 'free',
+    docKey: 'sender',
+    referenceFile: 'references/sender.md',
+    description: 'Send native SOL or SPL tokens from the MCP keypair to any Solana address. Uses Helius Sender for optimal landing rates. Requires a configured keypair.',
+  },
   'token-holders': {
     name: 'Token Holders',
     mcpTools: ['getTokenHolders'],

--- a/helius-mcp/src/tools/recommend.ts
+++ b/helius-mcp/src/tools/recommend.ts
@@ -27,6 +27,7 @@ export const KNOWN_TOOLS = new Set([
   'lookupHeliusDocs', 'listHeliusDocTopics', 'getHeliusCreditsInfo', 'getRateLimitInfo',
   'troubleshootError', 'getSenderInfo', 'getWebhookGuide', 'getLatencyComparison', 'getPumpFunGuide',
   'recommendStack',
+  'transferSol', 'transferToken',
 ]);
 
 // ─── Plan Ranking ───

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -567,7 +567,7 @@ export function registerTransactionTools(server: McpServer) {
             if (until) rpcParams.until = until;
 
             // Kit returns bigint for slot/blockTime fields
-            const sigs = await (helius as any).getSignaturesForAddress(address, rpcParams).send();
+            const sigs = await (helius as any).getSignaturesForAddress(address, rpcParams);
 
             if (!sigs || sigs.length === 0) {
               return mcpText(`**Signatures for ${formatAddress(address)}**\n\nNo signatures found.`);

--- a/helius-mcp/src/tools/transfers.ts
+++ b/helius-mcp/src/tools/transfers.ts
@@ -56,6 +56,20 @@ export function registerTransferTools(server: McpServer) {
         // Convert SOL to lamports
         const lamports = BigInt(Math.round(amount * 1_000_000_000));
 
+        // Pre-flight balance check
+        const helius = getHeliusClient();
+        const balanceResult = await helius.getBalance(signerData.walletAddress);
+        const balanceLamports = BigInt(balanceResult.value);
+        // Reserve ~0.005 SOL for tx fees (priority fee + rent if needed)
+        const reserveLamports = 5_000_000n;
+        if (balanceLamports < lamports + reserveLamports) {
+          const available = Number(balanceLamports) / 1_000_000_000;
+          return mcpError(
+            `Insufficient SOL balance. You have ${available} SOL but need ${amount} SOL plus ~0.005 SOL for transaction fees.\n\n` +
+            `Wallet: \`${signerData.walletAddress}\``
+          );
+        }
+
         // Create signer from keypair bytes
         const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
 
@@ -67,7 +81,6 @@ export function registerTransferTools(server: McpServer) {
         });
 
         // Send via Helius Sender
-        const helius = getHeliusClient();
         const signature = await helius.tx.sendTransactionWithSender({
           signers: [signer],
           instructions: [ix],
@@ -178,6 +191,22 @@ export function registerTransferTools(server: McpServer) {
           mint,
           tokenProgram: TOKEN_PROGRAM_ADDRESS,
         });
+
+        // Pre-flight token balance check
+        try {
+          const tokenBalance = await helius.getTokenAccountBalance(senderAta);
+          const currentRaw = BigInt(tokenBalance.value.amount);
+          if (currentRaw < rawAmount) {
+            const currentHuman = Number(currentRaw) / 10 ** decimals;
+            return mcpError(
+              `Insufficient ${tokenSymbol || tokenName} balance. You have ${currentHuman} but are trying to send ${amount}.\n\n` +
+              `Wallet: \`${signerData.walletAddress}\`\n` +
+              `Mint: \`${mintAddress}\``
+            );
+          }
+        } catch {
+          // Token account may not exist yet — let the on-chain error handle it
+        }
 
         // Build instructions: idempotent ATA creation + transfer
         const createAtaIx = getCreateAssociatedTokenIdempotentInstruction({

--- a/helius-mcp/src/tools/transfers.ts
+++ b/helius-mcp/src/tools/transfers.ts
@@ -8,33 +8,11 @@ import {
   getTransferCheckedInstruction,
   TOKEN_PROGRAM_ADDRESS,
 } from '@solana-program/token';
-import { getHeliusClient, hasApiKey, getSessionSecretKey, setSessionSecretKey, getSessionWalletAddress, setSessionWalletAddress } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey, loadSignerOrFail } from '../utils/helius.js';
 import { mcpText, mcpError, handleToolError, isValidAddressFormat } from '../utils/errors.js';
 import { noApiKeyResponse } from './shared.js';
-import { loadKeypairFromDisk } from '../utils/config.js';
-import { loadKeypair } from 'helius-sdk/auth/loadKeypair';
-import { getAddress } from 'helius-sdk/auth/getAddress';
 
 const TOKEN_2022_PROGRAM_ID = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb';
-
-// ── Helper: load signer keypair from session or disk ──
-
-async function loadSignerOrFail(): Promise<{ secretKey: Uint8Array; walletAddress: string }> {
-  let secretKey = getSessionSecretKey();
-  if (!secretKey) {
-    secretKey = loadKeypairFromDisk();
-    if (secretKey) {
-      const walletKeypair = loadKeypair(secretKey);
-      const addr = await getAddress(walletKeypair);
-      setSessionSecretKey(secretKey);
-      setSessionWalletAddress(addr);
-    }
-  }
-  if (!secretKey) {
-    throw new Error('NO_KEYPAIR');
-  }
-  return { secretKey, walletAddress: getSessionWalletAddress()! };
-}
 
 // ── Tool Registration ──
 

--- a/helius-mcp/src/tools/transfers.ts
+++ b/helius-mcp/src/tools/transfers.ts
@@ -1,0 +1,247 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { createKeyPairSignerFromBytes, address } from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getTransferCheckedInstruction,
+  TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
+import { getHeliusClient, hasApiKey, getSessionSecretKey, setSessionSecretKey, getSessionWalletAddress, setSessionWalletAddress } from '../utils/helius.js';
+import { mcpText, mcpError, handleToolError, isValidAddressFormat } from '../utils/errors.js';
+import { noApiKeyResponse } from './shared.js';
+import { loadKeypairFromDisk } from '../utils/config.js';
+import { loadKeypair } from 'helius-sdk/auth/loadKeypair';
+import { getAddress } from 'helius-sdk/auth/getAddress';
+
+const TOKEN_2022_PROGRAM_ID = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb';
+
+// ── Helper: load signer keypair from session or disk ──
+
+async function loadSignerOrFail(): Promise<{ secretKey: Uint8Array; walletAddress: string }> {
+  let secretKey = getSessionSecretKey();
+  if (!secretKey) {
+    secretKey = loadKeypairFromDisk();
+    if (secretKey) {
+      const walletKeypair = loadKeypair(secretKey);
+      const addr = await getAddress(walletKeypair);
+      setSessionSecretKey(secretKey);
+      setSessionWalletAddress(addr);
+    }
+  }
+  if (!secretKey) {
+    throw new Error('NO_KEYPAIR');
+  }
+  return { secretKey, walletAddress: getSessionWalletAddress()! };
+}
+
+// ── Tool Registration ──
+
+export function registerTransferTools(server: McpServer) {
+
+  // ── Transfer SOL ──
+
+  server.tool(
+    'transferSol',
+    'BEST FOR: sending native SOL from your MCP wallet to another address. ' +
+    'PREFER transferToken for SPL tokens. ' +
+    'Transfers native SOL using Helius Sender for optimal landing rates. ' +
+    'Requires a configured keypair (call generateKeypair if needed). ' +
+    'This is an irreversible on-chain transaction. ' +
+    'Credit cost: ~3 credits (CU simulation + priority fee estimate + send).',
+    {
+      recipientAddress: z.string().describe('Recipient Solana wallet address (base58 encoded)'),
+      amount: z.number().positive().describe('Amount of SOL to send (e.g., 0.5 for half a SOL)'),
+    },
+    async ({ recipientAddress, amount }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
+      try {
+        // Load keypair
+        let signerData: { secretKey: Uint8Array; walletAddress: string };
+        try {
+          signerData = await loadSignerOrFail();
+        } catch {
+          return mcpError(
+            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before sending.'
+          );
+        }
+
+        // Validate recipient address
+        if (!isValidAddressFormat(recipientAddress)) {
+          return mcpError(
+            `Invalid recipient address "${recipientAddress}". Expected a valid Solana address (32-44 base58 characters).`
+          );
+        }
+
+        // Convert SOL to lamports
+        const lamports = BigInt(Math.round(amount * 1_000_000_000));
+
+        // Create signer from keypair bytes
+        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
+
+        // Build transfer instruction
+        const ix = getTransferSolInstruction({
+          source: signer,
+          destination: address(recipientAddress),
+          amount: lamports,
+        });
+
+        // Send via Helius Sender
+        const helius = getHeliusClient();
+        const signature = await helius.tx.sendTransactionWithSender({
+          signers: [signer],
+          instructions: [ix],
+          region: 'Default',
+        });
+
+        return mcpText(
+          `**SOL Transfer Sent**\n\n` +
+          `- **From:** \`${signerData.walletAddress}\`\n` +
+          `- **To:** \`${recipientAddress}\`\n` +
+          `- **Amount:** ${amount} SOL\n` +
+          `- **Signature:** \`${signature}\`\n` +
+          `- **Explorer:** https://solscan.io/tx/${signature}`
+        );
+      } catch (err) {
+        return handleToolError(err, 'Error sending SOL transfer');
+      }
+    }
+  );
+
+  // ── Transfer SPL Token ──
+
+  server.tool(
+    'transferToken',
+    'BEST FOR: sending SPL tokens (USDC, BONK, JUP, etc.) from your MCP wallet to another address. ' +
+    'PREFER transferSol for native SOL. ' +
+    'Automatically creates recipient token account if needed. ' +
+    'Uses Helius Sender for optimal landing rates. ' +
+    'Requires a configured keypair. ' +
+    'This is an irreversible on-chain transaction. ' +
+    'Credit cost: ~13 credits (10 DAS for mint info + ~3 for CU simulation, priority fee, send).',
+    {
+      recipientAddress: z.string().describe('Recipient Solana wallet address (base58 encoded)'),
+      mintAddress: z.string().describe('Token mint address (base58 encoded, e.g., EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v for USDC)'),
+      amount: z.number().positive().describe('Amount of tokens to send in human-readable units (e.g., 10 for 10 USDC)'),
+    },
+    async ({ recipientAddress, mintAddress, amount }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
+      try {
+        // Load keypair
+        let signerData: { secretKey: Uint8Array; walletAddress: string };
+        try {
+          signerData = await loadSignerOrFail();
+        } catch {
+          return mcpError(
+            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before sending.'
+          );
+        }
+
+        // Validate addresses
+        if (!isValidAddressFormat(recipientAddress)) {
+          return mcpError(
+            `Invalid recipient address "${recipientAddress}". Expected a valid Solana address (32-44 base58 characters).`
+          );
+        }
+        if (!isValidAddressFormat(mintAddress)) {
+          return mcpError(
+            `Invalid mint address "${mintAddress}". Expected a valid Solana address (32-44 base58 characters).`
+          );
+        }
+
+        // Fetch token metadata via DAS to get decimals and token program
+        const helius = getHeliusClient();
+        let asset: any;
+        try {
+          asset = await helius.getAsset({ id: mintAddress });
+        } catch {
+          return mcpError(
+            `Could not fetch token metadata for mint \`${mintAddress}\`. Verify the mint address is correct.`
+          );
+        }
+
+        if (!asset?.token_info?.decimals && asset?.token_info?.decimals !== 0) {
+          return mcpError(
+            `Mint \`${mintAddress}\` does not appear to be a fungible token (no decimals info found). Use \`getAsset\` to inspect it.`
+          );
+        }
+
+        const decimals: number = asset.token_info.decimals;
+        const tokenProgram: string | undefined = asset.token_info.token_program;
+        const tokenName: string = asset.content?.metadata?.name || 'Unknown Token';
+        const tokenSymbol: string = asset.content?.metadata?.symbol || '';
+
+        // Token-2022 check
+        if (tokenProgram === TOKEN_2022_PROGRAM_ID) {
+          return mcpError(
+            `Token-2022 transfers are not yet supported. This token (\`${tokenName}\`${tokenSymbol ? ` / ${tokenSymbol}` : ''}) uses the Token-2022 program. Standard SPL Token transfers are supported.`
+          );
+        }
+
+        // Convert human-readable amount to raw amount
+        const rawAmount = BigInt(Math.round(amount * 10 ** decimals));
+
+        // Create signer from keypair bytes
+        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
+        const mint = address(mintAddress);
+        const recipient = address(recipientAddress);
+
+        // Derive ATAs
+        const [senderAta] = await findAssociatedTokenPda({
+          owner: signer.address,
+          mint,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        });
+        const [recipientAta] = await findAssociatedTokenPda({
+          owner: recipient,
+          mint,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        });
+
+        // Build instructions: idempotent ATA creation + transfer
+        const createAtaIx = getCreateAssociatedTokenIdempotentInstruction({
+          payer: signer,
+          ata: recipientAta,
+          owner: recipient,
+          mint,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        });
+
+        const transferIx = getTransferCheckedInstruction({
+          source: senderAta,
+          mint,
+          destination: recipientAta,
+          authority: signer,
+          amount: rawAmount,
+          decimals,
+        });
+
+        // Send via Helius Sender
+        const signature = await helius.tx.sendTransactionWithSender({
+          signers: [signer],
+          instructions: [createAtaIx, transferIx],
+          region: 'Default',
+        });
+
+        const displayName = tokenSymbol
+          ? `${amount} ${tokenSymbol} (${tokenName})`
+          : `${amount} ${tokenName}`;
+
+        return mcpText(
+          `**Token Transfer Sent**\n\n` +
+          `- **From:** \`${signerData.walletAddress}\`\n` +
+          `- **To:** \`${recipientAddress}\`\n` +
+          `- **Amount:** ${displayName}\n` +
+          `- **Mint:** \`${mintAddress}\`\n` +
+          `- **Signature:** \`${signature}\`\n` +
+          `- **Explorer:** https://solscan.io/tx/${signature}`
+        );
+      } catch (err) {
+        return handleToolError(err, 'Error sending token transfer');
+      }
+    }
+  );
+}

--- a/helius-mcp/src/tools/transfers.ts
+++ b/helius-mcp/src/tools/transfers.ts
@@ -4,6 +4,7 @@ import { createKeyPairSignerFromBytes, address } from '@solana/kit';
 import { getTransferSolInstruction } from '@solana-program/system';
 import {
   findAssociatedTokenPda,
+  getCloseAccountInstruction,
   getCreateAssociatedTokenIdempotentInstruction,
   getTransferCheckedInstruction,
   TOKEN_PROGRAM_ADDRESS,
@@ -27,12 +28,14 @@ export function registerTransferTools(server: McpServer) {
     'Transfers native SOL using Helius Sender for optimal landing rates. ' +
     'Requires a configured keypair (call generateKeypair if needed). ' +
     'This is an irreversible on-chain transaction. ' +
+    'Set sendMax to true to drain the entire SOL balance (sends balance minus transaction fees). ' +
     'Credit cost: ~3 credits (CU simulation + priority fee estimate + send).',
     {
       recipientAddress: z.string().describe('Recipient Solana wallet address (base58 encoded)'),
-      amount: z.number().positive().describe('Amount of SOL to send (e.g., 0.5 for half a SOL)'),
+      amount: z.number().positive().optional().describe('Amount of SOL to send (e.g., 0.5 for half a SOL). Required unless sendMax is true.'),
+      sendMax: z.boolean().optional().default(false).describe('Send the maximum possible amount (entire balance minus transaction fees). When true, amount is ignored.'),
     },
-    async ({ recipientAddress, amount }) => {
+    async ({ recipientAddress, amount, sendMax }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
@@ -53,21 +56,43 @@ export function registerTransferTools(server: McpServer) {
           );
         }
 
-        // Convert SOL to lamports
-        const lamports = BigInt(Math.round(amount * 1_000_000_000));
-
-        // Pre-flight balance check
         const helius = getHeliusClient();
         const balanceResult = await helius.getBalance(signerData.walletAddress);
         const balanceLamports = BigInt(balanceResult.value);
-        // Reserve ~0.005 SOL for tx fees (priority fee + rent if needed)
-        const reserveLamports = 5_000_000n;
-        if (balanceLamports < lamports + reserveLamports) {
-          const available = Number(balanceLamports) / 1_000_000_000;
-          return mcpError(
-            `Insufficient SOL balance. You have ${available} SOL but need ${amount} SOL plus ~0.005 SOL for transaction fees.\n\n` +
-            `Wallet: \`${signerData.walletAddress}\``
-          );
+
+        let lamports: bigint;
+        let sendAmount: number;
+
+        if (sendMax) {
+          // The account must reach exactly 0 lamports — any non-zero balance below the
+          // rent-exempt minimum (~0.00089 SOL) is rejected by the runtime. We cap the
+          // priority fee at 0 so the total fee is deterministically 5000 lamports
+          // (the base fee per signature), and transfer balance - 5000 to drain to zero.
+          const txFee = 5000n;
+          lamports = balanceLamports - txFee;
+          if (lamports <= 0n) {
+            const available = Number(balanceLamports) / 1_000_000_000;
+            return mcpError(
+              `Balance too low to cover the transaction fee. You have ${available} SOL.\n\n` +
+              `Wallet: \`${signerData.walletAddress}\``
+            );
+          }
+          sendAmount = Number(lamports) / 1_000_000_000;
+        } else {
+          if (amount === undefined) {
+            return mcpError('Either `amount` must be specified or `sendMax` must be true.');
+          }
+          lamports = BigInt(Math.round(amount * 1_000_000_000));
+          sendAmount = amount;
+          // Reserve ~0.005 SOL for tx fees (priority fee + sender tip)
+          const reserveLamports = 5_000_000n;
+          if (balanceLamports < lamports + reserveLamports) {
+            const available = Number(balanceLamports) / 1_000_000_000;
+            return mcpError(
+              `Insufficient SOL balance. You have ${available} SOL but need ${sendAmount} SOL plus ~0.005 SOL for transaction fees.\n\n` +
+              `Wallet: \`${signerData.walletAddress}\``
+            );
+          }
         }
 
         // Create signer from keypair bytes
@@ -80,20 +105,31 @@ export function registerTransferTools(server: McpServer) {
           amount: lamports,
         });
 
-        // Send via Helius Sender
-        const signature = await helius.tx.sendTransactionWithSender({
-          signers: [signer],
-          instructions: [ix],
-          region: 'Default',
-        });
+        let signature: string;
+        if (sendMax) {
+          // Use sendSmartTransaction (no sender tip) with priorityFeeCap=0 so the
+          // total fee is exactly 5000 lamports, draining the account to zero.
+          signature = await helius.tx.sendSmartTransaction({
+            signers: [signer],
+            instructions: [ix],
+            priorityFeeCap: 0,
+          });
+        } else {
+          // Use Helius Sender for optimal landing rates
+          signature = await helius.tx.sendTransactionWithSender({
+            signers: [signer],
+            instructions: [ix],
+            region: 'Default',
+          });
+        }
 
         return mcpText(
           `**SOL Transfer Sent**\n\n` +
           `- **From:** \`${signerData.walletAddress}\`\n` +
           `- **To:** \`${recipientAddress}\`\n` +
-          `- **Amount:** ${amount} SOL\n` +
+          `- **Amount:** ${sendAmount} SOL${sendMax ? ' (max)' : ''}\n` +
           `- **Signature:** \`${signature}\`\n` +
-          `- **Explorer:** https://solscan.io/tx/${signature}`
+          `- **Explorer:** https://orbmarkets.io/tx/${signature}`
         );
       } catch (err) {
         return handleToolError(err, 'Error sending SOL transfer');
@@ -111,13 +147,15 @@ export function registerTransferTools(server: McpServer) {
     'Uses Helius Sender for optimal landing rates. ' +
     'Requires a configured keypair. ' +
     'This is an irreversible on-chain transaction. ' +
+    'Set sendMax to true to send the entire token balance and close the sender token account (reclaims rent). ' +
     'Credit cost: ~13 credits (10 DAS for mint info + ~3 for CU simulation, priority fee, send).',
     {
       recipientAddress: z.string().describe('Recipient Solana wallet address (base58 encoded)'),
       mintAddress: z.string().describe('Token mint address (base58 encoded, e.g., EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v for USDC)'),
-      amount: z.number().positive().describe('Amount of tokens to send in human-readable units (e.g., 10 for 10 USDC)'),
+      amount: z.number().positive().optional().describe('Amount of tokens to send in human-readable units (e.g., 10 for 10 USDC). Required unless sendMax is true.'),
+      sendMax: z.boolean().optional().default(false).describe('Send the entire token balance and close the sender token account to reclaim rent. When true, amount is ignored.'),
     },
-    async ({ recipientAddress, mintAddress, amount }) => {
+    async ({ recipientAddress, mintAddress, amount, sendMax }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
@@ -172,9 +210,6 @@ export function registerTransferTools(server: McpServer) {
           );
         }
 
-        // Convert human-readable amount to raw amount
-        const rawAmount = BigInt(Math.round(amount * 10 ** decimals));
-
         // Create signer from keypair bytes
         const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
         const mint = address(mintAddress);
@@ -192,20 +227,52 @@ export function registerTransferTools(server: McpServer) {
           tokenProgram: TOKEN_PROGRAM_ADDRESS,
         });
 
-        // Pre-flight token balance check
-        try {
-          const tokenBalance = await helius.getTokenAccountBalance(senderAta);
-          const currentRaw = BigInt(tokenBalance.value.amount);
-          if (currentRaw < rawAmount) {
-            const currentHuman = Number(currentRaw) / 10 ** decimals;
+        let rawAmount: bigint;
+        let sendAmount: number;
+
+        if (sendMax) {
+          // Fetch full token balance for max send
+          let tokenBalance;
+          try {
+            tokenBalance = await helius.getTokenAccountBalance(senderAta);
+          } catch {
             return mcpError(
-              `Insufficient ${tokenSymbol || tokenName} balance. You have ${currentHuman} but are trying to send ${amount}.\n\n` +
+              `No token account found for ${tokenSymbol || tokenName}. You may not hold this token.\n\n` +
               `Wallet: \`${signerData.walletAddress}\`\n` +
               `Mint: \`${mintAddress}\``
             );
           }
-        } catch {
-          // Token account may not exist yet — let the on-chain error handle it
+          rawAmount = BigInt(tokenBalance.value.amount);
+          if (rawAmount === 0n) {
+            return mcpError(
+              `${tokenSymbol || tokenName} balance is 0. Nothing to send.\n\n` +
+              `Wallet: \`${signerData.walletAddress}\`\n` +
+              `Mint: \`${mintAddress}\``
+            );
+          }
+          sendAmount = Number(rawAmount) / 10 ** decimals;
+        } else {
+          if (amount === undefined) {
+            return mcpError('Either `amount` must be specified or `sendMax` must be true.');
+          }
+          rawAmount = BigInt(Math.round(amount * 10 ** decimals));
+          sendAmount = amount;
+
+          // Pre-flight token balance check
+          try {
+            const tokenBalance = await helius.getTokenAccountBalance(senderAta);
+            const currentRaw = BigInt(tokenBalance.value.amount);
+            if (currentRaw < rawAmount) {
+              const currentHuman = Number(currentRaw) / 10 ** decimals;
+              return mcpError(
+                `Insufficient ${tokenSymbol || tokenName} balance. You have ${currentHuman} but are trying to send ${sendAmount}.\n\n` +
+                `Wallet: \`${signerData.walletAddress}\`\n` +
+                `Mint: \`${mintAddress}\``
+              );
+            }
+          } catch {
+            // Token account may not exist yet — let the on-chain error handle it
+          }
         }
 
         // Build instructions: idempotent ATA creation + transfer
@@ -226,25 +293,36 @@ export function registerTransferTools(server: McpServer) {
           decimals,
         });
 
+        // When sending max, close the sender's ATA to reclaim rent
+        const closeIx = sendMax
+          ? getCloseAccountInstruction({
+              account: senderAta,
+              destination: signer.address,
+              owner: signer,
+            })
+          : undefined;
+
         // Send via Helius Sender
         const signature = await helius.tx.sendTransactionWithSender({
           signers: [signer],
-          instructions: [createAtaIx, transferIx],
+          instructions: closeIx
+            ? [createAtaIx, transferIx, closeIx]
+            : [createAtaIx, transferIx],
           region: 'Default',
         });
 
         const displayName = tokenSymbol
-          ? `${amount} ${tokenSymbol} (${tokenName})`
-          : `${amount} ${tokenName}`;
+          ? `${sendAmount} ${tokenSymbol} (${tokenName})`
+          : `${sendAmount} ${tokenName}`;
 
         return mcpText(
           `**Token Transfer Sent**\n\n` +
           `- **From:** \`${signerData.walletAddress}\`\n` +
           `- **To:** \`${recipientAddress}\`\n` +
-          `- **Amount:** ${displayName}\n` +
+          `- **Amount:** ${displayName}${sendMax ? ' (max)' : ''}\n` +
           `- **Mint:** \`${mintAddress}\`\n` +
           `- **Signature:** \`${signature}\`\n` +
-          `- **Explorer:** https://solscan.io/tx/${signature}`
+          `- **Explorer:** https://orbmarkets.io/tx/${signature}`
         );
       } catch (err) {
         return handleToolError(err, 'Error sending token transfer');

--- a/helius-mcp/src/tools/transfers.ts
+++ b/helius-mcp/src/tools/transfers.ts
@@ -64,6 +64,12 @@ export function registerTransferTools(server: McpServer) {
         let sendAmount: number;
 
         if (sendMax) {
+          // WARNING: This assumes sendSmartTransaction with priorityFeeCap=0 produces a
+          // single-signer transaction whose only lamport cost is the 5000-lamport base fee.
+          // If the SDK ever adds additional signers, compute budget instructions, or other
+          // lamport-consuming operations, this will under-transfer and leave a dust balance
+          // (or over-transfer and fail). Verify this invariant after any SDK upgrade.
+          //
           // The account must reach exactly 0 lamports — any non-zero balance below the
           // rent-exempt minimum (~0.00089 SOL) is rejected by the runtime. We cap the
           // priority fee at 0 so the total fee is deterministically 5000 lamports

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -106,7 +106,15 @@ export async function loadSignerOrFail(): Promise<{ secretKey: Uint8Array; walle
   if (!secretKey) {
     throw new Error('NO_KEYPAIR');
   }
-  return { secretKey, walletAddress: getSessionWalletAddress()! };
+
+  // Derive the address from the key if not already cached in session
+  let walletAddress = getSessionWalletAddress();
+  if (!walletAddress) {
+    const walletKeypair = loadKeypair(secretKey);
+    walletAddress = await getAddress(walletKeypair);
+    setSessionWalletAddress(walletAddress);
+  }
+  return { secretKey, walletAddress };
 }
 
 export async function restRequest(endpoint: string, options: RequestInit = {}): Promise<any> {

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -82,6 +82,33 @@ export function getLaserstreamUrl(region?: 'ewr' | 'pitt' | 'slc' | 'lax' | 'lon
   return `https://laserstream-mainnet-${selectedRegion}.helius-rpc.com`;
 }
 
+/**
+ * Load the signer keypair from session or disk.
+ * Returns the raw secret key bytes and the wallet address string.
+ * Throws with message 'NO_KEYPAIR' if no keypair is available.
+ */
+export async function loadSignerOrFail(): Promise<{ secretKey: Uint8Array; walletAddress: string }> {
+  // Lazy-import to avoid circular deps (config → helius → config)
+  const { loadKeypairFromDisk } = await import('./config.js');
+  const { loadKeypair } = await import('helius-sdk/auth/loadKeypair');
+  const { getAddress } = await import('helius-sdk/auth/getAddress');
+
+  let secretKey = getSessionSecretKey();
+  if (!secretKey) {
+    secretKey = loadKeypairFromDisk();
+    if (secretKey) {
+      const walletKeypair = loadKeypair(secretKey);
+      const addr = await getAddress(walletKeypair);
+      setSessionSecretKey(secretKey);
+      setSessionWalletAddress(addr);
+    }
+  }
+  if (!secretKey) {
+    throw new Error('NO_KEYPAIR');
+  }
+  return { secretKey, walletAddress: getSessionWalletAddress()! };
+}
+
 export async function restRequest(endpoint: string, options: RequestInit = {}): Promise<any> {
   const apiKey = getApiKey();
   const separator = endpoint.includes('?') ? '&' : '?';

--- a/helius-mcp/tests/tools.test.ts
+++ b/helius-mcp/tests/tools.test.ts
@@ -30,8 +30,8 @@ describe('Helius MCP Tools', () => {
     registerTools(mockServer);
   });
 
-  it('registers 46 tools', () => {
-    expect(tools.size).toBe(46);
+  it('registers 48 tools', () => {
+    expect(tools.size).toBe(48);
   });
 
   it('all tools have descriptions', () => {
@@ -68,6 +68,8 @@ describe('Helius MCP Tools', () => {
       'getRateLimitInfo', 'getSenderInfo', 'troubleshootError',
       // Docs
       'lookupHeliusDocs', 'getHeliusCreditsInfo',
+      // Transfers
+      'transferSol', 'transferToken',
     ];
 
     for (const name of expected) {

--- a/helius-plugin/skills/build/SKILL.md
+++ b/helius-plugin/skills/build/SKILL.md
@@ -64,9 +64,11 @@ These intents overlap across multiple files. Route them correctly:
 
 ### Transaction Sending & Swaps
 **Read**: `references/sender.md`, `references/priority-fees.md`
-**MCP tools**: `getPriorityFeeEstimate`, `getSenderInfo`, `parseTransactions`
+**MCP tools**: `getPriorityFeeEstimate`, `getSenderInfo`, `parseTransactions`, `transferSol`, `transferToken`
 
 Use this when the user wants to:
+- Send SOL to another wallet
+- Transfer SPL tokens (USDC, BONK, JUP, etc.)
 - Send transactions with optimal landing rates
 - Integrate with DFlow, Jupiter, Titan, or other swap APIs
 - Build trading bots, swap interfaces, or trading terminals

--- a/helius-skills/helius/SKILL.md
+++ b/helius-skills/helius/SKILL.md
@@ -65,9 +65,11 @@ These intents overlap across multiple files. Route them correctly:
 
 ### Transaction Sending & Swaps
 **Read**: `references/sender.md`, `references/priority-fees.md`
-**MCP tools**: `getPriorityFeeEstimate`, `getSenderInfo`, `parseTransactions`
+**MCP tools**: `getPriorityFeeEstimate`, `getSenderInfo`, `parseTransactions`, `transferSol`, `transferToken`
 
 Use this when the user wants to:
+- Send SOL to another wallet
+- Transfer SPL tokens (USDC, BONK, JUP, etc.)
 - Send transactions with optimal landing rates
 - Integrate with DFlow, Jupiter, Titan, or other swap APIs
 - Build trading bots, swap interfaces, or trading terminals


### PR DESCRIPTION
## Summary

- Adds two new MCP tools — `transferSol` and `transferToken` — for sending native SOL and SPL tokens directly through the MCP server
- Both tools use Helius Sender (`sendTransactionWithSender`) for optimal transaction landing rates via SWQoS routing
- `transferToken` auto-resolves decimals from DAS, creates recipient ATA idempotently, and blocks Token-2022 tokens with a clear error message
- Adds `sendMax` support to both tools for draining full balances
- Fixes redundant `.send()` calls on RPC methods that broke `getNetworkStatus`, `getBlock`, `getAccountInfo`, and `getSignaturesForAddress`

## Changes

**New file:**
- `helius-mcp/src/tools/transfers.ts` — `registerTransferTools()` with `transferSol`, `transferToken`

**Modified files:**
- `package.json` — Added `@solana/kit`, `@solana-program/system`, `@solana-program/token` dependencies
- `src/tools/index.ts` — Registers transfer tools
- `src/tools/recommend.ts` — Added to `KNOWN_TOOLS` set
- `src/tools/product-catalog.ts` — New `'token-transfers'` catalog entry
- `src/index.ts` — Added "Transfers / Sending" section to server instructions
- `src/utils/helius.ts` — Extracted `loadSignerOrFail()` helper
- `tests/tools.test.ts` — Updated tool count (46 → 48) and expected tools list
- `README.md` — Added "Transfers (2)" line
- `helius-skills/helius/SKILL.md` + `helius-plugin/skills/build/SKILL.md` — Updated routing section

**`sendMax` support:**
- `transferSol` with `sendMax: true` drains the wallet to exactly 0 lamports. Uses `sendSmartTransaction` (no sender tip) with `priorityFeeCap: 0` so the fee is deterministically 5000 lamports (base fee). This avoids the rent-exempt minimum issue — Solana rejects non-zero balances below ~890,880 lamports, so the account must reach exactly 0.
- `transferToken` with `sendMax: true` sends the full token balance and appends a `closeAccount` instruction to close the sender's ATA and reclaim ~0.002 SOL of rent.

**Explorer links:**
- Switched from `solscan.io` to `orbmarkets.io` for transaction explorer links in both tools.

**Bug fix:**
- `src/tools/network.ts`, `blocks.ts`, `accounts.ts`, `transactions.ts` — Removed redundant `.send()` calls. The SDK's `wrapAutoSend` proxy already auto-sends pending RPC requests, so calling `.send()` again on the resolved result threw "is not a function" errors.

## Test plan

- [x] `pnpm build` — TypeScript compilation succeeds
- [x] `pnpm test` — Build + catalog validation passes (13 products)
- [ ] Manual test: `transferSol` with specific amount
- [ ] Manual test: `transferSol` with `sendMax: true` (drains wallet to 0)
- [ ] Manual test: `transferToken` with specific amount
- [ ] Manual test: `transferToken` with `sendMax: true` (full balance + ATA close)
- [ ] Test Token-2022 detection returns clear error
- [ ] Test error paths: no keypair, invalid address, invalid mint, missing amount without sendMax
- [ ] Verify `getNetworkStatus`, `getBlock`, `getAccountInfo`, `getTransactionHistory` (signatures mode) work after `.send()` removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)