### PR TITLE
feat(skills): Add Skill Versioning

### DIFF
--- a/.agents/skills/helius-dflow/SKILL.md
+++ b/.agents/skills/helius-dflow/SKILL.md
@@ -2,6 +2,7 @@
 
 ---
 name: helius-dflow
+version: "1.0.0"
 description: >
   Build Solana trading applications combining DFlow trading APIs with Helius
   infrastructure. Use this skill when: building swap UIs or trading terminals,

--- a/.agents/skills/helius-dflow/prompts/claude.system.md
+++ b/.agents/skills/helius-dflow/prompts/claude.system.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-dflow/prompts/full.md
+++ b/.agents/skills/helius-dflow/prompts/full.md
@@ -1,4 +1,5 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
+<!-- Version: 1.0.0 -->
 
 
 # Helius x DFlow — Build Trading Apps on Solana

--- a/.agents/skills/helius-dflow/prompts/openai.developer.md
+++ b/.agents/skills/helius-dflow/prompts/openai.developer.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-phantom/SKILL.md
+++ b/.agents/skills/helius-phantom/SKILL.md
@@ -2,6 +2,7 @@
 
 ---
 name: helius-phantom
+version: "1.0.0"
 description: >
   Build frontend Solana applications with Phantom Connect SDK and Helius
   infrastructure. Use this skill when: connecting Phantom wallet in React,

--- a/.agents/skills/helius-phantom/prompts/claude.system.md
+++ b/.agents/skills/helius-phantom/prompts/claude.system.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-phantom/prompts/full.md
+++ b/.agents/skills/helius-phantom/prompts/full.md
@@ -1,4 +1,5 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
+<!-- Version: 1.0.0 -->
 
 
 # Helius x Phantom — Build Frontend Solana Apps

--- a/.agents/skills/helius-phantom/prompts/openai.developer.md
+++ b/.agents/skills/helius-phantom/prompts/openai.developer.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius/SKILL.md
+++ b/.agents/skills/helius/SKILL.md
@@ -2,6 +2,7 @@
 
 ---
 name: helius
+version: "1.0.0"
 description: >
   Build Solana applications with Helius infrastructure. Use this skill when:
   sending transactions (SOL, SPL tokens, swaps), querying assets/NFTs (DAS API),

--- a/.agents/skills/helius/prompts/claude.system.md
+++ b/.agents/skills/helius/prompts/claude.system.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius/prompts/full.md
+++ b/.agents/skills/helius/prompts/full.md
@@ -1,4 +1,5 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
+<!-- Version: 1.0.0 -->
 
 
 # Helius — Build on Solana

--- a/.agents/skills/helius/prompts/openai.developer.md
+++ b/.agents/skills/helius/prompts/openai.developer.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/svm/SKILL.md
+++ b/.agents/skills/svm/SKILL.md
@@ -2,6 +2,7 @@
 
 ---
 name: svm
+version: "1.0.0"
 description: >
   Explore Solana's architecture and protocol internals. Use this skill when:
   understanding the SVM execution engine, learning about the account model and

--- a/.agents/skills/svm/prompts/claude.system.md
+++ b/.agents/skills/svm/prompts/claude.system.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/svm/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/svm/prompts/full.md
+++ b/.agents/skills/svm/prompts/full.md
@@ -1,4 +1,5 @@
 <!-- Generated from helius-skills/svm/SKILL.md — do not edit -->
+<!-- Version: 1.0.0 -->
 
 
 # SVM — Understand Solana's Architecture

