### PR TITLE
feat(MCP): Prep For 1.0.0 Release

### DIFF
--- a/helius-mcp/LICENSE
+++ b/helius-mcp/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Helius Labs
+Copyright (c) 2026 Helius Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/helius-mcp/README.md
+++ b/helius-mcp/README.md
@@ -44,6 +44,8 @@ The MCP includes a fully autonomous signup flow — no browser needed:
 3. Call `checkSignupBalance` to verify funds arrived
 4. Call `agenticSignup` to create your account — API key is configured automatically
 
+> **Paid plans (developer/business/professional):** `agenticSignup` and `upgradePlan` require `email`, `firstName`, and `lastName`. Basic plan does not.
+
 Or do the same from the terminal:
 
 ```bash

--- a/helius-mcp/README.md
+++ b/helius-mcp/README.md
@@ -6,6 +6,21 @@ MCP server for Helius — Solana blockchain data access for AI assistants, provi
 
 ### 1. Add the MCP server
 
+Add to your MCP host's config (works with Claude, Cursor, Windsurf, and any MCP-compatible client):
+
+```json
+{
+  "mcpServers": {
+    "helius": {
+      "command": "npx",
+      "args": ["helius-mcp@latest"]
+    }
+  }
+}
+```
+
+Or if you're using Claude Code:
+
 ```bash
 claude mcp add helius npx helius-mcp@latest
 ```
@@ -18,7 +33,7 @@ claude mcp add helius npx helius-mcp@latest
 export HELIUS_API_KEY=your-api-key
 ```
 
-Or set it inside Claude by calling the `setHeliusApiKey` tool.
+Or set it from your AI assistant by calling the `setHeliusApiKey` tool.
 
 **If you need a new account:**
 
@@ -48,17 +63,19 @@ Ask questions in plain English — the right tool is selected automatically:
 
 ## Tools
 
-**Onboarding:** getStarted, setHeliusApiKey, generateKeypair, checkSignupBalance, agenticSignup, getAccountStatus
+**Onboarding (6):** getStarted, setHeliusApiKey, generateKeypair, checkSignupBalance, agenticSignup, getAccountStatus
 
-**DAS API (12):** getAsset, getAssetBatch, getAssetsByOwner, getAssetsByGroup, getAssetsByCreator, getAssetsByAuthority, searchAssets, getAssetProof, getAssetProofBatch, getSignaturesForAsset, getNftEditions, getTokenAccounts
+**DAS API (9):** getAsset (single + batch), getAssetsByOwner, getAssetsByGroup, searchAssets (routes getAssetsByCreator / getAssetsByAuthority), getAssetProof, getAssetProofBatch, getSignaturesForAsset, getNftEditions, getTokenAccounts
 
-**RPC (4):** getBalance, getAccountInfo, getMultipleAccounts, getSignaturesForAddress
+**RPC (5):** getBalance, getTokenBalances, getAccountInfo (single + batch), getNetworkStatus, getBlock
 
-**Transactions (1):** parseTransactions
+**Transactions (2):** parseTransactions, getTransactionHistory
 
 **Transfers (2):** transferSol, transferToken
 
 **Priority Fees (1):** getPriorityFeeEstimate
+
+**Tokens (2):** getTokenHolders, getProgramAccounts
 
 **Webhooks (5):** getAllWebhooks, getWebhookByID, createWebhook, updateWebhook, deleteWebhook
 
@@ -68,9 +85,11 @@ Ask questions in plain English — the right tool is selected automatically:
 
 **Wallet (6):** getWalletIdentity, batchWalletIdentity, getWalletBalances, getWalletHistory, getWalletTransfers, getWalletFundedBy
 
-**Plans & Billing:** getHeliusPlanInfo, compareHeliusPlans, previewUpgrade, upgradePlan, payRenewal
+**Plans & Billing (5):** getHeliusPlanInfo, compareHeliusPlans, previewUpgrade, upgradePlan, payRenewal
 
-**Docs & Guides:** lookupHeliusDocs, listHeliusDocTopics, getHeliusCreditsInfo, getRateLimitInfo, troubleshootError, getSenderInfo, getWebhookGuide, getLatencyComparison, getPumpFunGuide
+**Docs & Guides (10):** lookupHeliusDocs, listHeliusDocTopics, getHeliusCreditsInfo, getRateLimitInfo, troubleshootError, getSenderInfo, getWebhookGuide, getLatencyComparison, getPumpFunGuide, recommendStack
+
+**Solana Knowledge (5):** getSIMD, listSIMDs, searchSolanaDocs, readSolanaSourceFile, fetchHeliusBlog
 
 ## Networks
 

--- a/helius-mcp/package.json
+++ b/helius-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "helius-mcp",
-  "version": "0.3.0",
-  "description": "Official Helius MCP Server - Complete Solana blockchain data access for Claude",
+  "version": "1.0.0",
+  "description": "Official Helius MCP Server - Complete Solana blockchain data access for AI assistants",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -21,8 +21,10 @@
     "solana",
     "blockchain",
     "mcp",
-    "claude",
+    "model-context-protocol",
     "ai",
+    "llm",
+    "claude",
     "web3",
     "nft",
     "defi",

--- a/helius-mcp/src/index.ts
+++ b/helius-mcp/src/index.ts
@@ -7,11 +7,12 @@ import { setApiKey, setSessionSecretKey, setSessionWalletAddress } from './utils
 import { getSharedApiKey, loadKeypairFromDisk } from './utils/config.js';
 import { loadKeypair } from 'helius-sdk/auth/loadKeypair';
 import { getAddress } from 'helius-sdk/auth/getAddress';
