### PR TITLE
fix(cli): Make WebSocket Commands Agent-Friendly

### DIFF
--- a/helius-cli/src/commands/ws.ts
+++ b/helius-cli/src/commands/ws.ts
@@ -1,12 +1,17 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { jsonReplacer, outputJson, classifyError, type OutputOptions } from "../lib/output.js";
+import { jsonReplacer, classifyError, type OutputOptions } from "../lib/output.js";
 
 interface WsOptions extends OutputOptions, ResolveOptions {}
 
-function printNotification(notification: unknown, options: WsOptions): void {
+/** Emit a JSON envelope: { event, timestamp, data } */
+function emitEvent(event: string, data: unknown): void {
+  console.log(JSON.stringify({ event, timestamp: new Date().toISOString(), data }, jsonReplacer));
+}
+
+function printNotification(notification: unknown, options: WsOptions, event: string): void {
   if (options.json) {
-    console.log(JSON.stringify(notification, jsonReplacer));
+    emitEvent(event, notification);
   } else {
     console.log(chalk.gray(new Date().toISOString()), JSON.stringify(notification, jsonReplacer, 2));
   }
@@ -16,10 +21,11 @@ async function streamSubscription(
   channel: { subscribe(opts: { abortSignal: AbortSignal }): Promise<AsyncIterable<unknown>> },
   abortController: AbortController,
   options: WsOptions,
+  event: string,
 ): Promise<void> {
   const subscription = await channel.subscribe({ abortSignal: abortController.signal });
   for await (const notification of subscription) {
-    printNotification(notification, options);
+    printNotification(notification, options, event);
   }
 }
 
@@ -28,7 +34,7 @@ function handleWsError(error: unknown, options: WsOptions): void {
   const { exitCode, errorCode, retryable } = classifyError(error);
   const message = error instanceof Error ? error.message : String(error);
   if (options.json) {
-    outputJson({ error: errorCode, message, retryable });
+    emitEvent("error", { error: errorCode, message, retryable });
   } else {
     const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
     console.error(chalk.red(`Error: ${message}${hint}`));
@@ -36,10 +42,18 @@ function handleWsError(error: unknown, options: WsOptions): void {
   process.exit(exitCode);
 }
 
-function setupShutdown(helius: any, abortController: AbortController, label: string): void {
-  console.log(chalk.gray(`\nStreaming ${label}... (Ctrl+C to stop)\n`));
+function setupShutdown(helius: any, abortController: AbortController, label: string, options: WsOptions): void {
+  if (options.json) {
+    emitEvent("connected", { subscription: label });
+  } else {
+    console.log(chalk.gray(`\nStreaming ${label}... (Ctrl+C to stop)\n`));
+  }
   const cleanup = () => {
-    console.log(chalk.gray("\nClosing WebSocket..."));
+    if (options.json) {
+      emitEvent("disconnected", { reason: "user_interrupt" });
+    } else {
+      console.log(chalk.gray("\nClosing WebSocket..."));
+    }
     abortController.abort();
     try { helius.ws.close(); } catch { /* ignore */ }
     process.exit(0);
@@ -55,9 +69,9 @@ export async function wsAccountCommand(address: string, options: WsOptions = {})
     const helius = getClient(apiKey, network);
     const ac = new AbortController();
 
-    setupShutdown(helius, ac, "account notifications");
+    setupShutdown(helius, ac, "account notifications", options);
     const channel = await helius.ws.accountNotifications(address as any, { encoding: "jsonParsed" });
-    await streamSubscription(channel as any, ac, options);
+    await streamSubscription(channel as any, ac, options, "accountNotification");
   } catch (error) {
     handleWsError(error, options);
   }
@@ -70,10 +84,10 @@ export async function wsLogsCommand(options: WsOptions & { mentions?: string } =
     const helius = getClient(apiKey, network);
     const ac = new AbortController();
 
-    setupShutdown(helius, ac, "log notifications");
+    setupShutdown(helius, ac, "log notifications", options);
     const filter = options.mentions ? { mentions: [options.mentions] as any } : "all" as const;
     const channel = await helius.ws.logsNotifications(filter);
-    await streamSubscription(channel as any, ac, options);
+    await streamSubscription(channel as any, ac, options, "logsNotification");
   } catch (error) {
     handleWsError(error, options);
   }
@@ -86,7 +100,7 @@ export async function wsSlotCommand(options: WsOptions = {}): Promise<void> {
     const helius = getClient(apiKey, network);
     const ac = new AbortController();
 
-    setupShutdown(helius, ac, "slot notifications");
+    setupShutdown(helius, ac, "slot notifications", options);
 
     // Use @solana/kit directly — the SDK wrapper has a bug where it passes
     // `undefined` as a config param to slotNotifications, which the RPC rejects.
@@ -98,7 +112,7 @@ export async function wsSlotCommand(options: WsOptions = {}): Promise<void> {
     const channel = rpc.slotNotifications();
     const subscription = await channel.subscribe({ abortSignal: ac.signal });
     for await (const notification of subscription) {
-      printNotification(notification, options);
+      printNotification(notification, options, "slotNotification");
     }
   } catch (error) {
     handleWsError(error, options);
@@ -112,9 +126,9 @@ export async function wsSignatureCommand(signature: string, options: WsOptions =
     const helius = getClient(apiKey, network);
     const ac = new AbortController();
 
-    setupShutdown(helius, ac, "signature notifications");
+    setupShutdown(helius, ac, "signature notifications", options);
     const channel = await helius.ws.signatureNotifications(signature);
-    await streamSubscription(channel as any, ac, options);
+    await streamSubscription(channel as any, ac, options, "signatureNotification");
   } catch (error) {
     handleWsError(error, options);
   }
@@ -127,9 +141,9 @@ export async function wsProgramCommand(programId: string, options: WsOptions = {
     const helius = getClient(apiKey, network);
     const ac = new AbortController();
 
-    setupShutdown(helius, ac, "program notifications");
+    setupShutdown(helius, ac, "program notifications", options);
     const channel = await helius.ws.programNotifications(programId as any, { encoding: "jsonParsed" });
-    await streamSubscription(channel as any, ac, options);
+    await streamSubscription(channel as any, ac, options, "programNotification");
   } catch (error) {
     handleWsError(error, options);
   }


### PR DESCRIPTION
This PR makes the current `ws` commands more agent-friendly by wrapping events in `{ event, timestamp, data }` objects, giving agents more signals alongside typed notifs