### PR TITLE
fix(cli): Silent Exit in non-JSON Mode

### DIFF
--- a/helius-cli/src/commands/apikeys.ts
+++ b/helius-cli/src/commands/apikeys.ts
@@ -13,7 +13,7 @@ async function resolveProjectId(jwt: string, projectId?: string, json?: boolean)
 
   if (projects.length === 0) {
     if (json) {
-      exitWithError("NO_PROJECTS", "No projects found", undefined, true);
+      exitWithError("NO_PROJECTS", "No projects found", undefined, json);
     }
     throw new Error("No projects found. Run `helius signup` to create your first project.");
   }
@@ -22,7 +22,7 @@ async function resolveProjectId(jwt: string, projectId?: string, json?: boolean)
     if (json) {
       exitWithError("MULTIPLE_PROJECTS", "Multiple projects found, specify project ID", {
         projects: projects.map(p => ({ id: p.id, name: p.name })),
-      }, true);
+      }, json);
     }
     console.log(
       chalk.yellow("Multiple projects found. Please specify a project ID.")
@@ -47,7 +47,7 @@ export async function apikeysCommand(projectId?: string, options: ApikeysOptions
     const jwt = getJwt();
     if (!jwt) {
       if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, true);
+        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
       }
       console.log(
         chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
@@ -114,7 +114,7 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
     const jwt = getJwt();
     if (!jwt) {
       if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, true);
+        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
       }
       console.log(
         chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
@@ -128,7 +128,7 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
 
     if (projects.length === 0) {
       if (options.json) {
-        exitWithError("NO_PROJECTS", "No projects found", undefined, true);
+        exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
       }
       spinner?.fail("No projects found.");
       process.exit(ExitCode.NO_PROJECTS);
@@ -139,7 +139,7 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
 
     if (!project) {
       if (options.json) {
-        exitWithError("PROJECT_NOT_FOUND", `Project ${id} not found`, undefined, true);
+        exitWithError("PROJECT_NOT_FOUND", `Project ${id} not found`, undefined, options.json);
       }
       spinner?.fail(`Project ${id} not found.`);
       process.exit(ExitCode.PROJECT_NOT_FOUND);
@@ -151,7 +151,7 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
 
     if (!walletAddress) {
       if (options.json) {
-        exitWithError("API_ERROR", "Could not determine wallet address from project", undefined, true);
+        exitWithError("API_ERROR", "Could not determine wallet address from project", undefined, options.json);
       }
       spinner?.fail("Could not determine wallet address from project.");
       process.exit(ExitCode.API_ERROR);

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -17,7 +17,7 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
       if (options.json) {
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, true);
+        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
       }
       console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
       console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -31,7 +31,7 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
       if (options.json) {
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, true);
+        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
       }
       console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
       console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));
@@ -69,7 +69,7 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
 
     if (intent.status !== "pending") {
       if (options.json) {
-        exitWithError("PAYMENT_FAILED", `Payment intent is ${intent.status}, cannot pay`, { intentId: intent.id }, true);
+        exitWithError("PAYMENT_FAILED", `Payment intent is ${intent.status}, cannot pay`, { intentId: intent.id }, options.json);
       }
       spinner?.fail(`Payment intent is ${intent.status} — cannot pay`);
       process.exit(ExitCode.PAYMENT_FAILED);

--- a/helius-cli/src/commands/project.ts
+++ b/helius-cli/src/commands/project.ts
@@ -12,7 +12,7 @@ export async function projectCommand(projectId?: string, options: OutputOptions 
     const jwt = getJwt();
     if (!jwt) {
       if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, true);
+        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
       }
       console.log(
         chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
@@ -30,7 +30,7 @@ export async function projectCommand(projectId?: string, options: OutputOptions 
 
       if (projects.length === 0) {
         if (options.json) {
-          exitWithError("NO_PROJECTS", "No projects found", undefined, true);
+          exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
         }
         console.log(chalk.yellow("No projects found."));
         console.log(chalk.gray("Run `helius signup` to create your first project."));
@@ -41,7 +41,7 @@ export async function projectCommand(projectId?: string, options: OutputOptions 
         if (options.json) {
           exitWithError("MULTIPLE_PROJECTS", "Multiple projects found, specify project ID", {
             projects: projects.map(p => ({ id: p.id, name: p.name })),
-          }, true);
+          }, options.json);
         }
         console.log(
           chalk.yellow(

--- a/helius-cli/src/commands/projects.ts
+++ b/helius-cli/src/commands/projects.ts
@@ -11,7 +11,7 @@ export async function projectsCommand(options: OutputOptions): Promise<void> {
     const jwt = getJwt();
     if (!jwt) {
       if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, true);
+        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
       }
       console.log(
         chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")

--- a/helius-cli/src/commands/rpc.ts
+++ b/helius-cli/src/commands/rpc.ts
@@ -12,7 +12,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
     const jwt = getJwt();
     if (!jwt) {
       if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, true);
+        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
       }
       console.log(
         chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
@@ -26,7 +26,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
 
     if (projects.length === 0) {
       if (options.json) {
-        exitWithError("NO_PROJECTS", "No projects found", undefined, true);
+        exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
       }
       console.log(chalk.yellow("No projects found."));
       console.log(chalk.gray("Run `helius signup` to create your first project."));
@@ -40,7 +40,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
         if (options.json) {
           exitWithError("MULTIPLE_PROJECTS", "Multiple projects found, specify project ID", {
             projects: projects.map(p => ({ id: p.id, name: p.name })),
-          }, true);
+          }, options.json);
         }
         console.log(
           chalk.yellow(
@@ -58,7 +58,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
       project = projects.find(p => p.id === projectId);
       if (!project) {
         if (options.json) {
-          exitWithError("PROJECT_NOT_FOUND", `Project ${projectId} not found`, undefined, true);
+          exitWithError("PROJECT_NOT_FOUND", `Project ${projectId} not found`, undefined, options.json);
         }
         console.log(chalk.red(`Project ${projectId} not found.`));
         process.exit(ExitCode.PROJECT_NOT_FOUND);
@@ -76,7 +76,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
 
       if (!fullProject.apiKeys || fullProject.apiKeys.length === 0) {
         if (options.json) {
-          exitWithError("NO_API_KEYS", "No API keys found", undefined, true);
+          exitWithError("NO_API_KEYS", "No API keys found", undefined, options.json);
         }
         console.log(chalk.yellow("No API keys found. Create one with `helius apikeys create`."));
         return;

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -88,7 +88,7 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     if (!keypairExists(options.keypair)) {
       if (options.json) {
         // In JSON mode, don't do interactive keygen — just error
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, true);
+        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
       }
       console.log(chalk.yellow("No keypair found. Generating one automatically...\n"));
       await keygenCommand({ output: options.keypair });
@@ -137,7 +137,7 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
           exitWithError("INSUFFICIENT_FUNDS", `Need more funds: ${missing.join(", ")}`, {
             wallet: walletAddress,
             required: { sol: solOk ? undefined : "~0.001 SOL", usdc: usdcOk ? undefined : requiredUsdcLabel },
-          }, true);
+          }, options.json);
         }
         console.error(chalk.red(`\nInsufficient funds. Send the following to ${chalk.cyan(walletAddress)}:`));
         for (const m of missing) {

--- a/helius-cli/src/commands/simd.ts
+++ b/helius-cli/src/commands/simd.ts
@@ -109,7 +109,7 @@ export async function simdGetCommand(number: string, options: SimdGetOptions = {
   try {
     if (!/^\d+$/.test(number)) {
       if (options.json) {
-        exitWithError("INVALID_INPUT", `Invalid SIMD number: "${number}". Must be numeric.`, undefined, true);
+        exitWithError("INVALID_INPUT", `Invalid SIMD number: "${number}". Must be numeric.`, undefined, options.json);
       }
       console.error(chalk.red(`Invalid SIMD number: "${number}". Must be a numeric value (e.g. 96, 0228).`));
       process.exit(ExitCode.INVALID_INPUT);
@@ -136,7 +136,7 @@ export async function simdGetCommand(number: string, options: SimdGetOptions = {
         .join("\n");
 
       if (options.json) {
-        exitWithError("NOT_FOUND", `SIMD-${paddedNumber} not found`, undefined, true);
+        exitWithError("NOT_FOUND", `SIMD-${paddedNumber} not found`, undefined, options.json);
       }
 
       console.log(chalk.yellow(`\nSIMD-${paddedNumber} not found.`));

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -38,7 +38,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     if (!PLAN_CATALOG[planKey]) {
       const available = Object.keys(PLAN_CATALOG).join(", ");
       if (options.json) {
-        exitWithError("API_ERROR", `Unknown plan: ${options.plan}. Available: ${available}`, undefined, true);
+        exitWithError("API_ERROR", `Unknown plan: ${options.plan}. Available: ${available}`, undefined, options.json);
       }
       console.error(chalk.red(`Unknown plan: ${options.plan}`));
       console.error(chalk.gray(`Available plans: ${available}`));
@@ -55,7 +55,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
       ].filter(Boolean);
       const msg = `Partial customer info provided. If any of --email/--first-name/--last-name is given, all three are required. Missing: ${missing.join(", ")}`;
       if (options.json) {
-        exitWithError("VALIDATION_ERROR", msg, undefined, true);
+        exitWithError("VALIDATION_ERROR", msg, undefined, options.json);
       }
       console.error(chalk.red(msg));
       process.exit(ExitCode.GENERAL_ERROR);
@@ -65,7 +65,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     if (options.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(options.email)) {
       const msg = `Invalid email format: ${options.email}`;
       if (options.json) {
-        exitWithError("VALIDATION_ERROR", msg, undefined, true);
+        exitWithError("VALIDATION_ERROR", msg, undefined, options.json);
       }
       console.error(chalk.red(msg));
       process.exit(ExitCode.GENERAL_ERROR);
@@ -74,7 +74,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
       if (options.json) {
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, true);
+        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
       }
       console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
       console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));
@@ -98,7 +98,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     const projects = await listProjects(authResult.token);
     if (projects.length === 0) {
       if (options.json) {
-        exitWithError("NO_PROJECTS", "No projects found. Run `helius signup` first.", undefined, true);
+        exitWithError("NO_PROJECTS", "No projects found. Run `helius signup` first.", undefined, options.json);
       }
       spinner?.fail("No projects found");
       console.error(chalk.gray("Run `helius signup` to create an account first."));

--- a/helius-cli/src/commands/usage.ts
+++ b/helius-cli/src/commands/usage.ts
@@ -11,7 +11,7 @@ export async function usageCommand(projectId?: string, options: OutputOptions = 
     const jwt = getJwt();
     if (!jwt) {
       if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, true);
+        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
       }
       console.log(
         chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
@@ -28,7 +28,7 @@ export async function usageCommand(projectId?: string, options: OutputOptions = 
 
       if (projects.length === 0) {
         if (options.json) {
-          exitWithError("NO_PROJECTS", "No projects found", undefined, true);
+          exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
         }
         console.log(chalk.yellow("No projects found."));
         console.log(chalk.gray("Run `helius signup` to create your first project."));
@@ -39,7 +39,7 @@ export async function usageCommand(projectId?: string, options: OutputOptions = 
         if (options.json) {
           exitWithError("MULTIPLE_PROJECTS", "Multiple projects found, specify project ID", {
             projects: projects.map(p => ({ id: p.id, name: p.name })),
-          }, true);
+          }, options.json);
         }
         console.log(
           chalk.yellow(

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -281,7 +281,7 @@ export function exitWithError(
   errorCode: string,
   message: string,
   details?: Record<string, unknown>,
-  json?: boolean
+  json = true,
 ): never {
   const exitCode = getExitCode(errorCode);
 

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -288,6 +288,12 @@ export function exitWithError(
   if (json) {
     const retryable = RETRYABLE_CODES.has(exitCode);
     outputJson({ error: errorCode, message, retryable, ...details });
+  } else {
+    console.error(chalk.red(message));
+    const guidance = CLI_GUIDANCE[errorCode];
+    if (guidance) {
+      console.error(chalk.yellow(`\n  Hint: ${guidance}`));
+    }
   }
 
   process.exit(exitCode);


### PR DESCRIPTION
This PR aims to fix the issue where `exitWithError()` calls `process.exit()` without printing anything when `json=false` by printing the error message in red with an actionable hint in yellow to match what `handleCommandError()` already does