### PR TITLE
feat(cli): Unify Error Handling Across Commands

### DIFF
--- a/helius-cli/src/commands/apikeys.ts
+++ b/helius-cli/src/commands/apikeys.ts
@@ -46,13 +46,7 @@ export async function apikeysCommand(projectId?: string, options: ApikeysOptions
   try {
     const jwt = getJwt();
     if (!jwt) {
-      if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
-      }
-      console.log(
-        chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
-      );
-      process.exit(ExitCode.NOT_LOGGED_IN);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
     }
 
     spinner?.start("Fetching API keys...");
@@ -113,13 +107,7 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
   try {
     const jwt = getJwt();
     if (!jwt) {
-      if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
-      }
-      console.log(
-        chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
-      );
-      process.exit(ExitCode.NOT_LOGGED_IN);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
     }
 
     // Get wallet address from the first project's users (the owner)
@@ -127,22 +115,14 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
     const projects = await listProjects(jwt);
 
     if (projects.length === 0) {
-      if (options.json) {
-        exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
-      }
-      spinner?.fail("No projects found.");
-      process.exit(ExitCode.NO_PROJECTS);
+      exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
     }
 
     const id = projectId || projects[0].id;
     const project = projects.find(p => p.id === id);
 
     if (!project) {
-      if (options.json) {
-        exitWithError("PROJECT_NOT_FOUND", `Project ${id} not found`, undefined, options.json);
-      }
-      spinner?.fail(`Project ${id} not found.`);
-      process.exit(ExitCode.PROJECT_NOT_FOUND);
+      exitWithError("PROJECT_NOT_FOUND", `Project ${id} not found`, undefined, options.json);
     }
 
     // Get wallet address from the project users (the owner)
@@ -150,11 +130,7 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
     const walletAddress = owner?.id;
 
     if (!walletAddress) {
-      if (options.json) {
-        exitWithError("API_ERROR", "Could not determine wallet address from project", undefined, options.json);
-      }
-      spinner?.fail("Could not determine wallet address from project.");
-      process.exit(ExitCode.API_ERROR);
+      exitWithError("API_ERROR", "Could not determine wallet address from project", undefined, options.json);
     }
 
     if (spinner) spinner.text = "Creating API key...";

--- a/helius-cli/src/commands/config-cmd.ts
+++ b/helius-cli/src/commands/config-cmd.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { formatEnumLabel } from "../lib/formatters.js";
 import { load, setApiKey, setNetwork, setProjectId, clearConfig } from "../lib/config.js";
-import { outputJson, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, type OutputOptions } from "../lib/output.js";
 
 interface ConfigShowOptions extends OutputOptions {
   reveal?: boolean;
@@ -45,8 +45,7 @@ export function configSetApiKeyCommand(key: string, options: OutputOptions = {})
 
 export function configSetNetworkCommand(network: string, options: OutputOptions = {}): void {
   if (network !== "mainnet" && network !== "devnet") {
-    console.error(chalk.red(`Invalid network: ${network}. Use "mainnet" or "devnet".`));
-    process.exit(ExitCode.GENERAL_ERROR);
+    exitWithError("INVALID_INPUT", `Invalid network: ${network}. Use "mainnet" or "devnet".`, undefined, options.json);
   }
   const resolved = network as "mainnet" | "devnet";
   setNetwork(resolved);

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -4,7 +4,7 @@ import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.
 import { signup } from "../lib/api.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface LoginOptions extends OutputOptions {
   keypair: string;
@@ -16,12 +16,7 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
   try {
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
-      if (options.json) {
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
-      }
-      console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
-      console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));
-      process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
     }
 
     // Load keypair

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -6,7 +6,7 @@ import { getPaymentIntent, executeRenewal } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
 
 interface PayOptions extends OutputOptions {
@@ -30,12 +30,7 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
   try {
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
-      if (options.json) {
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
-      }
-      console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
-      console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));
-      process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
     }
 
     // 1. Load keypair and authenticate