--- a/.agents/skills/svm/prompts/openai.developer.md
+++ b/.agents/skills/svm/prompts/openai.developer.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/svm/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,14 @@ The SVM skill (`helius-skills/svm/`, `helius-plugin/skills/svm/`, and `helius-cu
 - The SVM skill contains 10 reference files: compilation, programs, execution, accounts, transactions, consensus, validators, data, development, tokens.
 - When updating SVM reference files, update in `helius-skills/svm/references/` first, then copy to both `helius-plugin/skills/svm/references/` and `helius-cursor/skills/svm/references/`.
 
+## Skill Versioning
+
+Skill versions are managed via `versions.json` at the repo root (single source of truth). The compiler reads this file and injects versions into all SKILL.md copies and prompt variants.
+
+- **To bump a version**: edit `versions.json`, then run `npx tsx scripts/compile-skills.ts`
+- The compiler updates: canonical `helius-skills/*/SKILL.md`, plugin/cursor copies, Codex SKILL.md, and all prompt variants (openai/claude/full)
+- Versions follow semver (`major.minor.patch`)
+
 ## Generated Output
 
 The following directories are **generated** by `npx tsx scripts/compile-skills.ts` from canonical sources in `helius-skills/`. Do not edit them directly.

--- a/helius-cursor/skills/build/SKILL.md
+++ b/helius-cursor/skills/build/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: build
 description: Build Solana applications with Helius infrastructure. Covers transaction sending (Sender), asset/NFT queries (DAS API), real-time streaming (WebSockets, Laserstream), event pipelines (webhooks), priority fees, wallet analysis, and agent onboarding.
+metadata:
+  version: "1.0.0"
 ---
 
 # Helius — Build on Solana

--- a/helius-cursor/skills/dflow/SKILL.md
+++ b/helius-cursor/skills/dflow/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: dflow
 description: Build Solana trading applications combining DFlow trading APIs with Helius infrastructure. Covers spot swaps (imperative and declarative), prediction markets, real-time market streaming, Proof KYC, transaction submission via Sender, fee optimization, shred-level streaming via LaserStream, and wallet intelligence.
+metadata:
+  version: "1.0.0"
 ---
 
 # Helius x DFlow — Build Trading Apps on Solana

--- a/helius-cursor/skills/phantom/SKILL.md
+++ b/helius-cursor/skills/phantom/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: phantom
 description: Build frontend Solana applications with Phantom Connect SDK and Helius infrastructure. Covers React, React Native, and browser SDK integration, transaction signing via Helius Sender, API key proxying, token gating, NFT minting, crypto payments, real-time updates, and secure frontend architecture.
+metadata:
+  version: "1.0.0"
 ---
 
 # Helius x Phantom — Build Frontend Solana Apps

--- a/helius-cursor/skills/svm/SKILL.md
+++ b/helius-cursor/skills/svm/SKILL.md
@@ -3,7 +3,7 @@ name: svm
 description: Explore Solana's architecture and protocol internals. Covers the SVM execution engine, account model, consensus, transactions, validator economics, data layer, development tooling, and token extensions using the Helius blog, SIMDs, and Agave/Firedancer source code.
 metadata:
   author: Helius Labs
-  version: "0.1.0"
+  version: "1.0.0"
   mcp-server: helius-mcp
 ---
 

--- a/helius-mcp/system-prompts/helius-dflow/claude.system.md
+++ b/helius-mcp/system-prompts/helius-dflow/claude.system.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-dflow/full.md
+++ b/helius-mcp/system-prompts/helius-dflow/full.md
@@ -1,4 +1,5 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
+<!-- Version: 1.0.0 -->
 
 
 # Helius x DFlow — Build Trading Apps on Solana

--- a/helius-mcp/system-prompts/helius-dflow/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-dflow/openai.developer.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-phantom/claude.system.md
+++ b/helius-mcp/system-prompts/helius-phantom/claude.system.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-phantom/full.md
+++ b/helius-mcp/system-prompts/helius-phantom/full.md
@@ -1,4 +1,5 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
+<!-- Version: 1.0.0 -->
 
 
 # Helius x Phantom — Build Frontend Solana Apps

--- a/helius-mcp/system-prompts/helius-phantom/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-phantom/openai.developer.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius/claude.system.md
+++ b/helius-mcp/system-prompts/helius/claude.system.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius/full.md
+++ b/helius-mcp/system-prompts/helius/full.md
@@ -1,4 +1,5 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
+<!-- Version: 1.0.0 -->
 
 
 # Helius — Build on Solana

--- a/helius-mcp/system-prompts/helius/openai.developer.md
+++ b/helius-mcp/system-prompts/helius/openai.developer.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/svm/claude.system.md
+++ b/helius-mcp/system-prompts/svm/claude.system.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/svm/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/svm/full.md
+++ b/helius-mcp/system-prompts/svm/full.md
@@ -1,4 +1,5 @@
 <!-- Generated from helius-skills/svm/SKILL.md — do not edit -->
+<!-- Version: 1.0.0 -->
 
 
 # SVM — Understand Solana's Architecture

--- a/helius-mcp/system-prompts/svm/openai.developer.md
+++ b/helius-mcp/system-prompts/svm/openai.developer.md
@@ -1,5 +1,6 @@
 <!-- Generated from helius-skills/svm/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
+<!-- Version: 1.0.0 -->
 
 ## Runtime Notes
 

--- a/helius-plugin/skills/build/SKILL.md
+++ b/helius-plugin/skills/build/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: build
 description: Build Solana applications with Helius infrastructure. Covers transaction sending (Sender), asset/NFT queries (DAS API), real-time streaming (WebSockets, Laserstream), event pipelines (webhooks), priority fees, wallet analysis, and agent onboarding.
+metadata:
+  version: "1.0.0"
 ---
 
 # Helius — Build on Solana

--- a/helius-plugin/skills/dflow/SKILL.md
+++ b/helius-plugin/skills/dflow/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: dflow
 description: Build Solana trading applications combining DFlow trading APIs with Helius infrastructure. Covers spot swaps (imperative and declarative), prediction markets, real-time market streaming, Proof KYC, transaction submission via Sender, fee optimization, shred-level streaming via LaserStream, and wallet intelligence.
+metadata:
+  version: "1.0.0"
 ---
 
 # Helius x DFlow — Build Trading Apps on Solana

--- a/helius-plugin/skills/phantom/SKILL.md
+++ b/helius-plugin/skills/phantom/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: phantom
 description: Build frontend Solana applications with Phantom Connect SDK and Helius infrastructure. Covers React, React Native, and browser SDK integration, transaction signing via Helius Sender, API key proxying, token gating, NFT minting, crypto payments, real-time updates, and secure frontend architecture.
+metadata:
+  version: "1.0.0"
 ---
 
 # Helius x Phantom — Build Frontend Solana Apps

--- a/helius-plugin/skills/svm/SKILL.md
+++ b/helius-plugin/skills/svm/SKILL.md
@@ -3,7 +3,7 @@ name: svm
 description: Explore Solana's architecture and protocol internals. Covers the SVM execution engine, account model, consensus, transactions, validator economics, data layer, development tooling, and token extensions using the Helius blog, SIMDs, and Agave/Firedancer source code.
 metadata:
   author: Helius Labs
-  version: "0.1.0"
+  version: "1.0.0"
   mcp-server: helius-mcp
 ---
 

--- a/helius-skills/helius-dflow/SKILL.md
+++ b/helius-skills/helius-dflow/SKILL.md
@@ -4,7 +4,7 @@ description: Build Solana trading applications combining DFlow trading APIs with
 license: MIT
 metadata:
   author: Helius Labs
-  version: "0.1.0"
+  version: "1.0.0"
   tags:
     - solana
     - trading

--- a/helius-skills/helius-phantom/SKILL.md
+++ b/helius-skills/helius-phantom/SKILL.md
@@ -4,7 +4,7 @@ description: Build frontend Solana applications with Phantom Connect SDK and Hel
 license: MIT
 metadata:
   author: Helius Labs
-  version: "0.2.0"
+  version: "1.0.0"
   tags:
     - solana
     - phantom

--- a/helius-skills/helius/SKILL.md
+++ b/helius-skills/helius/SKILL.md
@@ -3,7 +3,7 @@ name: helius
 description: Build Solana applications with Helius infrastructure. Covers transaction sending (Sender), asset/NFT queries (DAS API), real-time streaming (WebSockets, Laserstream), event pipelines (webhooks), priority fees, wallet analysis, and agent onboarding.
 metadata:
   author: Helius Labs
-  version: "0.1.0"
+  version: "1.0.0"
   mcp-server: helius-mcp
 ---
 

--- a/helius-skills/svm/SKILL.md
+++ b/helius-skills/svm/SKILL.md
@@ -3,7 +3,7 @@ name: svm
 description: Explore Solana's architecture and protocol internals. Covers the SVM execution engine, account model, consensus, transactions, validator economics, data layer, development tooling, and token extensions using the Helius blog, SIMDs, and Agave/Firedancer source code.
 metadata:
   author: Helius Labs
-  version: "0.1.0"
+  version: "1.0.0"
   mcp-server: helius-mcp
 ---
 

--- a/scripts/compile-skills.ts
+++ b/scripts/compile-skills.ts
@@ -258,7 +258,7 @@ function inlineReferences(body: string, refsDir: string): string {
   if (!existsSync(refsDir)) return body;
 
   const refFiles = readdirSync(refsDir)
-    .filter((f: any) => f.endsWith(".md"))
+    .filter((f: string) => f.endsWith(".md"))
     .sort();
 
   if (refFiles.length === 0) return body;
@@ -392,7 +392,7 @@ function compileSkill(config: SkillConfig): void {
 
   // Count refs for summary
   const refCount = existsSync(refsDir)
-    ? readdirSync(refsDir).filter((f: any) => f.endsWith(".md")).length
+    ? readdirSync(refsDir).filter((f: string) => f.endsWith(".md")).length
     : 0;
 
   console.log(`  ✓ ${config.dir} v${version} (${refCount} refs, 3 prompts)`);

--- a/scripts/compile-skills.ts
+++ b/scripts/compile-skills.ts
@@ -258,7 +258,7 @@ function inlineReferences(body: string, refsDir: string): string {
   if (!existsSync(refsDir)) return body;
 
   const refFiles = readdirSync(refsDir)
-    .filter((f) => f.endsWith(".md"))
+    .filter((f: any) => f.endsWith(".md"))
     .sort();
 
   if (refFiles.length === 0) return body;
@@ -392,7 +392,7 @@ function compileSkill(config: SkillConfig): void {
 
   // Count refs for summary
   const refCount = existsSync(refsDir)
-    ? readdirSync(refsDir).filter((f) => f.endsWith(".md")).length
+    ? readdirSync(refsDir).filter((f: any) => f.endsWith(".md")).length
     : 0;
 
   console.log(`  ✓ ${config.dir} v${version} (${refCount} refs, 3 prompts)`);

--- a/scripts/compile-skills.ts
+++ b/scripts/compile-skills.ts
@@ -28,13 +28,24 @@ const MCP_OUT = join(ROOT, "helius-mcp", "system-prompts");
 interface SkillConfig {
   /** Directory name under helius-skills/ */
   dir: string;
+  /** Directory name under helius-plugin/skills/ and helius-cursor/skills/ */
+  pluginDir: string;
   /** Enhanced multi-line description for Codex implicit invocation */
   enhancedDescription: string;
 }
 
