### PR TITLE
feat(mcp): add staking tools

### DIFF
--- a/helius-mcp/src/index.ts
+++ b/helius-mcp/src/index.ts
@@ -62,6 +62,11 @@ const server = new McpServer(
 | event notifications (any plan) | createWebhook | 100 |
 | live streaming (WS, Business+) | transactionSubscribe, accountSubscribe | — |
 | production streaming (gRPC, Pro) | laserstreamSubscribe | — |
+| stake SOL to Helius validator | stakeSOL | ~3 |
+| deactivate stake account | unstakeSOL | ~3 |
+| withdraw from deactivated stake | withdrawStake | ~3 |
+| list Helius stake accounts | getStakeAccounts | ~10 |
+| check withdrawable stake amount | getWithdrawableAmount | ~3 |
 | Account setup | getStarted → generateKeypair → agenticSignup | — |
 
 Rules:
@@ -69,6 +74,7 @@ Rules:
 - For errors, use troubleshootError first.
 - When a user describes ANY project they want to build ("I want to build/make/create...", "help me build...", "I need a..."), call recommendStack immediately with their description — do not ask clarifying questions first. After recommendations, use getHeliusPlanInfo for pricing and lookupHeliusDocs for API details.
 - "send SOL" / "transfer SOL" → transferSol (~3 credits). "send tokens" / "transfer USDC/BONK/etc" → transferToken (~13 credits). Both require a configured keypair (generateKeypair) and use Helius Sender.
+- "stake SOL" / "delegate SOL" → stakeSOL (~3 credits). "unstake" / "deactivate" → unstakeSOL (~3 credits). "withdraw stake" → withdrawStake (~3 credits). All staking delegates to the Helius validator. Requires a configured keypair (generateKeypair).
 
 ## Feedback
 Every tool accepts \`_feedback\` and \`_model\` params. Always include \`_model\` with your LLM model identifier (e.g. "claude-sonnet-4-20250514", "gpt-4o"). After each tool call, assess the response and include \`_feedback\` on your next call — what worked, what was confusing, what data was missing or could be improved.`

--- a/helius-mcp/src/tools/index.ts
+++ b/helius-mcp/src/tools/index.ts
@@ -22,6 +22,7 @@ import { registerGuideTools } from './guides.js';
 import { registerRecommendTools } from './recommend.js';
 import { registerSolanaKnowledgeTools } from './solana-knowledge.js';
 import { registerTransferTools } from './transfers.js';
+import { registerStakingTools } from './staking.js';
 
 /**
  * Patches McpServer to inject optional _feedback and _model params into every
@@ -102,4 +103,5 @@ export function registerTools(server: McpServer) {
   registerRecommendTools(server);
   registerSolanaKnowledgeTools(server);
   registerTransferTools(server);
+  registerStakingTools(server);
 }

--- a/helius-mcp/src/tools/product-catalog.ts
+++ b/helius-mcp/src/tools/product-catalog.ts
@@ -122,6 +122,15 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     referenceFile: 'references/sender.md',
     description: 'Send native SOL or SPL tokens from the MCP keypair to any Solana address. Uses Helius Sender for optimal landing rates. Requires a configured keypair.',
   },
+  'native-staking': {
+    name: 'Native Staking',
+    mcpTools: ['stakeSOL', 'unstakeSOL', 'withdrawStake', 'getStakeAccounts', 'getWithdrawableAmount'],
+    creditCostPerCall: '~3-10 credits + on-chain fees',
+    minimumPlan: 'free',
+    docKey: 'sender',
+    referenceFile: 'references/sender.md',
+    description: 'Stake, unstake, and withdraw native SOL via the Helius validator. Earn staking yield with one-click delegation. Query stake accounts and withdrawable amounts.',
+  },
   'token-holders': {
     name: 'Token Holders',
     mcpTools: ['getTokenHolders'],

--- a/helius-mcp/src/tools/recommend.ts
+++ b/helius-mcp/src/tools/recommend.ts
@@ -29,6 +29,7 @@ export const KNOWN_TOOLS = new Set([
   'troubleshootError', 'getSenderInfo', 'getWebhookGuide', 'getLatencyComparison', 'getPumpFunGuide',
   'recommendStack',
   'transferSol', 'transferToken',
+  'stakeSOL', 'unstakeSOL', 'withdrawStake', 'getStakeAccounts', 'getWithdrawableAmount',
 ]);
 
 // ─── Plan Ranking ───

--- a/helius-mcp/src/tools/staking.ts
+++ b/helius-mcp/src/tools/staking.ts
@@ -2,11 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { createKeyPairSignerFromBytes, address } from '@solana/kit';
 import { getHeliusClient, hasApiKey, loadSignerOrFail, getSessionWalletAddress } from '../utils/helius.js';
-<<<<<<< HEAD
-import { mcpText, mcpError, handleToolError, isValidAddressFormat } from '../utils/errors.js';
-=======
 import { mcpText, mcpError, handleToolError, isValidAddressFormat, missingParamError } from '../utils/errors.js';
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
 import { noApiKeyResponse } from './shared.js';
 
 // ── Tool Registration ──
@@ -39,12 +35,8 @@ export function registerStakingTools(server: McpServer) {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-<<<<<<< HEAD
-            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before staking.'
-=======
             'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before staking.',
             { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 
@@ -59,12 +51,8 @@ export function registerStakingTools(server: McpServer) {
           const available = Number(balanceLamports) / 1_000_000_000;
           return mcpError(
             `Insufficient SOL balance. You have ${available} SOL but need ${amount} SOL plus ~0.01 SOL for rent-exempt reserve and transaction fees.\n\n` +
-<<<<<<< HEAD
-            `Wallet: \`${signerData.walletAddress}\``
-=======
             `Wallet: \`${signerData.walletAddress}\``,
             { type: 'INSUFFICIENT_FUNDS', code: 'LOW_SOL', retryable: false, recovery: 'Fund the wallet with more SOL.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 
@@ -124,24 +112,16 @@ export function registerStakingTools(server: McpServer) {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-<<<<<<< HEAD
-            'No keypair found. Call `generateKeypair` first to create a wallet.'
-=======
             'No keypair found. Call `generateKeypair` first to create a wallet.',
             { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 
         // Validate address
         if (!isValidAddressFormat(stakeAccountAddress)) {
           return mcpError(
-<<<<<<< HEAD
-            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
-=======
             `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`,
             { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 
@@ -205,34 +185,22 @@ export function registerStakingTools(server: McpServer) {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-<<<<<<< HEAD
-            'No keypair found. Call `generateKeypair` first to create a wallet.'
-=======
             'No keypair found. Call `generateKeypair` first to create a wallet.',
             { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 
         // Validate addresses
         if (!isValidAddressFormat(stakeAccountAddress)) {
           return mcpError(
-<<<<<<< HEAD
-            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
-=======
             `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`,
             { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
         if (destination && !isValidAddressFormat(destination)) {
           return mcpError(
-<<<<<<< HEAD
-            `Invalid destination address "${destination}". Expected a valid Solana address (32-44 base58 characters).`
-=======
             `Invalid destination address "${destination}". Expected a valid Solana address (32-44 base58 characters).`,
             { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 
@@ -253,12 +221,8 @@ export function registerStakingTools(server: McpServer) {
           return mcpError(
             `No funds available to withdraw from stake account \`${stakeAccountAddress}\`. ` +
             `The stake may still be active or in cooldown (not yet fully deactivated). ` +
-<<<<<<< HEAD
-            `Use \`getStakeAccounts\` to check the status.`
-=======
             `Use \`getStakeAccounts\` to check the status.`,
             { type: 'INSUFFICIENT_FUNDS', code: 'ZERO_BALANCE', retryable: false, recovery: 'Stake may still be active or in cooldown. Use getStakeAccounts to check status.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 
@@ -312,24 +276,14 @@ export function registerStakingTools(server: McpServer) {
         if (!walletAddress) {
           walletAddress = getSessionWalletAddress() ?? undefined;
           if (!walletAddress) {
-<<<<<<< HEAD
-            return mcpError(
-              'No wallet address provided and no keypair configured. Either pass a `wallet` address or call `generateKeypair` first.'
-            );
-=======
             return missingParamError('getStakeAccounts', 'Pass a wallet address or call generateKeypair first.');
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           }
         }
 
         if (!isValidAddressFormat(walletAddress)) {
           return mcpError(
-<<<<<<< HEAD
-            `Invalid wallet address "${walletAddress}". Expected a valid Solana address (32-44 base58 characters).`
-=======
             `Invalid wallet address "${walletAddress}". Expected a valid Solana address (32-44 base58 characters).`,
             { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 
@@ -350,11 +304,7 @@ export function registerStakingTools(server: McpServer) {
         for (const account of accounts) {
           const pubkey = account.pubkey;
           const lamports = account.account.lamports;
-<<<<<<< HEAD
-          const solAmount = lamports / 1_000_000_000;
-=======
           const solAmount = Number(lamports) / 1_000_000_000;
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           const delegation = account.account.data?.parsed?.info?.stake?.delegation;
 
           let status = 'Unknown';
@@ -413,12 +363,8 @@ export function registerStakingTools(server: McpServer) {
       try {
         if (!isValidAddressFormat(stakeAccountAddress)) {
           return mcpError(
-<<<<<<< HEAD
-            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
-=======
             `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`,
             { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
->>>>>>> 8f5d5cb6119beaa591d0038bbc58185f2d23f0a2
           );
         }
 

--- a/helius-mcp/src/tools/staking.ts
+++ b/helius-mcp/src/tools/staking.ts
@@ -1,0 +1,388 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { createKeyPairSignerFromBytes, address } from '@solana/kit';
+import { getHeliusClient, hasApiKey, loadSignerOrFail, getSessionWalletAddress } from '../utils/helius.js';
+import { mcpText, mcpError, handleToolError, isValidAddressFormat } from '../utils/errors.js';
+import { noApiKeyResponse } from './shared.js';
+
+// ── Tool Registration ──
+
+export function registerStakingTools(server: McpServer) {
+
+  // ── Stake SOL ──
+
+  server.tool(
+    'stakeSOL',
+    'BEST FOR: staking native SOL to the Helius validator to earn yield. ' +
+    'PREFER getStakeAccounts to view existing stake accounts, getWithdrawableAmount to check withdrawal eligibility. ' +
+    'Creates a new stake account, delegates to the Helius validator, and sends the transaction on-chain. ' +
+    'Requires a configured keypair (call generateKeypair if needed). ' +
+    'This is an irreversible on-chain transaction. ' +
+    'The Solana runtime requires a rent-exempt reserve (~0.00228 SOL) on top of the staked amount. ' +
+    'Credit cost: ~3 credits (CU simulation + priority fee estimate + send).',
+    {
+      amount: z.number().positive().describe(
+        'Amount of SOL to stake (e.g., 1.0 for one SOL). This is the delegation amount; a small rent-exempt reserve (~0.00228 SOL) is added automatically.'
+      ),
+    },
+    async ({ amount }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
+      try {
+        // Load keypair
+        let signerData: { secretKey: Uint8Array; walletAddress: string };
+        try {
+          signerData = await loadSignerOrFail();
+        } catch {
+          return mcpError(
+            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before staking.'
+          );
+        }
+
+        const helius = getHeliusClient();
+
+        // Pre-flight balance check — need amount + ~0.01 SOL for rent + fees
+        const balanceResult = await helius.getBalance(signerData.walletAddress);
+        const balanceLamports = BigInt(balanceResult.value);
+        const stakeLamports = BigInt(Math.round(amount * 1_000_000_000));
+        const reserveLamports = 10_000_000n; // ~0.01 SOL for rent-exempt reserve + fees
+        if (balanceLamports < stakeLamports + reserveLamports) {
+          const available = Number(balanceLamports) / 1_000_000_000;
+          return mcpError(
+            `Insufficient SOL balance. You have ${available} SOL but need ${amount} SOL plus ~0.01 SOL for rent-exempt reserve and transaction fees.\n\n` +
+            `Wallet: \`${signerData.walletAddress}\``
+          );
+        }
+
+        // Create signer from keypair bytes
+        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
+
+        // Get stake instructions (async — fetches rent-exempt minimum from RPC)
+        const { instructions, stakeAccount } = await helius.stake.getStakeInstructions(signer, amount);
+
+        // Send transaction — stakeAccount is a generated keypair that must co-sign
+        const signature = await helius.tx.sendTransactionWithSender({
+          signers: [signer, stakeAccount],
+          instructions: [...instructions],
+          region: 'Default',
+        });
+
+        return mcpText(
+          `**SOL Staked to Helius Validator**\n\n` +
+          `- **From:** \`${signerData.walletAddress}\`\n` +
+          `- **Stake Account:** \`${stakeAccount.address}\`\n` +
+          `- **Amount:** ${amount} SOL\n` +
+          `- **Signature:** \`${signature}\`\n` +
+          `- **Explorer:** https://orbmarkets.io/tx/${signature}\n\n` +
+          `The stake account is now delegated to the Helius validator. ` +
+          `Staking rewards begin accruing after the activation epoch completes (~1 epoch / 2-3 days).`
+        );
+      } catch (err) {
+        return handleToolError(err, 'Error staking SOL');
+      }
+    }
+  );
+
+  // ── Unstake SOL ──
+
+  server.tool(
+    'unstakeSOL',
+    'BEST FOR: deactivating (unstaking) a stake account to begin the cooldown period before withdrawal. ' +
+    'PREFER getStakeAccounts to find stake account addresses first. ' +
+    'Sends a deactivation transaction for the given stake account. ' +
+    'After deactivation, wait ~1 full epoch (2-3 days) before funds become withdrawable. ' +
+    'Use withdrawStake after cooldown completes. ' +
+    'Requires a configured keypair (the stake authority). ' +
+    'This is an irreversible on-chain transaction. ' +
+    'Credit cost: ~3 credits.',
+    {
+      stakeAccount: z.string().describe(
+        'Address of the stake account to deactivate (base58 encoded). Use getStakeAccounts to find your Helius stake accounts.'
+      ),
+    },
+    async ({ stakeAccount: stakeAccountAddress }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
+      try {
+        // Load keypair
+        let signerData: { secretKey: Uint8Array; walletAddress: string };
+        try {
+          signerData = await loadSignerOrFail();
+        } catch {
+          return mcpError(
+            'No keypair found. Call `generateKeypair` first to create a wallet.'
+          );
+        }
+
+        // Validate address
+        if (!isValidAddressFormat(stakeAccountAddress)) {
+          return mcpError(
+            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
+          );
+        }
+
+        const helius = getHeliusClient();
+        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
+
+        // Get deactivation instruction (synchronous)
+        const ix = helius.stake.getUnstakeInstruction(signer, address(stakeAccountAddress));
+
+        // Send transaction
+        const signature = await helius.tx.sendTransactionWithSender({
+          signers: [signer],
+          instructions: [ix],
+          region: 'Default',
+        });
+
+        return mcpText(
+          `**Stake Account Deactivated**\n\n` +
+          `- **Stake Account:** \`${stakeAccountAddress}\`\n` +
+          `- **Authority:** \`${signerData.walletAddress}\`\n` +
+          `- **Signature:** \`${signature}\`\n` +
+          `- **Explorer:** https://orbmarkets.io/tx/${signature}\n\n` +
+          `The stake account is now deactivating. Funds will become withdrawable after the cooldown period (~1 full epoch / 2-3 days). ` +
+          `Use \`getWithdrawableAmount\` to check when funds are ready, then \`withdrawStake\` to withdraw.`
+        );
+      } catch (err) {
+        return handleToolError(err, 'Error deactivating stake account');
+      }
+    }
+  );
+
+  // ── Withdraw Stake ──
+
+  server.tool(
+    'withdrawStake',
+    'BEST FOR: withdrawing SOL from a deactivated stake account back to your wallet. ' +
+    'PREFER getWithdrawableAmount to check if funds are available before withdrawing. ' +
+    'By default withdraws the full balance (including rent-exempt reserve) and closes the stake account. ' +
+    'The stake account must be fully deactivated (cooldown complete, ~1 epoch after unstakeSOL) before withdrawal. ' +
+    'Requires a configured keypair (the withdraw authority). ' +
+    'This is an irreversible on-chain transaction. ' +
+    'Credit cost: ~3 credits.',
+    {
+      stakeAccount: z.string().describe(
+        'Address of the deactivated stake account to withdraw from (base58 encoded).'
+      ),
+      destination: z.string().optional().describe(
+        'Destination wallet address to receive the withdrawn SOL (base58 encoded). Defaults to the MCP wallet address if omitted.'
+      ),
+      amount: z.number().positive().optional().describe(
+        'Amount of SOL to withdraw. If omitted, withdraws the entire withdrawable balance (including rent-exempt reserve, which closes the account).'
+      ),
+    },
+    async ({ stakeAccount: stakeAccountAddress, destination, amount }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
+      try {
+        // Load keypair
+        let signerData: { secretKey: Uint8Array; walletAddress: string };
+        try {
+          signerData = await loadSignerOrFail();
+        } catch {
+          return mcpError(
+            'No keypair found. Call `generateKeypair` first to create a wallet.'
+          );
+        }
+
+        // Validate addresses
+        if (!isValidAddressFormat(stakeAccountAddress)) {
+          return mcpError(
+            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
+          );
+        }
+        if (destination && !isValidAddressFormat(destination)) {
+          return mcpError(
+            `Invalid destination address "${destination}". Expected a valid Solana address (32-44 base58 characters).`
+          );
+        }
+
+        const helius = getHeliusClient();
+        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
+        const dest = destination || signerData.walletAddress;
+
+        // Determine lamports to withdraw
+        let lamports: number;
+        if (amount === undefined) {
+          // Withdraw full balance including rent-exempt reserve (closes account)
+          lamports = await helius.stake.getWithdrawableAmount(stakeAccountAddress, true);
+        } else {
+          lamports = Math.round(amount * 1_000_000_000);
+        }
+
+        if (lamports === 0) {
+          return mcpError(
+            `No funds available to withdraw from stake account \`${stakeAccountAddress}\`. ` +
+            `The stake may still be active or in cooldown (not yet fully deactivated). ` +
+            `Use \`getStakeAccounts\` to check the status.`
+          );
+        }
+
+        // Get withdraw instruction (synchronous)
+        const ix = helius.stake.getWithdrawInstruction(signer, address(stakeAccountAddress), address(dest), lamports);
+
+        // Send transaction
+        const signature = await helius.tx.sendTransactionWithSender({
+          signers: [signer],
+          instructions: [ix],
+          region: 'Default',
+        });
+
+        const solAmount = lamports / 1_000_000_000;
+
+        return mcpText(
+          `**Stake Withdrawn**\n\n` +
+          `- **Stake Account:** \`${stakeAccountAddress}\`\n` +
+          `- **Destination:** \`${dest}\`\n` +
+          `- **Amount:** ${solAmount} SOL\n` +
+          `- **Signature:** \`${signature}\`\n` +
+          `- **Explorer:** https://orbmarkets.io/tx/${signature}` +
+          (amount === undefined ? `\n\nThe full balance was withdrawn and the stake account has been closed.` : '')
+        );
+      } catch (err) {
+        return handleToolError(err, 'Error withdrawing stake');
+      }
+    }
+  );
+
+  // ── Get Stake Accounts ──
+
+  server.tool(
+    'getStakeAccounts',
+    'BEST FOR: listing all stake accounts delegated to the Helius validator for a wallet. ' +
+    'PREFER getWithdrawableAmount to check withdrawal eligibility for a specific stake account. ' +
+    'Returns stake account addresses, delegated amounts, and activation status (active, deactivating, or inactive). ' +
+    'Does not require a keypair — any wallet address can be queried. ' +
+    'Credit cost: ~10 credits (getProgramAccounts).',
+    {
+      wallet: z.string().optional().describe(
+        'Wallet address to query Helius stake accounts for (base58 encoded). Defaults to the MCP wallet if omitted and a keypair is configured.'
+      ),
+    },
+    async ({ wallet }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
+      try {
+        // Resolve wallet address
+        let walletAddress = wallet;
+        if (!walletAddress) {
+          walletAddress = getSessionWalletAddress() ?? undefined;
+          if (!walletAddress) {
+            return mcpError(
+              'No wallet address provided and no keypair configured. Either pass a `wallet` address or call `generateKeypair` first.'
+            );
+          }
+        }
+
+        if (!isValidAddressFormat(walletAddress)) {
+          return mcpError(
+            `Invalid wallet address "${walletAddress}". Expected a valid Solana address (32-44 base58 characters).`
+          );
+        }
+
+        const helius = getHeliusClient();
+        const accounts = await helius.stake.getHeliusStakeAccounts(walletAddress);
+
+        if (!accounts || accounts.length === 0) {
+          return mcpText(
+            `**No Helius Stake Accounts Found**\n\n` +
+            `Wallet \`${walletAddress}\` has no stake accounts delegated to the Helius validator.\n\n` +
+            `Use \`stakeSOL\` to stake SOL to the Helius validator.`
+          );
+        }
+
+        const U64_MAX = '18446744073709551615';
+        const lines: string[] = [`**Helius Stake Accounts for \`${walletAddress}\`**\n`];
+
+        for (const account of accounts) {
+          const pubkey = account.pubkey;
+          const lamports = account.account.lamports;
+          const solAmount = lamports / 1_000_000_000;
+          const delegation = account.account.data?.parsed?.info?.stake?.delegation;
+
+          let status = 'Unknown';
+          let details = '';
+          if (delegation) {
+            const deactivationEpoch = delegation.deactivationEpoch;
+            if (deactivationEpoch === U64_MAX) {
+              status = 'Active';
+              details = `Activation epoch: ${delegation.activationEpoch}`;
+            } else {
+              status = 'Deactivating';
+              details = `Deactivation epoch: ${deactivationEpoch}`;
+            }
+          } else {
+            status = 'Inactive';
+          }
+
+          lines.push(
+            `### \`${pubkey}\`\n` +
+            `- **Balance:** ${solAmount} SOL\n` +
+            `- **Status:** ${status}\n` +
+            (details ? `- **${details}**\n` : '') +
+            (delegation ? `- **Delegated stake:** ${Number(delegation.stake) / 1_000_000_000} SOL\n` : '')
+          );
+        }
+
+        lines.push(`---\n_${accounts.length} stake account(s) found._`);
+
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return handleToolError(err, 'Error fetching stake accounts');
+      }
+    }
+  );
+
+  // ── Get Withdrawable Amount ──
+
+  server.tool(
+    'getWithdrawableAmount',
+    'BEST FOR: checking how much SOL can be withdrawn from a stake account. ' +
+    'PREFER getStakeAccounts to find stake account addresses, withdrawStake to actually withdraw. ' +
+    'Returns 0 if the stake account is still active or in cooldown (not yet withdrawable). ' +
+    'Does not require a keypair. ' +
+    'Credit cost: ~3 credits (getAccountInfo + getEpochInfo + getMinimumBalanceForRentExemption).',
+    {
+      stakeAccount: z.string().describe(
+        'Stake account address to check (base58 encoded). Use getStakeAccounts to find stake account addresses.'
+      ),
+      includeRentExempt: z.boolean().optional().default(false).describe(
+        'If true, includes the rent-exempt reserve (~0.00228 SOL) in the withdrawable amount. Withdrawing the full amount (with rent) closes the stake account.'
+      ),
+    },
+    async ({ stakeAccount: stakeAccountAddress, includeRentExempt }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
+      try {
+        if (!isValidAddressFormat(stakeAccountAddress)) {
+          return mcpError(
+            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
+          );
+        }
+
+        const helius = getHeliusClient();
+        const lamports = await helius.stake.getWithdrawableAmount(stakeAccountAddress, includeRentExempt);
+        const solAmount = lamports / 1_000_000_000;
+
+        if (lamports === 0) {
+          return mcpText(
+            `**Withdrawable Amount: 0 SOL**\n\n` +
+            `Stake account \`${stakeAccountAddress}\` has no withdrawable funds.\n\n` +
+            `This usually means the stake is still active or in the cooldown period after deactivation. ` +
+            `Use \`getStakeAccounts\` to check the current status.`
+          );
+        }
+
+        return mcpText(
+          `**Withdrawable Amount**\n\n` +
+          `- **Stake Account:** \`${stakeAccountAddress}\`\n` +
+          `- **Withdrawable:** ${solAmount} SOL (${lamports.toLocaleString()} lamports)\n` +
+          `- **Includes rent-exempt reserve:** ${includeRentExempt ? 'Yes (withdrawing closes the account)' : 'No'}\n\n` +
+          `Use \`withdrawStake\` to withdraw these funds.`
+        );
+      } catch (err) {
+        return handleToolError(err, 'Error checking withdrawable amount');
+      }
+    }
+  );
+}

--- a/helius-mcp/src/tools/staking.ts
+++ b/helius-mcp/src/tools/staking.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { createKeyPairSignerFromBytes, address } from '@solana/kit';
 import { getHeliusClient, hasApiKey, loadSignerOrFail, getSessionWalletAddress } from '../utils/helius.js';
-import { mcpText, mcpError, handleToolError, isValidAddressFormat } from '../utils/errors.js';
+import { mcpText, mcpError, handleToolError, isValidAddressFormat, missingParamError } from '../utils/errors.js';
 import { noApiKeyResponse } from './shared.js';
 
 // ── Tool Registration ──
@@ -35,7 +35,8 @@ export function registerStakingTools(server: McpServer) {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before staking.'
+            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before staking.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
           );
         }
 
@@ -50,7 +51,8 @@ export function registerStakingTools(server: McpServer) {
           const available = Number(balanceLamports) / 1_000_000_000;
           return mcpError(
             `Insufficient SOL balance. You have ${available} SOL but need ${amount} SOL plus ~0.01 SOL for rent-exempt reserve and transaction fees.\n\n` +
-            `Wallet: \`${signerData.walletAddress}\``
+            `Wallet: \`${signerData.walletAddress}\``,
+            { type: 'INSUFFICIENT_FUNDS', code: 'LOW_SOL', retryable: false, recovery: 'Fund the wallet with more SOL.' }
           );
         }
 
@@ -110,14 +112,16 @@ export function registerStakingTools(server: McpServer) {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet.'
+            'No keypair found. Call `generateKeypair` first to create a wallet.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
           );
         }
 
         // Validate address
         if (!isValidAddressFormat(stakeAccountAddress)) {
           return mcpError(
-            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
+            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`,
+            { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
           );
         }
 
@@ -181,19 +185,22 @@ export function registerStakingTools(server: McpServer) {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet.'
+            'No keypair found. Call `generateKeypair` first to create a wallet.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
           );
         }
 
         // Validate addresses
         if (!isValidAddressFormat(stakeAccountAddress)) {
           return mcpError(
-            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
+            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`,
+            { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
           );
         }
         if (destination && !isValidAddressFormat(destination)) {
           return mcpError(
-            `Invalid destination address "${destination}". Expected a valid Solana address (32-44 base58 characters).`
+            `Invalid destination address "${destination}". Expected a valid Solana address (32-44 base58 characters).`,
+            { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
           );
         }
 
@@ -214,7 +221,8 @@ export function registerStakingTools(server: McpServer) {
           return mcpError(
             `No funds available to withdraw from stake account \`${stakeAccountAddress}\`. ` +
             `The stake may still be active or in cooldown (not yet fully deactivated). ` +
-            `Use \`getStakeAccounts\` to check the status.`
+            `Use \`getStakeAccounts\` to check the status.`,
+            { type: 'INSUFFICIENT_FUNDS', code: 'ZERO_BALANCE', retryable: false, recovery: 'Stake may still be active or in cooldown. Use getStakeAccounts to check status.' }
           );
         }
 
@@ -268,15 +276,14 @@ export function registerStakingTools(server: McpServer) {
         if (!walletAddress) {
           walletAddress = getSessionWalletAddress() ?? undefined;
           if (!walletAddress) {
-            return mcpError(
-              'No wallet address provided and no keypair configured. Either pass a `wallet` address or call `generateKeypair` first.'
-            );
+            return missingParamError('getStakeAccounts', 'Pass a wallet address or call generateKeypair first.');
           }
         }
 
         if (!isValidAddressFormat(walletAddress)) {
           return mcpError(
-            `Invalid wallet address "${walletAddress}". Expected a valid Solana address (32-44 base58 characters).`
+            `Invalid wallet address "${walletAddress}". Expected a valid Solana address (32-44 base58 characters).`,
+            { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
           );
         }
 
@@ -297,7 +304,7 @@ export function registerStakingTools(server: McpServer) {
         for (const account of accounts) {
           const pubkey = account.pubkey;
           const lamports = account.account.lamports;
-          const solAmount = lamports / 1_000_000_000;
+          const solAmount = Number(lamports) / 1_000_000_000;
           const delegation = account.account.data?.parsed?.info?.stake?.delegation;
 
           let status = 'Unknown';
@@ -356,7 +363,8 @@ export function registerStakingTools(server: McpServer) {
       try {
         if (!isValidAddressFormat(stakeAccountAddress)) {
           return mcpError(
-            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`
+            `Invalid stake account address "${stakeAccountAddress}". Expected a valid Solana address (32-44 base58 characters).`,
+            { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address.' }
           );
         }
 

--- a/helius-mcp/tests/tools.test.ts
+++ b/helius-mcp/tests/tools.test.ts
@@ -86,6 +86,8 @@ describe('Helius MCP Tools', () => {
       'getLatencyComparison', 'getPumpFunGuide', 'recommendStack',
       // Solana Knowledge
       'getSIMD', 'listSIMDs', 'searchSolanaDocs', 'readSolanaSourceFile', 'fetchHeliusBlog',
+      // Staking
+      'stakeSOL', 'unstakeSOL', 'withdrawStake', 'getStakeAccounts', 'getWithdrawableAmount',
     ];
 
     for (const name of expected) {
@@ -119,6 +121,8 @@ describe('noApiKey guard', () => {
     // Wallet
     'getWalletBalances', 'getWalletHistory', 'getWalletTransfers',
     'getWalletIdentity', 'batchWalletIdentity', 'getWalletFundedBy',
+    // Staking
+    'stakeSOL', 'unstakeSOL', 'withdrawStake', 'getStakeAccounts', 'getWithdrawableAmount',
   ];
 
   let tools: Map<string, { name: string; description: string; handler: Function }>;

--- a/helius-mcp/tests/tools.test.ts
+++ b/helius-mcp/tests/tools.test.ts
@@ -34,8 +34,8 @@ describe('Helius MCP Tools', () => {
     registerTools(mockServer);
   });
 
-  it('registers 63 tools', () => {
-    expect(tools.size).toBe(63);
+  it('registers 68 tools', () => {
+    expect(tools.size).toBe(68);
   });
 
   it('all tools have descriptions', () => {


### PR DESCRIPTION
## Summary
- Adds 5 staking tools to `helius-mcp` for parity with `helius-cli` staking functionality: `stakeSOL`, `unstakeSOL`, `withdrawStake`, `getStakeAccounts`, `getWithdrawableAmount`
- Write tools build, sign, and send transactions via Helius Sender; read tools query stake state without requiring a keypair
- Updates routing table, product catalog, known tools set, and tool count test

## Test plan
- [x] `pnpm build` compiles cleanly
- [x] `pnpm validate` passes (14 products in catalog)
- [x] `pnpm test` passes (122 tests, 4 suites)
- [ ] Manual smoke test: start MCP server, verify 5 new tools appear, test `getStakeAccounts` with a known wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)