### PR TITLE
feat(plugin): Add Temp Claude Marketplace Workaround

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "helius-labs",
+  "description": "Helius developer tools for building on Solana",
+  "owner": {
+    "name": "Helius Labs",
+    "email": "support@helius.xyz"
+  },
+  "plugins": [
+    {
+      "name": "helius",
+      "source": "./helius-plugin",
+      "description": "Build on Solana with Helius — live blockchain tools, expert coding patterns, and autonomous account signup",
+      "version": "1.0.0",
+      "author": { "name": "Helius Labs", "url": "https://helius.dev" },
+      "homepage": "https://www.helius.dev/docs",
+      "repository": "https://github.com/helius-labs/core-ai",
+      "license": "MIT",
+      "keywords": ["solana", "blockchain", "rpc", "nft", "defi", "web3", "helius"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds `.claude-plugin/marketplace.json` as a fallback install path for our Claude Code plugin, in case our Anthropic review is delayed while we launch

Users can install via:
- `/plugin marketplace add helius-labs/core-ai`
- `/plugin install helius@helius-labs`