+import { version } from './version.js';
 
 const server = new McpServer(
   {
     name: 'helius-mcp',
-    version: '0.3.0'
+    version
   },
   {
     instructions: `These instructions provide fallback tool selection guidance. If you have more specific routing instructions from a Helius skill or system prompt, prefer those.
@@ -21,24 +22,28 @@ const server = new McpServer(
 | Intent | Tool | Credits |
 |--------|------|---------|
 | SOL balance | getBalance | 1 |
-| token balances | getTokenBalances | 10/pg |
+| token balances by wallet | getTokenBalances | 10/pg |
 | full portfolio + USD | getWalletBalances | 100 |
 | parse tx by signature | parseTransactions | 100 |
-| transaction history | getTransactionHistory | ~110 |
+| wallet transaction history | getTransactionHistory | ~110 |
 | balance deltas/tx | getWalletHistory | 100 |
 | sends/receives | getWalletTransfers | 100 |
-| asset by mint | getAsset | 10 |
+| asset by mint (single or batch) | getAsset | 10 |
 | wallet NFTs | getAssetsByOwner | 10 |
-| filtered asset search | searchAssets | 10 |
+| filtered asset search / by creator or authority | searchAssets | 10 |
 | collection NFTs | getAssetsByGroup | 10 |
 | asset tx history (by mint) | getSignaturesForAsset | 10 |
 | edition prints of master NFT | getNftEditions | 10 |
-| raw account inspection | getAccountInfo | 1 |
+| cNFT Merkle proof (single or batch) | getAssetProof, getAssetProofBatch | 10 |
+| raw account inspection (single or batch) | getAccountInfo | 1 |
 | token holders by mint | getTokenHolders | ~20 |
-| token account queries | getTokenAccounts | 10 |
+| token accounts by mint or owner | getTokenAccounts | 10 |
 | program accounts / protocol state | getProgramAccounts | 10 |
+| network status / epoch / block height | getNetworkStatus | 3 |
+| block data by slot | getBlock | 1 |
 | plans/pricing | getHeliusPlanInfo | 0 |
 | plan comparison | compareHeliusPlans | 0 |
+| plan upgrade / billing | previewUpgrade, upgradePlan, payRenewal | 0 |
 | rate limits/credits | getRateLimitInfo | 0 |
 | API docs by topic | lookupHeliusDocs | 0 |
 | error diagnosis | troubleshootError | 0 |
@@ -46,8 +51,12 @@ const server = new McpServer(
 | webhook setup guide | getWebhookGuide | 0 |
 | streaming latency | getLatencyComparison | 0 |
 | pump.fun tokens | getPumpFunGuide | 0 |
-| project architecture | recommendStack | 0 |
+| project architecture / stack selection | recommendStack | 0 |
+| Solana SIMDs / protocol proposals | getSIMD, listSIMDs | 0 |
+| Solana source / docs search | searchSolanaDocs, readSolanaSourceFile | 0 |
+| Helius blog posts | fetchHeliusBlog | 0 |
 | wallet identity | getWalletIdentity | 100 |
+| batch wallet identity | batchWalletIdentity | 100 |
 | funding source | getWalletFundedBy | 100 |
 | event notifications (any plan) | createWebhook | 100 |
 | live streaming (WS, Business+) | transactionSubscribe, accountSubscribe | — |

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -135,6 +135,8 @@ export function registerAuthTools(server: McpServer) {
         'Call `agenticSignup` to process the payment and create your Helius account.',
         'Your API key will be configured automatically — no extra steps needed.',
         '',
+        '> **Paid plans only:** `agenticSignup` requires `email`, `firstName`, and `lastName` for developer/business/professional plans. Basic plan ($1) does not require them.',
+        '',
         '---',
         '',
         '## Path C — Use the Helius CLI',
@@ -262,7 +264,7 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'agenticSignup',
-    'Create a Helius account using the generated keypair. Default: basic plan ($1 USDC). For paid plans, specify plan: developer ($49/mo), business ($499/mo), or professional ($999/mo). On success, automatically configures the API key for this session.',
+    'Create a Helius account using the generated keypair. Default: basic plan ($1 USDC). For paid plans (developer/business/professional), email, firstName, and lastName are required. On success, automatically configures the API key for this session.',
     {
       plan: z.string().optional().describe('Plan to sign up for: "basic" ($1, default), "developer", "business", or "professional"'),
       period: z.enum(["monthly", "yearly"]).optional().describe('Billing period for paid plans (default: monthly)'),
@@ -415,7 +417,7 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'upgradePlan',
-    'Upgrade your Helius plan. Processes USDC payment with proration. Call previewUpgrade first to see pricing.',
+    'Upgrade your Helius plan. Processes USDC payment with proration. Call previewUpgrade first to see pricing. Requires email, firstName, and lastName for first-time upgrades — all three must be provided together.',
     {
       plan: z.enum(['developer', 'business', 'professional']).describe('Target plan name'),
       period: z.enum(['monthly', 'yearly']).default('monthly').describe('Billing period'),

--- a/helius-mcp/tsconfig.json
+++ b/helius-mcp/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": true
+    "declaration": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
This PR implements various fixes and updates to prepare the MCP for its 1.0.0 release. Namely:
- Version bump from 0.3.0 to 1.0.0
- Make it so the version in `index.ts` auto-updates, and is no longer hardcoded
- Added node types to `tsconfig.json`
- Removed Claude-specific bias from the package metadata
- Updated the `README.md` to lead the quick start with a universal JSON config and better tooling 