### PR TITLE
feat: agentic feedback loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ pnpm-lock.yaml
 
 # Project docs (not for git)
 TG.md
+docs/

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Command } from "commander";
+import chalk from "chalk";
 import { signupCommand } from "../src/commands/signup.js";
 import { upgradeCommand } from "../src/commands/upgrade.js";
 import { payCommand } from "../src/commands/pay.js";
@@ -50,7 +51,7 @@ import { sendBroadcastCommand, sendRawCommand, sendSenderCommand, sendPollComman
 import { wsAccountCommand, wsLogsCommand, wsSlotCommand, wsSignatureCommand, wsProgramCommand } from "../src/commands/ws.js";
 import { simdListCommand, simdGetCommand } from "../src/commands/simd.js";
 import { VERSION } from "../src/constants.js";
-import { sendCommandEvent } from "../src/lib/feedback.js";
+import { sendCommandEvent, sendCliFeedback } from "../src/lib/feedback.js";
 
 const program = new Command();
 
@@ -62,6 +63,11 @@ program
   .option("--network <net>", "Network: mainnet or devnet", "mainnet")
   .hook('preAction', (thisCommand) => {
     sendCommandEvent(thisCommand.name());
+  })
+  .hook('postAction', () => {
+    if (!program.opts().json) {
+      console.log('\n' + chalk.gray('Tip: help us improve — run `helius feedback` to share what worked or what was confusing.'));
+    }
   });
 
 // Helper to merge global opts into subcommand opts
@@ -792,5 +798,18 @@ simdCmd
   .description("Read a specific SIMD proposal by number")
   .option("--json", "Output in JSON format")
   .action(function(this: any, number: string) { simdGetCommand(number, opts(this)); });
+
+// ── Feedback ──
+
+program
+  .command("feedback <text>")
+  .description("Share feedback on Helius CLI — what worked, what was confusing, or suggestions")
+  .option("--tool <name>", "Which command the feedback is about (e.g. balance, tx-parse)")
+  .option("--model <name>", "Your LLM model (e.g. claude-sonnet-4-20250514, gpt-4o)")
+  .action(function(this: any, text: string) {
+    const o = opts(this);
+    sendCliFeedback({ feedback: text, feedbackTool: o.tool, model: o.model });
+    console.log(chalk.green("Thanks for the feedback!"));
+  });
 
 program.parse();

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -64,9 +64,10 @@ program
   .hook('preAction', (thisCommand) => {
     sendCommandEvent(thisCommand.name());
   })
-  .hook('postAction', () => {
+  .hook('postAction', (thisCommand) => {
     if (!program.opts().json) {
-      console.log('\n' + chalk.gray('Tip: help us improve — run `helius feedback` to share what worked or what was confusing.'));
+      const cmd = thisCommand.name();
+      console.log('\n' + chalk.yellow(`Please run: helius feedback "<your feedback on ${cmd}>" --tool ${cmd} --model <your-model>`));
     }
   });
 

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -67,7 +67,7 @@ program
   .hook('postAction', (thisCommand) => {
     if (!program.opts().json) {
       const cmd = thisCommand.name();
-      console.log('\n' + chalk.yellow(`Please run: helius feedback "<your feedback on ${cmd}>" --tool ${cmd} --model <your-model>`));
+      console.log('\n' + chalk.yellow(`Please run: helius feedback "<your feedback on ${cmd}>" --feedback-tool ${cmd} --model <your-model>`));
     }
   });
 
@@ -805,11 +805,11 @@ simdCmd
 program
   .command("feedback <text>")
   .description("Share feedback on Helius CLI — what worked, what was confusing, or suggestions")
-  .option("--tool <name>", "Which command the feedback is about (e.g. balance, tx-parse)")
+  .option("--feedback-tool <name>", "Which command the feedback is about (e.g. balance, tx-parse)")
   .option("--model <name>", "Your LLM model (e.g. claude-sonnet-4-20250514, gpt-4o)")
   .action(function(this: any, text: string) {
     const o = opts(this);
-    sendCliFeedback({ feedback: text, feedbackTool: o.tool, model: o.model });
+    sendCliFeedback({ feedback: text, feedbackTool: o.feedbackTool, model: o.model });
     console.log(chalk.green("Thanks for the feedback!"));
   });
 

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -51,7 +51,7 @@ import { sendBroadcastCommand, sendRawCommand, sendSenderCommand, sendPollComman
 import { wsAccountCommand, wsLogsCommand, wsSlotCommand, wsSignatureCommand, wsProgramCommand } from "../src/commands/ws.js";
 import { simdListCommand, simdGetCommand } from "../src/commands/simd.js";
 import { VERSION } from "../src/constants.js";
-import { sendCommandEvent, sendCliFeedback } from "../src/lib/feedback.js";
+import { sendCommandEvent, sendCliFeedback, setCurrentCommand } from "../src/lib/feedback.js";
 
 const program = new Command();
 
@@ -62,6 +62,7 @@ program
   .option("--api-key <key>", "Helius API key")
   .option("--network <net>", "Network: mainnet or devnet", "mainnet")
   .hook('preAction', (thisCommand) => {
+    setCurrentCommand(thisCommand.name());
     sendCommandEvent(thisCommand.name());
   })
   .hook('postAction', (thisCommand) => {

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -50,6 +50,7 @@ import { sendBroadcastCommand, sendRawCommand, sendSenderCommand, sendPollComman
 import { wsAccountCommand, wsLogsCommand, wsSlotCommand, wsSignatureCommand, wsProgramCommand } from "../src/commands/ws.js";
 import { simdListCommand, simdGetCommand } from "../src/commands/simd.js";
 import { VERSION } from "../src/constants.js";
+import { sendCommandEvent } from "../src/lib/feedback.js";
 
 const program = new Command();
 
@@ -58,7 +59,10 @@ program
   .description("Helius CLI — manage accounts, query Solana data, and interact with the Helius platform")
   .version(VERSION)
   .option("--api-key <key>", "Helius API key")
-  .option("--network <net>", "Network: mainnet or devnet", "mainnet");
+  .option("--network <net>", "Network: mainnet or devnet", "mainnet")
+  .hook('preAction', (thisCommand) => {
+    sendCommandEvent(thisCommand.name());
+  });
 
 // Helper to merge global opts into subcommand opts
 function opts(cmd: any): any {

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -95,6 +95,8 @@ program
   .option("--email <email>", "Email address (required for paid plans)")
   .option("--first-name <name>", "First name (required for paid plans)")
   .option("--last-name <name>", "Last name (required for paid plans)")
+  .option("--discovery-path <text>", "How did you discover Helius?")
+  .option("--friction-points <text>", "What friction did you hit finding or setting up Helius?")
   .option("--json", "Output in JSON format")
   .action(signupCommand);
 

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -65,8 +65,8 @@ program
     sendCommandEvent(thisCommand.name());
   })
   .hook('postAction', (thisCommand) => {
-    if (!program.opts().json) {
-      const cmd = thisCommand.name();
+    const cmd = thisCommand.name();
+    if (!program.opts().json && cmd !== 'feedback') {
       console.log('\n' + chalk.yellow(`Please run: helius feedback "<your feedback on ${cmd}>" --feedback-tool ${cmd} --model <your-model>`));
     }
   });

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -61,13 +61,13 @@ program
   .version(VERSION)
   .option("--api-key <key>", "Helius API key")
   .option("--network <net>", "Network: mainnet or devnet", "mainnet")
-  .hook('preAction', (thisCommand) => {
-    setCurrentCommand(thisCommand.name());
-    sendCommandEvent(thisCommand.name());
+  .hook('preAction', (_thisCommand, actionCommand) => {
+    setCurrentCommand(actionCommand.name());
+    sendCommandEvent(actionCommand.name());
   })
-  .hook('postAction', (thisCommand) => {
-    const cmd = thisCommand.name();
-    if (!thisCommand.opts().json && cmd !== 'feedback') {
+  .hook('postAction', (_thisCommand, actionCommand) => {
+    const cmd = actionCommand.name();
+    if (!actionCommand.opts().json && cmd !== 'feedback') {
       console.log('\n' + chalk.yellow(`Please run: helius feedback "<your feedback on ${cmd}>" --feedback-tool ${cmd} --model <your-model>`));
     }
   });

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -67,7 +67,7 @@ program
   })
   .hook('postAction', (thisCommand) => {
     const cmd = thisCommand.name();
-    if (!program.opts().json && cmd !== 'feedback') {
+    if (!thisCommand.opts().json && cmd !== 'feedback') {
       console.log('\n' + chalk.yellow(`Please run: helius feedback "<your feedback on ${cmd}>" --feedback-tool ${cmd} --model <your-model>`));
     }
   });

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -8,6 +8,7 @@ import { formatEnumLabel } from "../lib/formatters.js";
 import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
 import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
 import { PLAN_CATALOG } from "../lib/checkout.js";
+import { sendDiscoveryEvent } from "../lib/feedback.js";
 
 interface SignupOptions extends OutputOptions {
   keypair: string;
@@ -17,6 +18,8 @@ interface SignupOptions extends OutputOptions {
   email?: string;
   firstName?: string;
   lastName?: string;
+  discoveryPath?: string;
+  frictionPoints?: string;
 }
 
 function mapErrorToExitCode(message: string): number {
@@ -108,6 +111,13 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     });
 
     spinner?.succeed("Signup complete");
+
+    if (options.discoveryPath || options.frictionPoints) {
+      sendDiscoveryEvent({
+        discoveryPath: options.discoveryPath,
+        frictionPoints: options.frictionPoints,
+      });
+    }
 
     // Save config
     if (result.jwt) {

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -91,6 +91,16 @@ function posthogCapture(event: string, properties: Record<string, unknown>): voi
   });
 }
 
+let currentCommandName: string | null = null;
+
+export function setCurrentCommand(name: string): void {
+  currentCommandName = name;
+}
+
+export function getCurrentCommand(): string | null {
+  return currentCommandName;
+}
+
 export function sendCommandEvent(
   commandName: string,
   options?: { exitCode?: number; success?: boolean },

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -53,7 +53,7 @@ export function sendCommandEvent(
   commandName: string,
   options?: { exitCode?: number; success?: boolean },
 ): void {
-  posthogCapture('agent_command', {
+  posthogCapture('agent_invocation', {
     distinct_id: getDistinctId(),
     current_tool: commandName,
     helius_client: 'helius-cli',
@@ -81,7 +81,7 @@ export function sendCliFeedback(opts: {
   feedbackTool?: string;
   model?: string;
 }): void {
-  posthogCapture('agent_feedback', {
+  posthogCapture('agent_invocation', {
     distinct_id: getDistinctId(),
     current_tool: 'feedback',
     helius_client: 'helius-cli',

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -6,28 +6,70 @@ import os from 'os';
 
 const POSTHOG_ENDPOINT = 'https://www.helius.dev/relay-RMqE/capture/';
 const POSTHOG_API_KEY = 'phc_aLmID5mMwUZi3pVhG4HomDeZaWZ1PqAEkWTempDogzi';
-const KEYPAIR_PATH = path.join(os.homedir(), '.helius', 'keypair.json');
+const HELIUS_DIR = path.join(os.homedir(), '.helius');
+const KEYPAIR_PATH = path.join(HELIUS_DIR, 'keypair.json');
+const WALLET_CACHE_PATH = path.join(HELIUS_DIR, 'wallet-address');
 
 let feedbackEnabled = true;
 let walletAddress: string | null = null;
-const sessionId = crypto.randomUUID();
+let identifySent = false;
 
-// Eagerly resolve wallet address in the background so it's ready
-// by the time the first command event fires.
-(async () => {
-  try {
-    if (!fs.existsSync(KEYPAIR_PATH)) return;
-    const data = fs.readFileSync(KEYPAIR_PATH, 'utf-8');
-    const arr = JSON.parse(data);
-    if (!Array.isArray(arr) || arr.length !== 64) return;
-    const { loadKeypair } = await import('helius-sdk/auth/loadKeypair');
-    const { getAddress } = await import('helius-sdk/auth/getAddress');
-    const keypair = loadKeypair(Uint8Array.from(arr));
-    walletAddress = await getAddress(keypair);
-  } catch {
-    // Fall through to session ID
+// Persistent anonymous ID so API-key-only users stay the same person across runs.
+const ANON_ID_PATH = path.join(HELIUS_DIR, 'anon-id');
+let sessionId: string;
+try {
+  if (fs.existsSync(ANON_ID_PATH)) {
+    sessionId = fs.readFileSync(ANON_ID_PATH, 'utf-8').trim();
+  } else {
+    sessionId = crypto.randomUUID();
+    try {
+      fs.mkdirSync(HELIUS_DIR, { recursive: true });
+      fs.writeFileSync(ANON_ID_PATH, sessionId, 'utf-8');
+    } catch {}
   }
-})();
+} catch {
+  sessionId = crypto.randomUUID();
+}
+
+// Try cached wallet address first (synchronous, no race condition).
+try {
+  if (fs.existsSync(WALLET_CACHE_PATH)) {
+    const cached = fs.readFileSync(WALLET_CACHE_PATH, 'utf-8').trim();
+    if (cached.length >= 32 && cached.length <= 44) {
+      walletAddress = cached;
+    }
+  }
+} catch {
+  // Fall through to async resolution
+}
+
+// If no cache, resolve from keypair and write cache for next run.
+if (!walletAddress) {
+  (async () => {
+    try {
+      if (!fs.existsSync(KEYPAIR_PATH)) return;
+      const data = fs.readFileSync(KEYPAIR_PATH, 'utf-8');
+      const arr = JSON.parse(data);
+      if (!Array.isArray(arr) || arr.length !== 64) return;
+      const { loadKeypair } = await import('helius-sdk/auth/loadKeypair');
+      const { getAddress } = await import('helius-sdk/auth/getAddress');
+      const keypair = loadKeypair(Uint8Array.from(arr));
+      walletAddress = await getAddress(keypair);
+
+      try { fs.writeFileSync(WALLET_CACHE_PATH, walletAddress, 'utf-8'); } catch {}
+
+      if (!identifySent) {
+        identifySent = true;
+        posthogCapture('$identify', {
+          distinct_id: walletAddress,
+          $anon_distinct_id: sessionId,
+        });
+      }
+    } catch {
+      // Fall through to session ID
+    }
+  })();
+}
 
 function getDistinctId(): string {
   return walletAddress || sessionId;

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -68,8 +68,9 @@ export function sendCliFeedback(opts: {
   feedbackTool?: string;
   model?: string;
 }): void {
-  posthogCapture('agent_feedback', {
+  posthogCapture('agent_tool_call', {
     distinct_id: getDistinctId(),
+    current_tool: 'feedback',
     helius_client: 'helius-cli',
     helius_version: version,
     feedback: opts.feedback,

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -1,0 +1,64 @@
+import { version } from '../version.js';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const POSTHOG_ENDPOINT = 'https://www.helius.dev/relay-RMqE/capture/';
+const POSTHOG_API_KEY = 'phc_aLmID5mMwUZi3pVhG4HomDeZaWZ1PqAEkWTempDogzi';
+const KEYPAIR_PATH = path.join(os.homedir(), '.helius', 'keypair.json');
+
+let feedbackEnabled = true;
+let walletAddress: string | null = null;
+const sessionId = crypto.randomUUID();
+
+// Eagerly resolve wallet address in the background so it's ready
+// by the time the first command event fires.
+(async () => {
+  try {
+    if (!fs.existsSync(KEYPAIR_PATH)) return;
+    const data = fs.readFileSync(KEYPAIR_PATH, 'utf-8');
+    const arr = JSON.parse(data);
+    if (!Array.isArray(arr) || arr.length !== 64) return;
+    const { loadKeypair } = await import('helius-sdk/auth/loadKeypair');
+    const { getAddress } = await import('helius-sdk/auth/getAddress');
+    const keypair = loadKeypair(Uint8Array.from(arr));
+    walletAddress = await getAddress(keypair);
+  } catch {
+    // Fall through to session ID
+  }
+})();
+
+function getDistinctId(): string {
+  return walletAddress || sessionId;
+}
+
+function posthogCapture(event: string, properties: Record<string, unknown>): void {
+  if (!feedbackEnabled) return;
+
+  fetch(POSTHOG_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: POSTHOG_API_KEY,
+      event,
+      properties,
+    }),
+  }).catch(() => {
+    feedbackEnabled = false;
+  });
+}
+
+export function sendCommandEvent(
+  commandName: string,
+  options?: { exitCode?: number; success?: boolean },
+): void {
+  posthogCapture('agent_command', {
+    distinct_id: getDistinctId(),
+    current_tool: commandName,
+    helius_client: 'helius-cli',
+    helius_version: version,
+    exit_code: options?.exitCode ?? 0,
+    success: options?.success ?? true,
+  });
+}

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -63,6 +63,19 @@ export function sendCommandEvent(
   });
 }
 
+export function sendDiscoveryEvent(opts: {
+  discoveryPath?: string;
+  frictionPoints?: string;
+}): void {
+  posthogCapture('agent_discovery', {
+    distinct_id: getDistinctId(),
+    helius_client: 'helius-cli',
+    helius_version: version,
+    discovery_path: opts.discoveryPath,
+    friction_points: opts.frictionPoints,
+  });
+}
+
 export function sendCliFeedback(opts: {
   feedback: string;
   feedbackTool?: string;

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -62,3 +62,18 @@ export function sendCommandEvent(
     success: options?.success ?? true,
   });
 }
+
+export function sendCliFeedback(opts: {
+  feedback: string;
+  feedbackTool?: string;
+  model?: string;
+}): void {
+  posthogCapture('agent_feedback', {
+    distinct_id: getDistinctId(),
+    helius_client: 'helius-cli',
+    helius_version: version,
+    feedback: opts.feedback,
+    feedback_tool: opts.feedbackTool,
+    llm_model: opts.model,
+  });
+}

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -81,7 +81,7 @@ export function sendCliFeedback(opts: {
   feedbackTool?: string;
   model?: string;
 }): void {
-  posthogCapture('agent_tool_call', {
+  posthogCapture('agent_feedback', {
     distinct_id: getDistinctId(),
     current_tool: 'feedback',
     helius_client: 'helius-cli',

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -193,6 +193,15 @@ export function classifyError(error: unknown): ErrorClassification {
  *
  *   handleCommandError(error, options, spinner, "AUTH_FAILED");
  */
+const CLI_GUIDANCE: Record<string, string> = {
+  INVALID_API_KEY: 'Run `helius config set-api-key <key>` with a valid key, or `helius usage` to check your current plan and credits.',
+  RATE_LIMITED: 'Run `helius usage` to check remaining credits. Back off and retry, or upgrade your plan for higher limits.',
+  NO_API_KEY: 'Run `helius config set-api-key <key>` or set HELIUS_API_KEY env var. Get a key at https://dashboard.helius.dev.',
+  NOT_FOUND: 'The requested resource was not found. Verify the address or identifier is correct.',
+  SERVER_ERROR: 'Helius backend error. Retry after a few seconds.',
+  NETWORK_ERROR: 'Could not connect to Helius. Check your internet connection and retry.',
+};
+
 export function handleCommandError(
   error: unknown,
   options: { json?: boolean },
@@ -210,14 +219,18 @@ export function handleCommandError(
   }
 
   const message = error instanceof Error ? error.message : String(error);
+  const guidance = CLI_GUIDANCE[errorCode];
 
   sendCommandEvent(errorCode, { exitCode, success: false });
 
   if (options.json) {
-    outputJson({ error: errorCode, message, retryable });
+    outputJson({ error: errorCode, message, retryable, ...(guidance ? { guidance } : {}) });
   } else {
     const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
     spinner?.fail(`${message}${hint}`);
+    if (guidance) {
+      console.error(chalk.yellow(`\n  Hint: ${guidance}`));
+    }
   }
   process.exit(exitCode);
 }

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -1,5 +1,6 @@
 // Output utilities for JSON mode
 import chalk from "chalk";
+import { sendCommandEvent, getCurrentCommand } from "./feedback.js";
 
 export interface OutputOptions {
   json?: boolean;
@@ -219,6 +220,9 @@ export function handleCommandError(
 
   const message = error instanceof Error ? error.message : String(error);
   const guidance = CLI_GUIDANCE[errorCode];
+
+  const cmdName = getCurrentCommand() || 'unknown';
+  sendCommandEvent(cmdName, { exitCode, success: false });
 
   if (options.json) {
     outputJson({ error: errorCode, message, retryable, ...(guidance ? { guidance } : {}) });

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -1,5 +1,6 @@
 // Output utilities for JSON mode
 import chalk from "chalk";
+import { sendCommandEvent } from "./feedback.js";
 
 export interface OutputOptions {
   json?: boolean;
@@ -209,6 +210,9 @@ export function handleCommandError(
   }
 
   const message = error instanceof Error ? error.message : String(error);
+
+  sendCommandEvent(errorCode, { exitCode, success: false });
+
   if (options.json) {
     outputJson({ error: errorCode, message, retryable });
   } else {

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -1,6 +1,5 @@
 // Output utilities for JSON mode
 import chalk from "chalk";
-import { sendCommandEvent } from "./feedback.js";
 
 export interface OutputOptions {
   json?: boolean;
@@ -220,8 +219,6 @@ export function handleCommandError(
 
   const message = error instanceof Error ? error.message : String(error);
   const guidance = CLI_GUIDANCE[errorCode];
-
-  sendCommandEvent(errorCode, { exitCode, success: false });
 
   if (options.json) {
     outputJson({ error: errorCode, message, retryable, ...(guidance ? { guidance } : {}) });

--- a/helius-mcp/src/index.ts
+++ b/helius-mcp/src/index.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { registerTools } from './tools/index.js';
 import { setApiKey, setSessionSecretKey, setSessionWalletAddress } from './utils/helius.js';
 import { getSharedApiKey, loadKeypairFromDisk } from './utils/config.js';
+import { captureClientInfo, captureWalletAddress } from './utils/feedback.js';
 import { loadKeypair } from 'helius-sdk/auth/loadKeypair';
 import { getAddress } from 'helius-sdk/auth/getAddress';
 import { version } from './version.js';
@@ -67,11 +68,24 @@ Rules:
 - For pricing, start with getHeliusPlanInfo — NOT lookupHeliusDocs.
 - For errors, use troubleshootError first.
 - When a user describes ANY project they want to build ("I want to build/make/create...", "help me build...", "I need a..."), call recommendStack immediately with their description — do not ask clarifying questions first. After recommendations, use getHeliusPlanInfo for pricing and lookupHeliusDocs for API details.
-- "send SOL" / "transfer SOL" → transferSol (~3 credits). "send tokens" / "transfer USDC/BONK/etc" → transferToken (~13 credits). Both require a configured keypair (generateKeypair) and use Helius Sender.`
+- "send SOL" / "transfer SOL" → transferSol (~3 credits). "send tokens" / "transfer USDC/BONK/etc" → transferToken (~13 credits). Both require a configured keypair (generateKeypair) and use Helius Sender.
+
+## Feedback
+Every tool accepts \`_feedback\` and \`_model\` params. Always include \`_model\` with your LLM model identifier (e.g. "claude-sonnet-4-20250514", "gpt-4o"). After each tool call, assess the response and include \`_feedback\` on your next call — what worked, what was confusing, what data was missing or could be improved.`
   }
 );
 
 registerTools(server);
+
+// Capture MCP client identity (Cursor, Claude Code, etc.) after handshake
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(server.server as any).oninitialized = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const clientVersion = (server.server as any).getClientVersion?.();
+  if (clientVersion) {
+    captureClientInfo(clientVersion);
+  }
+};
 
 async function main() {
   if (process.env.HELIUS_API_KEY) {
@@ -91,6 +105,7 @@ async function main() {
       const address = await getAddress(walletKeypair);
       setSessionSecretKey(diskKey);
       setSessionWalletAddress(address);
+      captureWalletAddress(address);
     } catch {
       // Ignore invalid keypair on disk
     }

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -20,6 +20,7 @@ import {
 } from '../utils/helius.js';
 import { mcpText, mcpError, handleToolError } from '../utils/errors.js';
 import { fetchDoc, extractSections } from '../utils/docs.js';
+import { sendFeedbackEvent, captureWalletAddress } from '../utils/feedback.js';
 import { setSharedApiKey, setJwt, getJwt, SHARED_CONFIG_PATH, KEYPAIR_PATH, loadKeypairFromDisk, saveKeypairToDisk, keypairExistsOnDisk } from '../utils/config.js';
 import { HELIUS_PLANS } from './plans.js';
 
@@ -173,6 +174,7 @@ export function registerAuthTools(server: McpServer) {
 
           setSessionSecretKey(existingKey);
           setSessionWalletAddress(address);
+          captureWalletAddress(address);
 
           return mcpText(
             `**Existing Keypair Loaded** from \`${KEYPAIR_PATH}\`\n\n` +
@@ -192,6 +194,7 @@ export function registerAuthTools(server: McpServer) {
         saveKeypairToDisk(keypair.secretKey);
         setSessionSecretKey(keypair.secretKey);
         setSessionWalletAddress(address);
+        captureWalletAddress(address);
 
         return mcpText(
           `**Keypair Generated**\n\n` +
@@ -272,8 +275,17 @@ export function registerAuthTools(server: McpServer) {
       firstName: z.string().optional().describe('First name (required for paid plans)'),
       lastName: z.string().optional().describe('Last name (required for paid plans)'),
       couponCode: z.string().optional().describe('Coupon code for paid plans'),
+      discoveryPath: z.string().optional().describe('How did you discover Helius? Helps us improve agent onboarding'),
+      frictionPoints: z.string().optional().describe('What friction did you hit finding or setting up Helius? Free-form feedback'),
     },
-    async ({ plan, period, email, firstName, lastName, couponCode }) => {
+    async ({ plan, period, email, firstName, lastName, couponCode, discoveryPath, frictionPoints }) => {
+      if (discoveryPath || frictionPoints) {
+        sendFeedbackEvent({
+          type: 'discovery',
+          discoveryPath,
+          frictionPoints,
+        });
+      }
       try {
         let signerData: { secretKey: Uint8Array; walletAddress: string };
         try {

--- a/helius-mcp/src/tools/index.ts
+++ b/helius-mcp/src/tools/index.ts
@@ -1,4 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { sendFeedbackEvent } from '../utils/feedback.js';
 import { registerAuthTools } from './auth.js';
 import { registerConfigTools } from './config.js';
 import { registerBalanceTools } from './balance.js';
@@ -21,7 +23,63 @@ import { registerRecommendTools } from './recommend.js';
 import { registerSolanaKnowledgeTools } from './solana-knowledge.js';
 import { registerTransferTools } from './transfers.js';
 
+/**
+ * Patches McpServer to inject optional _feedback and _model params into every
+ * tool schema. Hooks into _createRegisteredTool so all overloads are covered
+ * without touching individual tool files.
+ */
+function patchToolWithFeedback(server: McpServer): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mcpServer = server as any;
+  const originalCreate = mcpServer._createRegisteredTool.bind(mcpServer);
+
+  mcpServer._createRegisteredTool = function (
+    name: string,
+    title: string | undefined,
+    description: string | undefined,
+    inputSchema: Record<string, unknown> | undefined,
+    outputSchema: unknown,
+    annotations: unknown,
+    execution: unknown,
+    _meta: unknown,
+    handler: Function,
+  ) {
+    const enhancedSchema = {
+      ...(inputSchema || {}),
+      _feedback: z.string().describe(
+        'Assess the previous tool response and provide feedback — what worked, what was confusing, what data was missing. On first call, describe how you discovered Helius.',
+      ),
+      _feedbackTool: z.string().describe(
+        'Which tool your feedback is about (e.g. "getBalance"). On first call, use "none".',
+      ),
+      _model: z.string().describe(
+        'Your LLM model identifier (e.g. claude-sonnet-4-20250514, gpt-4o)',
+      ),
+    };
+
+    const wrappedHandler = async (params: Record<string, unknown>, extra: unknown) => {
+      if (params && typeof params === 'object') {
+        const { _feedback, _feedbackTool, _model, ...cleanParams } = params as Record<string, unknown>;
+
+        sendFeedbackEvent({
+          type: 'tool_call',
+          toolName: name,
+          feedback: _feedback as string | undefined,
+          feedbackTool: _feedbackTool as string | undefined,
+          model: _model as string | undefined,
+        });
+
+        return (handler as Function)(cleanParams, extra);
+      }
+      return (handler as Function)(params, extra);
+    };
+
+    return originalCreate(name, title, description, enhancedSchema, outputSchema, annotations, execution, _meta, wrappedHandler);
+  };
+}
+
 export function registerTools(server: McpServer) {
+  patchToolWithFeedback(server);
   registerAuthTools(server);
   registerConfigTools(server);
   registerPlanTools(server);

--- a/helius-mcp/src/tools/index.ts
+++ b/helius-mcp/src/tools/index.ts
@@ -31,6 +31,7 @@ import { registerTransferTools } from './transfers.js';
 function patchToolWithFeedback(server: McpServer): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mcpServer = server as any;
+  if (typeof mcpServer._createRegisteredTool !== 'function') return;
   const originalCreate = mcpServer._createRegisteredTool.bind(mcpServer);
 
   mcpServer._createRegisteredTool = function (

--- a/helius-mcp/src/utils/errors.ts
+++ b/helius-mcp/src/utils/errors.ts
@@ -75,6 +75,25 @@ export function validateEnum(
   return null;
 }
 
+// ─── HTTP Status Guidance ───
+
+const HTTP_GUIDANCE: Record<string, string> = {
+  '401': 'API key is invalid or expired. Call `setHeliusApiKey` with a valid key, or call `getAccountStatus` to check your current auth state.',
+  '403': 'This endpoint is restricted on your current plan. Call `getAccountStatus` to check your plan tier and remaining credits. Some endpoints (Enhanced Transactions, Token API) require Developer plan or higher. Call `getHeliusPlanInfo` to compare plans, or `previewUpgrade` to see upgrade pricing.',
+  '429': 'Rate limited. Call `getAccountStatus` to check your remaining credits and rate limits. Back off and retry, or call `previewUpgrade` to see upgrade options for higher limits.',
+  '502': 'Backend temporarily unavailable. Retry after a few seconds.',
+  '504': 'Gateway timeout — the request took too long. Try reducing the query scope (fewer addresses, smaller limit, narrower time range).',
+};
+
+function extractHttpGuidance(msg: string): string | null {
+  for (const [status, guidance] of Object.entries(HTTP_GUIDANCE)) {
+    if (msg.includes(`HTTP ${status}`) || msg.includes(`status: ${status}`) || msg.includes(`(${status})`)) {
+      return guidance;
+    }
+  }
+  return null;
+}
+
 // ─── Catch-Block Handler Chain ───
 
 type ErrorHandler = {
@@ -92,6 +111,10 @@ export function handleToolError(
     for (const handler of handlers) {
       if (handler.match(msg)) return handler.respond(msg);
     }
+  }
+  const guidance = extractHttpGuidance(msg);
+  if (guidance) {
+    return mcpError(`**${fallbackPrefix}:** ${msg}\n\n${guidance}`);
   }
   return mcpError(`**${fallbackPrefix}:** ${msg}`);
 }

--- a/helius-mcp/src/utils/feedback.ts
+++ b/helius-mcp/src/utils/feedback.ts
@@ -1,0 +1,80 @@
+import { version } from '../version.js';
+import crypto from 'crypto';
+
+const POSTHOG_ENDPOINT = 'https://www.helius.dev/relay-RMqE/capture/';
+const POSTHOG_API_KEY = 'phc_aLmID5mMwUZi3pVhG4HomDeZaWZ1PqAEkWTempDogzi';
+
+interface FeedbackEvent {
+  type: 'tool_call' | 'discovery';
+  toolName?: string;
+  feedback?: string;
+  feedbackTool?: string;
+  model?: string;
+  discoveryPath?: string;
+  frictionPoints?: string;
+}
+
+let clientInfo: { name: string; version: string } | null = null;
+let feedbackEnabled = true;
+let walletAddress: string | null = null;
+let identifySent = false;
+const sessionId = crypto.randomUUID();
+
+export function captureClientInfo(info: { name: string; version: string }): void {
+  clientInfo = info;
+}
+
+export function captureWalletAddress(address: string): void {
+  const previousId = walletAddress ? null : sessionId;
+  walletAddress = address;
+
+  if (previousId && !identifySent) {
+    identifySent = true;
+    posthogCapture('$identify', {
+      distinct_id: address,
+      $anon_distinct_id: previousId,
+    });
+  }
+}
+
+function getDistinctId(): string {
+  return walletAddress || sessionId;
+}
+
+function posthogCapture(event: string, properties: Record<string, unknown>): void {
+  if (!feedbackEnabled) return;
+
+  fetch(POSTHOG_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: POSTHOG_API_KEY,
+      event,
+      properties,
+    }),
+  }).catch(() => {
+    feedbackEnabled = false;
+  });
+}
+
+export function sendFeedbackEvent(event: FeedbackEvent): void {
+  const eventName = event.type === 'discovery' ? 'agent_discovery' : 'agent_tool_call';
+
+  const properties: Record<string, unknown> = {
+    distinct_id: getDistinctId(),
+    helius_client: 'helius-mcp',
+    helius_version: version,
+  };
+
+  if (clientInfo) {
+    properties.mcp_client = `${clientInfo.name}/${clientInfo.version}`;
+  }
+  if (event.toolName) properties.current_tool = event.toolName;
+  if (event.feedback) properties.feedback = event.feedback;
+  if (event.feedbackTool) properties.feedback_tool = event.feedbackTool;
+  if (event.model) properties.llm_model = event.model;
+  if (event.discoveryPath) properties.discovery_path = event.discoveryPath;
+  if (event.frictionPoints) properties.friction_points = event.frictionPoints;
+
+  posthogCapture(eventName, properties);
+}

--- a/helius-mcp/src/utils/feedback.ts
+++ b/helius-mcp/src/utils/feedback.ts
@@ -58,7 +58,7 @@ function posthogCapture(event: string, properties: Record<string, unknown>): voi
 }
 
 export function sendFeedbackEvent(event: FeedbackEvent): void {
-  const eventName = event.type === 'discovery' ? 'agent_discovery' : 'agent_tool_call';
+  const eventName = event.type === 'discovery' ? 'agent_discovery' : 'agent_invocation';
 
   const properties: Record<string, unknown> = {
     distinct_id: getDistinctId(),

--- a/helius-mcp/src/utils/feedback.ts
+++ b/helius-mcp/src/utils/feedback.ts
@@ -1,8 +1,13 @@
 import { version } from '../version.js';
 import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
 const POSTHOG_ENDPOINT = 'https://www.helius.dev/relay-RMqE/capture/';
 const POSTHOG_API_KEY = 'phc_aLmID5mMwUZi3pVhG4HomDeZaWZ1PqAEkWTempDogzi';
+const HELIUS_DIR = path.join(os.homedir(), '.helius');
+const ANON_ID_PATH = path.join(HELIUS_DIR, 'anon-id');
 
 interface FeedbackEvent {
   type: 'tool_call' | 'discovery';
@@ -18,7 +23,22 @@ let clientInfo: { name: string; version: string } | null = null;
 let feedbackEnabled = true;
 let walletAddress: string | null = null;
 let identifySent = false;
-const sessionId = crypto.randomUUID();
+
+// Persistent anonymous ID shared with helius-cli.
+let sessionId: string;
+try {
+  if (fs.existsSync(ANON_ID_PATH)) {
+    sessionId = fs.readFileSync(ANON_ID_PATH, 'utf-8').trim();
+  } else {
+    sessionId = crypto.randomUUID();
+    try {
+      fs.mkdirSync(HELIUS_DIR, { recursive: true });
+      fs.writeFileSync(ANON_ID_PATH, sessionId, 'utf-8');
+    } catch {}
+  }
+} catch {
+  sessionId = crypto.randomUUID();
+}
 
 export function captureClientInfo(info: { name: string; version: string }): void {
   clientInfo = info;


### PR DESCRIPTION
## agent feedback loop

adds posthog analytics and agent feedback collection to both helius-mcp and helius-cli. events are sent via the helius.dev reverse proxy (fire-and-forget, auto-disables on failure).

### helius-mcp

- every tool call sends `agent_invocation` event to posthog with `current_tool`, `feedback`, `feedback_tool`, `llm_model`
- `_feedback`, `_feedbackTool`, `_model` are **required** params on every tool — agents must provide feedback and identify themselves
- on signup (`agenticSignup`), sends `agent_discovery` event with `discovery_path` and `friction_points`
- captures mcp client identity (cursor, claude code, etc.) from protocol handshake
- uses wallet pubkey as posthog `distinct_id`, session uuid as fallback pre-keygen
- `$identify` merges pre-keygen events with wallet identity

### helius-cli

- every command sends `agent_invocation` event via commander `preAction` hook
- failed commands also send event with `exit_code` and `success: false`
- `helius feedback <text> --feedback-tool <cmd> --model <name>` command for explicit feedback
- after every command output, prints a directive prompting the agent to run `helius feedback`
- `helius signup` accepts `--discovery-path` and `--friction-points` flags, sends `agent_discovery` event
- uses wallet pubkey as `distinct_id`, session uuid as fallback

### posthog events

| event | source | when |
|-------|--------|------|
| `agent_invocation` | both | every mcp tool call or cli command |
| `agent_discovery` | both | signup |

`helius_client` (`helius-mcp` / `helius-cli`) distinguishes the source in every event.

### files changed

- `helius-mcp/src/utils/feedback.ts` — posthog sender, wallet-based identity, `$identify` merge
- `helius-mcp/src/tools/index.ts` — patches `_createRegisteredTool` to inject feedback params
- `helius-mcp/src/index.ts` — captures mcp client identity, feedback instructions
- `helius-mcp/src/tools/auth.ts` — discovery feedback on signup
- `helius-cli/src/lib/feedback.ts` — posthog sender, wallet-based identity
- `helius-cli/bin/helius.ts` — preAction hook, postAction prompt, feedback command
- `helius-cli/src/commands/signup.ts` — discovery feedback on signup
- `helius-cli/src/lib/output.ts` — error event capture