### PR TITLE
feat(cli): Implement Better Error Handling With Custom Catch Block

### DIFF
--- a/helius-cli/CLAUDE.md
+++ b/helius-cli/CLAUDE.md
@@ -47,16 +47,16 @@ All data commands follow this pattern:
 5. Output: formatted terminal (chalk) or `outputJson()` for `--json`
 6. Error: use `handleCommandError(error, options, spinner)` — classifies the error, emits JSON or spinner output, and exits with the classified exit code
 
-Standard catch block template (all commands except `ws.ts` and `signup.ts`):
+Standard catch block template (all commands except `ws.ts`):
 ```ts
 } catch (error) {
   handleCommandError(error, options, spinner);
 }
 ```
 
-`handleCommandError()` in `src/lib/output.ts` calls `classifyError()` internally, formats JSON or spinner output (with retryable hint), and exits with the classified exit code. All error output logic lives in this single function — do not duplicate it inline.
+`handleCommandError()` in `src/lib/output.ts` calls `classifyError()` internally, formats JSON or spinner output (with retryable hint), and exits with the classified exit code. All error output logic lives in this single function — do not duplicate it inline. Payment-specific errors (Insufficient SOL/USDC, Checkout failed/expired/timeout) are classified via keyword matching in `classifyError()`.
 
-WebSocket commands (`ws.ts`) use a variant that preserves the AbortError early-return and uses `console.error` instead of spinner. `signup.ts` uses a custom catch block with `mapErrorToExitCode()` for domain-specific payment errors (Insufficient SOL/USDC, Checkout failed).
+WebSocket commands (`ws.ts`) use a variant that preserves the AbortError early-return and uses `console.error` instead of spinner.
 
 ## API Key Resolution Chain
 
@@ -92,7 +92,7 @@ The `retryable` field in `--json` error output reflects this directly.
 
 1. **`HeliusHttpError`** (from `restRequest()` — wallet.ts REST path): exact `status` property → precise code
 2. **Status in message** (enhanced TX: `"Helius HTTP 429: ..."`, webhooks: `"HTTP error! status: 429 - ..."`): regex extracts status → same mapping
-3. **Keyword matching** (RPC caller path — DAS, ZK, staking, raw): matches phrases like `"invalid api key"`, `"rate limit"`, `"not found"`, `"ECONNREFUSED"`, `SyntaxError`, etc.
+3. **Keyword matching** (RPC caller path — DAS, ZK, staking, raw, payment): matches phrases like `"insufficient sol"`, `"insufficient usdc"`, `"checkout failed"`, `"invalid api key"`, `"rate limit"`, `"not found"`, `"ECONNREFUSED"`, `SyntaxError`, etc.
 
 `restRequest()` throws `HeliusHttpError` (defined in `src/lib/helius.ts`) so the REST path always hits Tier 1. The SDK paths hit Tier 2 or 3 depending on the client.
 

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -5,7 +5,7 @@ import { agenticSignup, listProjects } from "../lib/api.js";
 import { setJwt, setApiKey, setSharedApiKey, setProjectId, SHARED_CONFIG_PATH } from "../lib/config.js";
 import { keypairExists, keygenCommand } from "./keygen.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
 import { PLAN_CATALOG } from "../lib/checkout.js";
 import { sendDiscoveryEvent } from "../lib/feedback.js";
@@ -20,17 +20,6 @@ interface SignupOptions extends OutputOptions {
   lastName?: string;
   discoveryPath?: string;
   frictionPoints?: string;
-}
-
-function mapErrorToExitCode(message: string): number {
-  if (message.includes("Insufficient SOL")) return ExitCode.INSUFFICIENT_SOL;
-  if (message.includes("Insufficient USDC")) return ExitCode.INSUFFICIENT_USDC;
-  if (
-    message.includes("Checkout failed") ||
-    message.includes("Checkout expired") ||
-    message.includes("Checkout timeout")
-  ) return ExitCode.PAYMENT_FAILED;
-  return ExitCode.GENERAL_ERROR;
 }
 
 export async function signupCommand(options: SignupOptions): Promise<void> {
@@ -225,13 +214,6 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
       );
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const exitCode = mapErrorToExitCode(message);
-
-    if (options.json) {
-      exitWithError("SIGNUP_FAILED", message, undefined, true);
-    }
-    spinner?.fail(`Error: ${message}`);
-    process.exit(exitCode);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -132,7 +132,18 @@ export function classifyError(error: unknown): ErrorClassification {
     return classifyByStatus(embeddedStatus);
   }
 
-  // Tier 3 — Keyword matching (RPC caller path, resolveApiKey, network errors)
+  // Tier 3 — Keyword matching (RPC caller path, resolveApiKey, payment, network errors)
+
+  // Payment / balance errors (signup, upgrade, pay)
+  if (/insufficient sol/i.test(msg)) {
+    return { exitCode: ExitCode.INSUFFICIENT_SOL, errorCode: "INSUFFICIENT_SOL", retryable: false };
+  }
+  if (/insufficient usdc/i.test(msg)) {
+    return { exitCode: ExitCode.INSUFFICIENT_USDC, errorCode: "INSUFFICIENT_USDC", retryable: false };
+  }
+  if (/checkout (failed|expired|timeout)/i.test(msg)) {
+    return { exitCode: ExitCode.PAYMENT_FAILED, errorCode: "PAYMENT_FAILED", retryable: false };
+  }
 
   // resolveApiKey() failure
   if (msg.includes("No API key found")) {
@@ -200,6 +211,9 @@ const CLI_GUIDANCE: Record<string, string> = {
   NOT_FOUND: 'The requested resource was not found. Verify the address or identifier is correct.',
   SERVER_ERROR: 'Helius backend error. Retry after a few seconds.',
   NETWORK_ERROR: 'Could not connect to Helius. Check your internet connection and retry.',
+  INSUFFICIENT_SOL: 'Fund your wallet with ~0.001 SOL for transaction fees, then retry.',
+  INSUFFICIENT_USDC: 'Fund your wallet with the required USDC amount, then retry.',
+  PAYMENT_FAILED: 'The on-chain payment did not complete. Check your wallet balance and retry.',
 };
 
 export function handleCommandError(


### PR DESCRIPTION
This PR moves the signup command's error handliong from a custom catch block to the shared `handleCommandError` pipeline, so signup errors now get consistent structured classification, `retryable` fields in JSON output, and telemetry like every other command 