### PR TITLE
Bump helius-mcp and helius-cli to 1.2.0

### DIFF
--- a/helius-cli/package.json
+++ b/helius-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CLI to create free Helius accounts and manage projects",
   "type": "module",
   "bin": {

--- a/helius-mcp/package.json
+++ b/helius-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-mcp",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Official Helius MCP Server - Complete Solana blockchain data access for AI assistants",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## summary

- bump `helius-mcp` from 1.0.0 to 1.2.0
- bump `helius-cli` from 1.1.0 to 1.2.0

### what's new in 1.2.0

**agent feedback loop (mcp + cli)**
- every mcp tool now accepts `_feedback`, `_feedbackTool`, and `_model` params, injected automatically via schema patching
- posthog analytics pipeline for `agent_invocation` and `agent_discovery` events
- identity tracking: wallet address when available, persistent anonymous id otherwise, with merge on signup
- mcp captures client info (cursor, claude code, etc.) after handshake
- cli: `helius feedback` command + post-command feedback prompt
- cli: `--discovery-path` and `--friction-points` options on signup

**actionable error guidance (mcp + cli)**
- mcp: http 401/403/429/502/504 errors now include which tool to call next (`getAccountStatus`, `getHeliusPlanInfo`, `previewUpgrade`)
- cli: same errors show a yellow hint line with the cli command to run next (`helius config set-api-key`, `helius usage`), plus a `guidance` field in `--json` output