+const PLUGIN_DIR = join(ROOT, "helius-plugin", "skills");
+const CURSOR_DIR = join(ROOT, "helius-cursor", "skills");
+
+/** Load skill versions from versions.json (single source of truth). */
+const VERSIONS: Record<string, string> = JSON.parse(
+  readFileSync(join(ROOT, "versions.json"), "utf-8")
+);
+
 const SKILLS: SkillConfig[] = [
   {
     dir: "helius",
+    pluginDir: "build",
     enhancedDescription: `Build Solana applications with Helius infrastructure. Use this skill when:
   sending transactions (SOL, SPL tokens, swaps), querying assets/NFTs (DAS API),
   streaming real-time data (WebSockets, Laserstream), setting up webhooks for
@@ -43,6 +54,7 @@ const SKILLS: SkillConfig[] = [
   },
   {
     dir: "helius-dflow",
+    pluginDir: "dflow",
     enhancedDescription: `Build Solana trading applications combining DFlow trading APIs with Helius
   infrastructure. Use this skill when: building swap UIs or trading terminals,
   integrating spot crypto swaps (imperative and declarative), trading on
@@ -52,6 +64,7 @@ const SKILLS: SkillConfig[] = [
   },
   {
     dir: "helius-phantom",
+    pluginDir: "phantom",
     enhancedDescription: `Build frontend Solana applications with Phantom Connect SDK and Helius
   infrastructure. Use this skill when: connecting Phantom wallet in React,
   React Native, or vanilla JS apps, signing and submitting transactions via
@@ -61,6 +74,7 @@ const SKILLS: SkillConfig[] = [
   },
   {
     dir: "svm",
+    pluginDir: "svm",
     enhancedDescription: `Explore Solana's architecture and protocol internals. Use this skill when:
   understanding the SVM execution engine, learning about the account model and
   PDAs, exploring consensus (Proof of History, Tower BFT), researching
@@ -88,10 +102,31 @@ function extractName(frontmatter: string): string {
   return match ? match[1].trim() : "unknown";
 }
 
-/** Build Codex-compatible frontmatter (name + enhanced description only). */
-function buildCodexFrontmatter(name: string, enhancedDesc: string): string {
+/** Inject or update the version field in YAML frontmatter. */
+function injectVersion(frontmatter: string, version: string): string {
+  // If metadata.version exists, replace it
+  if (/^\s+version:\s*.+$/m.test(frontmatter)) {
+    return frontmatter.replace(
+      /^(\s+version:\s*).+$/m,
+      `$1"${version}"`
+    );
+  }
+  // If metadata block exists, append version to it
+  if (/^metadata:\s*$/m.test(frontmatter)) {
+    return frontmatter.replace(
+      /^(metadata:\s*)$/m,
+      `$1\n  version: "${version}"`
+    );
+  }
+  // Otherwise append a metadata block
+  return `${frontmatter}\nmetadata:\n  version: "${version}"`;
+}
+
+/** Build Codex-compatible frontmatter (name + enhanced description + version). */
+function buildCodexFrontmatter(name: string, enhancedDesc: string, version: string): string {
   return `---
 name: ${name}
+version: "${version}"
 description: >
   ${enhancedDesc}
 ---`;
@@ -169,9 +204,10 @@ function renameHeadings(body: string): string {
 }
 
 /** Build the OpenAI API preamble (Layer A harness for openai.developer.md). */
-function buildOpenAIPreamble(skillName: string): string {
+function buildOpenAIPreamble(skillName: string, version: string): string {
   return `<!-- Generated from helius-skills/${skillName}/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a \`developer\` message -->
+<!-- Version: ${version} -->
 
 ## Runtime Notes
 
@@ -184,9 +220,10 @@ function buildOpenAIPreamble(skillName: string): string {
 }
 
 /** Build the Claude API preamble (Layer A harness for claude.system.md). */
-function buildClaudePreamble(skillName: string): string {
+function buildClaudePreamble(skillName: string, version: string): string {
   return `<!-- Generated from helius-skills/${skillName}/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
+<!-- Version: ${version} -->
 
 ## Runtime Notes
 
@@ -262,14 +299,27 @@ function compileSkill(config: SkillConfig): void {
   const raw = readFileSync(skillMdPath, "utf-8");
   const { frontmatter, body } = parseFrontmatter(raw);
   const name = extractName(frontmatter);
+  const version = VERSIONS[config.dir];
+  if (!version) {
+    console.error(`  SKIP: no version in versions.json for "${config.dir}"`);
+    return;
+  }
   const generationHeader = `<!-- Generated from helius-skills/${config.dir}/SKILL.md — do not edit -->\n\n`;
+
+  // --- Update canonical SKILL.md version from versions.json ---
+  const updatedFrontmatter = injectVersion(frontmatter, version);
+  const updatedCanonical = `---\n${updatedFrontmatter}\n---\n${body}`;
+  if (updatedCanonical !== raw) {
+    writeFileSync(skillMdPath, updatedCanonical);
+    console.log(`  ↻ ${config.dir}/SKILL.md version → ${version}`);
+  }
 
   // --- Apply transforms ---
   let transformed = stripClaudeSpecific(body);
   transformed = renameHeadings(transformed);
 
   // --- Codex SKILL.md ---
-  const codexFrontmatter = buildCodexFrontmatter(name, config.enhancedDescription);
+  const codexFrontmatter = buildCodexFrontmatter(name, config.enhancedDescription, version);
   const codexSkillMd = `${codexFrontmatter}\n${transformed}`;
 
   // --- Prompt variants ---
@@ -277,17 +327,18 @@ function compileSkill(config: SkillConfig): void {
 
   // openai.developer.md
   const openaiContent =
-    buildOpenAIPreamble(config.dir) +
+    buildOpenAIPreamble(config.dir, version) +
     wrapWithDelimiters(name, compactBody);
 
   // claude.system.md
   const claudeContent =
-    buildClaudePreamble(config.dir) +
+    buildClaudePreamble(config.dir, version) +
     wrapWithDelimiters(name, compactBody);
 
   // full.md (all references inlined, no frontmatter — targets Cursor Rules / ChatGPT)
   const fullBody = inlineReferences(transformed, refsDir);
-  const fullContent = generationHeader + fullBody;
+  const fullVersionHeader = `<!-- Generated from helius-skills/${config.dir}/SKILL.md — do not edit -->\n<!-- Version: ${version} -->\n\n`;
+  const fullContent = fullVersionHeader + fullBody;
 
   // --- Write outputs ---
   const agentsSkillDir = join(AGENTS_OUT, config.dir);
@@ -325,12 +376,26 @@ function compileSkill(config: SkillConfig): void {
   writeFileSync(join(mcpSkillDir, "claude.system.md"), claudeContent);
   writeFileSync(join(mcpSkillDir, "full.md"), fullContent);
 
+  // --- Sync version into plugin/cursor SKILL.md copies ---
+  for (const destRoot of [PLUGIN_DIR, CURSOR_DIR]) {
+    const destSkillMd = join(destRoot, config.pluginDir, "SKILL.md");
+    if (!existsSync(destSkillMd)) continue;
+    const destRaw = readFileSync(destSkillMd, "utf-8");
+    const destParsed = parseFrontmatter(destRaw);
+    const destUpdatedFm = injectVersion(destParsed.frontmatter, version);
+    const destUpdated = `---\n${destUpdatedFm}\n---\n${destParsed.body}`;
+    if (destUpdated !== destRaw) {
+      writeFileSync(destSkillMd, destUpdated);
+      console.log(`  ↻ ${relative(ROOT, destSkillMd)} version → ${version}`);
+    }
+  }
+
   // Count refs for summary
   const refCount = existsSync(refsDir)
     ? readdirSync(refsDir).filter((f) => f.endsWith(".md")).length
     : 0;
 
-  console.log(`  ✓ ${config.dir} (${refCount} refs, 3 prompts)`);
+  console.log(`  ✓ ${config.dir} v${version} (${refCount} refs, 3 prompts)`);
 }
 
 function main(): void {

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,6 @@
+{
+  "helius": "1.0.0",
+  "helius-dflow": "1.0.0",
+  "helius-phantom": "1.0.0",
+  "svm": "1.0.0"
+}


### PR DESCRIPTION
This PR adds `versions.json` as the single source of truth for skill versions, which we need to track when publishing on certain sites (e.g., ClawHub). The PR also updates `compile-skills.ts` to read these versions and inject them into all `SKILL.md` copies