@@ -68,11 +63,7 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
     }
 
     if (intent.status !== "pending") {
-      if (options.json) {
-        exitWithError("PAYMENT_FAILED", `Payment intent is ${intent.status}, cannot pay`, { intentId: intent.id }, options.json);
-      }
-      spinner?.fail(`Payment intent is ${intent.status} — cannot pay`);
-      process.exit(ExitCode.PAYMENT_FAILED);
+      exitWithError("PAYMENT_FAILED", `Payment intent is ${intent.status}, cannot pay`, { intentId: intent.id }, options.json);
     }
 
     if (!options.yes) {

--- a/helius-cli/src/commands/project.ts
+++ b/helius-cli/src/commands/project.ts
@@ -11,13 +11,7 @@ export async function projectCommand(projectId?: string, options: OutputOptions 
   try {
     const jwt = getJwt();
     if (!jwt) {
-      if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
-      }
-      console.log(
-        chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
-      );
-      process.exit(ExitCode.NOT_LOGGED_IN);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
     }
 
     // If no project ID provided, try to get the only project
@@ -29,12 +23,7 @@ export async function projectCommand(projectId?: string, options: OutputOptions 
       spinner?.stop();
 
       if (projects.length === 0) {
-        if (options.json) {
-          exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
-        }
-        console.log(chalk.yellow("No projects found."));
-        console.log(chalk.gray("Run `helius signup` to create your first project."));
-        process.exit(ExitCode.NO_PROJECTS);
+        exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
       }
 
       if (projects.length > 1) {

--- a/helius-cli/src/commands/projects.ts
+++ b/helius-cli/src/commands/projects.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { listProjects } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 export async function projectsCommand(options: OutputOptions): Promise<void> {
   const spinner = options.json ? null : ora();
@@ -10,13 +10,7 @@ export async function projectsCommand(options: OutputOptions): Promise<void> {
   try {
     const jwt = getJwt();
     if (!jwt) {
-      if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
-      }
-      console.log(
-        chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
-      );
-      process.exit(ExitCode.NOT_LOGGED_IN);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
     }
 
     spinner?.start("Fetching projects...");

--- a/helius-cli/src/commands/rpc.ts
+++ b/helius-cli/src/commands/rpc.ts
@@ -11,13 +11,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
   try {
     const jwt = getJwt();
     if (!jwt) {
-      if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
-      }
-      console.log(
-        chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
-      );
-      process.exit(ExitCode.NOT_LOGGED_IN);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
     }
 
     spinner?.start("Fetching projects...");
@@ -25,12 +19,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
     spinner?.stop();
 
     if (projects.length === 0) {
-      if (options.json) {
-        exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
-      }
-      console.log(chalk.yellow("No projects found."));
-      console.log(chalk.gray("Run `helius signup` to create your first project."));
-      process.exit(ExitCode.NO_PROJECTS);
+      exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
     }
 
     // If no project ID provided, try to get the only project
@@ -57,11 +46,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
     } else {
       project = projects.find(p => p.id === projectId);
       if (!project) {
-        if (options.json) {
-          exitWithError("PROJECT_NOT_FOUND", `Project ${projectId} not found`, undefined, options.json);
-        }
-        console.log(chalk.red(`Project ${projectId} not found.`));
-        process.exit(ExitCode.PROJECT_NOT_FOUND);
+        exitWithError("PROJECT_NOT_FOUND", `Project ${projectId} not found`, undefined, options.json);
       }
     }
 
@@ -75,11 +60,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
       spinner?.stop();
 
       if (!fullProject.apiKeys || fullProject.apiKeys.length === 0) {
-        if (options.json) {
-          exitWithError("NO_API_KEYS", "No API keys found", undefined, options.json);
-        }
-        console.log(chalk.yellow("No API keys found. Create one with `helius apikeys create`."));
-        return;
+        exitWithError("NO_API_KEYS", "No API keys found", undefined, options.json);
       }
 
       const apiKey = fullProject.apiKeys[0].keyId;

--- a/helius-cli/src/commands/simd.ts
+++ b/helius-cli/src/commands/simd.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
 import { CLI_USER_AGENT } from "../http.js";
-import { outputJson, handleCommandError, exitWithError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, exitWithError, type OutputOptions } from "../lib/output.js";
 
 // ---------------------------------------------------------------------------
 // GitHub constants
@@ -108,11 +108,7 @@ export async function simdGetCommand(number: string, options: SimdGetOptions = {
   const spinner = options.json ? null : ora();
   try {
     if (!/^\d+$/.test(number)) {
-      if (options.json) {
-        exitWithError("INVALID_INPUT", `Invalid SIMD number: "${number}". Must be numeric.`, undefined, options.json);
-      }
-      console.error(chalk.red(`Invalid SIMD number: "${number}". Must be a numeric value (e.g. 96, 0228).`));
-      process.exit(ExitCode.INVALID_INPUT);
+      exitWithError("INVALID_INPUT", `Invalid SIMD number: "${number}". Must be numeric.`, undefined, options.json);
     }
 
     const paddedNumber = number.replace(/^0+/, "").padStart(4, "0");

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, handleCommandError, ExitCode, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface StakeOptions extends OutputOptions, ResolveOptions {}
 
@@ -122,8 +122,7 @@ export async function stakeWithdrawInstructionCommand(stakeAccount: string, opti
 export async function stakeCreateCommand(amount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
   const spinner = options.json ? null : ora();
   if (!options.keypair) {
-    spinner?.fail("Missing --keypair flag");
-    process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
   }
   try {
     spinner?.start("Resolving API key...");
@@ -149,8 +148,7 @@ export async function stakeCreateCommand(amount: string, options: StakeOptions &
 export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
   const spinner = options.json ? null : ora();
   if (!options.keypair) {
-    spinner?.fail("Missing --keypair flag");
-    process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
   }
   try {
     spinner?.start("Resolving API key...");
@@ -174,8 +172,7 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
 export async function stakeWithdrawCommand(stakeAccount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
   const spinner = options.json ? null : ora();
   if (!options.keypair) {
-    spinner?.fail("Missing --keypair flag");
-    process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
   }
   try {
     spinner?.start("Resolving API key...");

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -5,7 +5,7 @@ import { signup, listProjects, getProject } from "../lib/api.js";
 import { getCheckoutPreview, executeCheckout, PLAN_CATALOG } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
 import { validateUpgradePlan, validatePeriod, validateEmail } from "../lib/validation.js";
 
@@ -60,12 +60,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
 
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
-      if (options.json) {
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
-      }
-      console.error(chalk.red(`Error: Keypair not found at ${options.keypair}`));
-      console.error(chalk.gray("Run `helius keygen` to generate a keypair first."));
-      process.exit(ExitCode.KEYPAIR_NOT_FOUND);
+      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
     }
 
     // 1. Load keypair and authenticate
@@ -84,12 +79,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     spinner?.start("Fetching project...");
     const projects = await listProjects(authResult.token);
     if (projects.length === 0) {
-      if (options.json) {
-        exitWithError("NO_PROJECTS", "No projects found. Run `helius signup` first.", undefined, options.json);
-      }
-      spinner?.fail("No projects found");
-      console.error(chalk.gray("Run `helius signup` to create an account first."));
-      process.exit(ExitCode.NO_PROJECTS);
+      exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
     }
     const project = projects[0];
     const projectDetails = await getProject(authResult.token, project.id);

--- a/helius-cli/src/commands/usage.ts
+++ b/helius-cli/src/commands/usage.ts
@@ -10,13 +10,7 @@ export async function usageCommand(projectId?: string, options: OutputOptions = 
   try {
     const jwt = getJwt();
     if (!jwt) {
-      if (options.json) {
-        exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
-      }
-      console.log(
-        chalk.red("Not logged in. Run `helius login` to authenticate, or `helius signup` to create a new account.")
-      );
-      process.exit(ExitCode.NOT_LOGGED_IN);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
     }
 
     // If no project ID provided, try to get the only project
@@ -27,12 +21,7 @@ export async function usageCommand(projectId?: string, options: OutputOptions = 
       spinner?.stop();
 
       if (projects.length === 0) {
-        if (options.json) {
-          exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
-        }
-        console.log(chalk.yellow("No projects found."));
-        console.log(chalk.gray("Run `helius signup` to create your first project."));
-        process.exit(ExitCode.NO_PROJECTS);
+        exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
       }
 
       if (projects.length > 1) {

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -214,6 +214,13 @@ const CLI_GUIDANCE: Record<string, string> = {
   INSUFFICIENT_SOL: 'Fund your wallet with ~0.001 SOL for transaction fees, then retry.',
   INSUFFICIENT_USDC: 'Fund your wallet with the required USDC amount, then retry.',
   PAYMENT_FAILED: 'The on-chain payment did not complete. Check your wallet balance and retry.',
+  NOT_LOGGED_IN: 'Run `helius login` to authenticate, or `helius signup` to create a new account.',
+  KEYPAIR_NOT_FOUND: 'Run `helius keygen` to generate a keypair first.',
+  NO_PROJECTS: 'Run `helius signup` to create your first project.',
+  MULTIPLE_PROJECTS: 'Specify a project ID. Run `helius projects` to list them.',
+  PROJECT_NOT_FOUND: 'Run `helius projects` to list available projects.',
+  NO_API_KEYS: 'Run `helius apikeys create` to create an API key.',
+  INVALID_INPUT: 'Check command usage with --help.',
 };
 
 export function handleCommandError(


### PR DESCRIPTION
This PR unifies CLI error handling across all commands by:
- Adding 7 `CLI_GUIDANCE` entries so non-JSON errors show actionable hints
- Collapsing duplicated `if (json) { exitWithError } else { chalk + process.exit }` patterns into single `exitWithError()` calls
- Fixing `config-cmd.ts` to use `exitWithError()`
- Fixing `stake.ts` to use `exitWithError()`
- Removing unused `ExitCode` imports