### PR TITLE
feat(cli): Add Client-Side Input Validation For Signup, Upgrade, and Webhooks

### DIFF
--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -9,6 +9,7 @@ import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOpt
 import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
 import { PLAN_CATALOG } from "../lib/checkout.js";
 import { sendDiscoveryEvent } from "../lib/feedback.js";
+import { validateSignupPlan, validatePeriod, validateEmail } from "../lib/validation.js";
 
 interface SignupOptions extends OutputOptions {
   keypair: string;
@@ -84,6 +85,20 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
   const spinner = options.json ? null : ora();
 
   try {
+    // Validate plan and period upfront
+    if (options.plan) {
+      const planErr = validateSignupPlan(options.plan);
+      if (planErr) exitWithError("INVALID_INPUT", planErr, undefined, options.json);
+    }
+    if (options.period) {
+      const periodErr = validatePeriod(options.period);
+      if (periodErr) exitWithError("INVALID_INPUT", periodErr, undefined, options.json);
+    }
+    if (options.email) {
+      const emailErr = validateEmail(options.email);
+      if (emailErr) exitWithError("INVALID_INPUT", emailErr, undefined, options.json);
+    }
+
     // Auto-generate keypair if none exists
     if (!keypairExists(options.keypair)) {
       if (options.json) {

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -7,6 +7,7 @@ import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
 import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
+import { validateUpgradePlan, validatePeriod, validateEmail } from "../lib/validation.js";
 
 interface UpgradeOptions extends OutputOptions {
   keypair: string;
@@ -33,17 +34,13 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
   const spinner = options.json ? null : ora();
 
   try {
-    // Validate plan name
+    // Validate plan, period, and email upfront
     const planKey = options.plan.toLowerCase();
-    if (!PLAN_CATALOG[planKey]) {
-      const available = Object.keys(PLAN_CATALOG).join(", ");
-      if (options.json) {
-        exitWithError("API_ERROR", `Unknown plan: ${options.plan}. Available: ${available}`, undefined, options.json);
-      }
-      console.error(chalk.red(`Unknown plan: ${options.plan}`));
-      console.error(chalk.gray(`Available plans: ${available}`));
-      process.exit(ExitCode.GENERAL_ERROR);
-    }
+    const planErr = validateUpgradePlan(options.plan);
+    if (planErr) exitWithError("INVALID_INPUT", planErr, undefined, options.json);
+
+    const periodErr = validatePeriod(options.period);
+    if (periodErr) exitWithError("INVALID_INPUT", periodErr, undefined, options.json);
 
     // All-or-none customer info validation
     const hasAnyCustomerInfo = options.email || options.firstName || options.lastName;
@@ -53,22 +50,12 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
         !options.firstName && "firstName",
         !options.lastName && "lastName",
       ].filter(Boolean);
-      const msg = `Partial customer info provided. If any of --email/--first-name/--last-name is given, all three are required. Missing: ${missing.join(", ")}`;
-      if (options.json) {
-        exitWithError("VALIDATION_ERROR", msg, undefined, options.json);
-      }
-      console.error(chalk.red(msg));
-      process.exit(ExitCode.GENERAL_ERROR);
+      exitWithError("INVALID_INPUT", `Partial customer info. If any of --email/--first-name/--last-name is given, all three are required. Missing: ${missing.join(", ")}`, undefined, options.json);
     }
 
-    // Basic email format validation
-    if (options.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(options.email)) {
-      const msg = `Invalid email format: ${options.email}`;
-      if (options.json) {
-        exitWithError("VALIDATION_ERROR", msg, undefined, options.json);
-      }
-      console.error(chalk.red(msg));
-      process.exit(ExitCode.GENERAL_ERROR);
+    if (options.email) {
+      const emailErr = validateEmail(options.email);
+      if (emailErr) exitWithError("INVALID_INPUT", emailErr, undefined, options.json);
     }
 
     // Check keypair exists

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -2,7 +2,8 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { validateSolanaAddresses } from "../lib/validation.js";
 
 interface WebhookOptions extends OutputOptions, ResolveOptions {}
 
@@ -77,8 +78,12 @@ export async function webhookCreateCommand(options: WebhookOptions & {
     const apiKey = await resolveApiKey(options);
     const helius = getClient(apiKey, resolveNetwork(options));
 
-    const accountAddresses = options.accounts.split(",").map((s: string) => s.trim());
-    const transactionTypes = options.types.split(",").map((s: string) => s.trim());
+    // Validate addresses before sending to API
+    const addrErr = validateSolanaAddresses(options.accounts);
+    if (addrErr) exitWithError("INVALID_INPUT", addrErr, undefined, options.json);
+
+    const accountAddresses = options.accounts.split(",").map((s: string) => s.trim()).filter(Boolean);
+    const transactionTypes = options.types.split(",").map((s: string) => s.trim()).filter(Boolean);
     const webhookType = (options.webhookType || "enhanced") as any;
 
     spinner?.start("Creating webhook...");
@@ -111,9 +116,14 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
     const helius = getClient(apiKey, resolveNetwork(options));
 
     const params: any = {};
+    // Validate addresses if provided
+    if (options.accounts) {
+      const addrErr = validateSolanaAddresses(options.accounts);
+      if (addrErr) exitWithError("INVALID_INPUT", addrErr, undefined, options.json);
+    }
     if (options.url) params.webhookURL = options.url;
-    if (options.accounts) params.accountAddresses = options.accounts.split(",").map((s: string) => s.trim());
-    if (options.types) params.transactionTypes = options.types.split(",").map((s: string) => s.trim());
+    if (options.accounts) params.accountAddresses = options.accounts.split(",").map((s: string) => s.trim()).filter(Boolean);
+    if (options.types) params.transactionTypes = options.types.split(",").map((s: string) => s.trim()).filter(Boolean);
 
     spinner?.start("Updating webhook...");
     const result = await helius.webhooks.update(webhookId, params);

--- a/helius-cli/src/lib/validation.ts
+++ b/helius-cli/src/lib/validation.ts
@@ -1,0 +1,52 @@
+import { PLAN_CATALOG } from "../lib/checkout.js";
+
+// Valid plans for signup (includes "basic" which isn't in PLAN_CATALOG)
+const SIGNUP_PLANS = new Set(["basic", ...Object.keys(PLAN_CATALOG)]);
+const UPGRADE_PLANS = new Set(Object.keys(PLAN_CATALOG));
+const VALID_PERIODS = new Set(["monthly", "yearly"]);
+
+// Base58 character set (no 0, O, I, l)
+const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+export function validateSignupPlan(plan: string): string | null {
+  if (!SIGNUP_PLANS.has(plan.toLowerCase())) {
+    const available = [...SIGNUP_PLANS].join(", ");
+    return `Unknown plan: ${plan}. Available: ${available}`;
+  }
+  return null;
+}
+
+export function validateUpgradePlan(plan: string): string | null {
+  if (!UPGRADE_PLANS.has(plan.toLowerCase())) {
+    const available = [...UPGRADE_PLANS].join(", ");
+    return `Unknown plan: ${plan}. Available: ${available}`;
+  }
+  return null;
+}
+
+export function validatePeriod(period: string): string | null {
+  if (!VALID_PERIODS.has(period.toLowerCase())) {
+    return `Invalid billing period: ${period}. Must be "monthly" or "yearly".`;
+  }
+  return null;
+}
+
+export function validateEmail(email: string): string | null {
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return `Invalid email format: ${email}`;
+  }
+  return null;
+}
+
+export function validateSolanaAddresses(raw: string): string | null {
+  const addresses = raw.split(",").map(s => s.trim()).filter(Boolean);
+  if (addresses.length === 0) {
+    return "No addresses provided. Provide a comma-separated list of Solana addresses.";
+  }
+  for (const addr of addresses) {
+    if (!BASE58_RE.test(addr)) {
+      return `Invalid Solana address: ${addr}`;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
This PR adds new shared validation utils so we now validate input for the `signup`, `upgrade`, and `webhook create/update` commands