### PR TITLE
fix(mcp): unify error responses with structured metadata

### DIFF
--- a/helius-mcp/src/tools/accounts.ts
+++ b/helius-mcp/src/tools/accounts.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatAddress, formatSol } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
-import { mcpText, validateEnum, handleToolError, addressError, paginationError } from '../utils/errors.js';
+import { mcpText, validateEnum, handleToolError, addressError, paginationError, missingParamError, exclusiveParamError, batchLimitError } from '../utils/errors.js';
 
 function formatParsedAccountData(account: {
   data: unknown;
@@ -53,11 +53,11 @@ export function registerAccountTools(server: McpServer) {
 
       // Validate: must provide exactly one of address or addresses
       if (!address && (!addresses || addresses.length === 0)) {
-        return mcpText(`**Error:** Provide either \`address\` (single account) or \`addresses\` (batch of up to 100).`);
+        return missingParamError('getAccountInfo', 'Provide either `address` (single account) or `addresses` (batch of up to 100).');
       }
 
       if (address && addresses && addresses.length > 0) {
-        return mcpText(`**Error:** Provide either \`address\` or \`addresses\`, not both.`);
+        return exclusiveParamError('getAccountInfo', 'address', 'addresses');
       }
 
       try {
@@ -66,7 +66,7 @@ export function registerAccountTools(server: McpServer) {
         // --- Batch mode ---
         if (addresses && addresses.length > 0) {
           if (addresses.length > 100) {
-            return mcpText(`**Error:** Maximum 100 accounts per request. You provided ${addresses.length}.`);
+            return batchLimitError('getAccountInfo', 100, addresses.length);
           }
 
           const result = await (helius as any).getMultipleAccounts(addresses, { encoding });
@@ -145,7 +145,7 @@ export function registerAccountTools(server: McpServer) {
       const helius = getHeliusClient();
 
       if (!owner && !mint) {
-        return mcpText(`**Error:** You must provide at least one of: owner or mint address.`);
+        return missingParamError('getTokenAccounts', 'Provide at least one of: `owner` or `mint` address.');
       }
 
       type TokenAccountParams = {

--- a/helius-mcp/src/tools/assets.ts
+++ b/helius-mcp/src/tools/assets.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatAddress } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
-import { mcpText, handleToolError, addressError, paginationError, notFoundError } from '../utils/errors.js';
+import { mcpText, mcpError, handleToolError, addressError, paginationError, notFoundError, missingParamError, exclusiveParamError, batchLimitError } from '../utils/errors.js';
 
 export function registerAssetTools(server: McpServer) {
   // Get Assets by Owner (NFTs and tokens via DAS)
@@ -98,11 +98,11 @@ export function registerAssetTools(server: McpServer) {
 
       // Validate: must provide exactly one of id or ids
       if (!id && (!ids || ids.length === 0)) {
-        return mcpText(`**Error:** Provide either "id" (single asset) or "ids" (batch of up to 1000).`);
+        return missingParamError('getAsset', 'Provide either `id` (single asset) or `ids` (batch of up to 1000).');
       }
 
       if (id && ids && ids.length > 0) {
-        return mcpText(`**Error:** Provide either "id" or "ids", not both.`);
+        return exclusiveParamError('getAsset', 'id', 'ids');
       }
 
       type Creator = { address: string; share: number; verified: boolean };
@@ -132,7 +132,7 @@ export function registerAssetTools(server: McpServer) {
       // --- Batch mode ---
       if (ids && ids.length > 0) {
         if (ids.length > 1000) {
-          return mcpText(`**Error:** Maximum 1000 assets per batch. You provided ${ids.length}.`);
+          return batchLimitError('getAsset', 1000, ids.length);
         }
 
         let assets;
@@ -343,7 +343,10 @@ export function registerAssetTools(server: McpServer) {
       // General search → searchAssets
       else {
         if (name && !ownerAddress) {
-          return mcpText(`**Search Error:** Searching by name requires an owner address. Please also provide \`ownerAddress\` to search for assets named "${name}".`);
+          return mcpError(
+            `**Search Error:** Searching by name requires an owner address. Please also provide \`ownerAddress\` to search for assets named "${name}".`,
+            { type: 'VALIDATION', code: 'MISSING_PARAM', retryable: false, recovery: 'Provide `ownerAddress` when searching by name.' }
+          );
         }
 
         type SearchParams = {

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -238,7 +238,10 @@ export function registerAuthTools(server: McpServer) {
         }
 
         if (!address) {
-          return mcpError('No signup wallet found. Call `generateKeypair` first to create a wallet.');
+          return mcpError(
+            'No signup wallet found. Call `generateKeypair` first to create a wallet.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
+          );
         }
 
         const solBalance = await checkSolBalance(address);
@@ -329,7 +332,10 @@ export function registerAuthTools(server: McpServer) {
         try {
           signerData = await loadSignerOrFail();
         } catch {
-          return mcpError('No signup keypair found. Call `generateKeypair` first to create a wallet, fund it, then call this tool.');
+          return mcpError(
+            'No signup keypair found. Call `generateKeypair` first to create a wallet, fund it, then call this tool.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet, fund it, then retry.' }
+          );
         }
 
         const result = await agenticSignup({
@@ -414,12 +420,18 @@ export function registerAuthTools(server: McpServer) {
       try {
         const jwt = getJwt();
         if (!jwt) {
-          return mcpError('Not authenticated. Call `agenticSignup` or authenticate first.');
+          return mcpError(
+            'Not authenticated. Call `agenticSignup` or authenticate first.',
+            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
+          );
         }
 
         const projects = await listProjects(jwt, MCP_USER_AGENT);
         if (projects.length === 0) {
-          return mcpError('No projects found. Call `agenticSignup` to create an account first.');
+          return mcpError(
+            'No projects found. Call `agenticSignup` to create an account first.',
+            { type: 'AUTH', code: 'NO_PROJECT', retryable: false, recovery: 'Call `agenticSignup` to create an account first.' }
+          );
         }
 
         const projectId = projects[0].id;
@@ -487,7 +499,8 @@ export function registerAuthTools(server: McpServer) {
             !lastName && 'lastName',
           ].filter(Boolean);
           return mcpError(
-            `Partial customer info provided. If any of email/firstName/lastName is given, all three are required. Missing: ${missing.join(', ')}`
+            `Partial customer info provided. If any of email/firstName/lastName is given, all three are required. Missing: ${missing.join(', ')}`,
+            { type: 'VALIDATION', code: 'MISSING_PARAM', retryable: false, recovery: `Provide all three: email, firstName, and lastName. Missing: ${missing.join(', ')}` }
           );
         }
 
@@ -495,17 +508,26 @@ export function registerAuthTools(server: McpServer) {
         try {
           signerData = await loadSignerOrFail();
         } catch {
-          return mcpError('No keypair found. Call `generateKeypair` first.');
+          return mcpError(
+            'No keypair found. Call `generateKeypair` first.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
+          );
         }
 
         const jwt = getJwt();
         if (!jwt) {
-          return mcpError('Not authenticated. Call `agenticSignup` or authenticate first.');
+          return mcpError(
+            'Not authenticated. Call `agenticSignup` or authenticate first.',
+            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
+          );
         }
 
         const projects = await listProjects(jwt, MCP_USER_AGENT);
         if (projects.length === 0) {
-          return mcpError('No projects found. Call `agenticSignup` to create an account first.');
+          return mcpError(
+            'No projects found. Call `agenticSignup` to create an account first.',
+            { type: 'AUTH', code: 'NO_PROJECT', retryable: false, recovery: 'Call `agenticSignup` to create an account first.' }
+          );
         }
 
         const projectId = projects[0].id;
@@ -524,7 +546,8 @@ export function registerAuthTools(server: McpServer) {
             `**Upgrade ${result.status}**\n\n` +
             (result.error ? `Error: ${result.error}\n` : '') +
             (result.txSignature ? `TX: \`${result.txSignature}\`\n` : '') +
-            `\nIf you need help, contact support with the payment intent ID: \`${result.paymentIntentId}\``
+            `\nIf you need help, contact support with the payment intent ID: \`${result.paymentIntentId}\``,
+            { type: 'API', code: 'OPERATION_FAILED', retryable: false, recovery: `Upgrade ${result.status}. Contact support with payment intent ID: ${result.paymentIntentId}` }
           );
         }
 
@@ -577,7 +600,10 @@ export function registerAuthTools(server: McpServer) {
         // ── Tier 3: full status via JWT ──
         const projects = await listProjects(jwt, MCP_USER_AGENT);
         if (projects.length === 0) {
-          return mcpError('No projects found. Call `agenticSignup` to create an account first.');
+          return mcpError(
+            'No projects found. Call `agenticSignup` to create an account first.',
+            { type: 'AUTH', code: 'NO_PROJECT', retryable: false, recovery: 'Call `agenticSignup` to create an account first.' }
+          );
         }
 
         const projectId = projects[0].id;
@@ -684,12 +710,18 @@ export function registerAuthTools(server: McpServer) {
         try {
           signerData = await loadSignerOrFail();
         } catch {
-          return mcpError('No keypair found. Call `generateKeypair` first.');
+          return mcpError(
+            'No keypair found. Call `generateKeypair` first.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
+          );
         }
 
         const jwt = getJwt();
         if (!jwt) {
-          return mcpError('Not authenticated. Call `agenticSignup` or authenticate first.');
+          return mcpError(
+            'Not authenticated. Call `agenticSignup` or authenticate first.',
+            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
+          );
         }
 
         const result = await executeRenewal(signerData.secretKey, jwt, paymentIntentId, MCP_USER_AGENT);
@@ -699,7 +731,8 @@ export function registerAuthTools(server: McpServer) {
             `**Payment ${result.status}**\n\n` +
             (result.error ? `Error: ${result.error}\n` : '') +
             (result.txSignature ? `TX: \`${result.txSignature}\`\n` : '') +
-            `\nIf you need help, contact support with the payment intent ID: \`${result.paymentIntentId}\``
+            `\nIf you need help, contact support with the payment intent ID: \`${result.paymentIntentId}\``,
+            { type: 'API', code: 'OPERATION_FAILED', retryable: false, recovery: `Payment ${result.status}. Contact support with payment intent ID: ${result.paymentIntentId}` }
           );
         }
 

--- a/helius-mcp/src/tools/config.ts
+++ b/helius-mcp/src/tools/config.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { setApiKey, setNetwork, hasApiKey, getHeliusClient } from '../utils/helius.js';
-import { mcpText, validateEnum, getErrorMessage } from '../utils/errors.js';
+import { mcpText, mcpError, validateEnum, getErrorMessage } from '../utils/errors.js';
 import { setSharedApiKey, SHARED_CONFIG_PATH } from '../utils/config.js';
 
 export function registerConfigTools(server: McpServer) {
@@ -36,7 +36,10 @@ export function registerConfigTools(server: McpServer) {
         const errorMsg = getErrorMessage(e);
         if (errorMsg.includes('invalid api key') || errorMsg.includes('401') || errorMsg.includes('Unauthorized')) {
           setApiKey('');
-          return mcpText(`❌ Invalid API key. Please check your key and try again.\n\nGet your key at https://dashboard.helius.dev/api-keys`);
+          return mcpError(
+            `❌ Invalid API key. Please check your key and try again.\n\nGet your key at https://dashboard.helius.dev/api-keys`,
+            { type: 'AUTH', code: 'INVALID_API_KEY', retryable: false, recovery: 'Check your API key at https://dashboard.helius.dev/api-keys and call setHeliusApiKey with a valid key.' }
+          );
         }
       }
 

--- a/helius-mcp/src/tools/das-extras.ts
+++ b/helius-mcp/src/tools/das-extras.ts
@@ -38,7 +38,10 @@ export function registerDasExtraTools(server: McpServer) {
       if (!hasApiKey()) return noApiKeyResponse();
       try {
         if (ids.length > 1000) {
-          return mcpError('Max 1000 proofs per batch');
+          return mcpError(
+            'Max 1000 proofs per batch',
+            { type: 'VALIDATION', code: 'TOO_MANY_ITEMS', retryable: false, recovery: 'Reduce batch to 1000 or fewer.' }
+          );
         }
         const helius = getHeliusClient();
         const result = await helius.getAssetProofBatch({ ids });
@@ -112,7 +115,7 @@ export function registerDasExtraTools(server: McpServer) {
       } catch (err) {
         const header = `Editions for ${formatAddress(mint)}`;
         return handleToolError(err, 'Error fetching editions', [
-          { match: (m) => m.includes('null value was encountered'), respond: () => mcpText(`**${header}**\n\nThis mint is not a master edition NFT. getNftEditions only works with master edition mints.`) },
+          { match: (m) => m.includes('null value was encountered'), respond: () => mcpError(`**${header}**\n\nThis mint is not a master edition NFT. getNftEditions only works with master edition mints.`, { type: 'VALIDATION', code: 'INVALID_PARAM', retryable: false, recovery: 'Provide a master edition mint address. getNftEditions only works with master edition NFTs.' }) },
           notFoundError(header, 'Asset not found. This mint address does not exist or has not been indexed.'),
           addressError(header, 'Invalid Solana address. Please provide a valid base58-encoded mint address.'),
           paginationError(header),

--- a/helius-mcp/src/tools/enhanced-websockets.ts
+++ b/helius-mcp/src/tools/enhanced-websockets.ts
@@ -215,7 +215,8 @@ export function registerEnhancedWebSocketTools(server: McpServer) {
         return mcpError(
           'Could not fetch live Enhanced WebSocket documentation. Try:\n' +
           '- `lookupHeliusDocs({ topic: \'enhanced-websockets\' })` for full documentation\n' +
-          '- Visit https://www.helius.dev/docs/enhanced-websockets directly'
+          '- Visit https://www.helius.dev/docs/enhanced-websockets directly',
+          { type: 'API', code: 'FETCH_FAILED', retryable: true, recovery: 'Try lookupHeliusDocs({ topic: "enhanced-websockets" }) or visit https://www.helius.dev/docs/enhanced-websockets directly' }
         );
       }
 

--- a/helius-mcp/src/tools/laserstream.ts
+++ b/helius-mcp/src/tools/laserstream.ts
@@ -39,7 +39,10 @@ export function registerLaserstreamTools(server: McpServer) {
       if (params.fromSlot !== undefined) {
         const slotNum = Number(params.fromSlot);
         if (!Number.isInteger(slotNum) || slotNum < 0) {
-          return mcpText(`**Laserstream Error**\n\nInvalid fromSlot "${params.fromSlot}". Must be a non-negative integer slot number.`);
+          return mcpError(
+            `**Laserstream Error**\n\nInvalid fromSlot "${params.fromSlot}". Must be a non-negative integer slot number.`,
+            { type: 'VALIDATION', code: 'INVALID_PARAM', retryable: false, recovery: 'Provide a non-negative integer slot number for fromSlot.' }
+          );
         }
       }
 
@@ -178,7 +181,8 @@ export function registerLaserstreamTools(server: McpServer) {
         return mcpError(
           'Could not fetch live Laserstream documentation. Try:\n' +
           '- `lookupHeliusDocs({ topic: \'laserstream\' })` for full documentation\n' +
-          '- Visit https://www.helius.dev/docs/laserstream/grpc directly'
+          '- Visit https://www.helius.dev/docs/laserstream/grpc directly',
+          { type: 'API', code: 'FETCH_FAILED', retryable: true, recovery: 'Try lookupHeliusDocs({ topic: "laserstream" }) or visit https://www.helius.dev/docs/laserstream/grpc directly' }
         );
       }
 

--- a/helius-mcp/src/tools/plans.ts
+++ b/helius-mcp/src/tools/plans.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { fetchDoc, extractSections } from '../utils/docs.js';
 import { mcpError } from '../utils/errors.js';
+import type { ErrorMeta } from '../utils/errors.js';
 import { getJwt } from '../utils/config.js';
 import { listProjects } from 'helius-sdk/auth/listProjects';
 import { getProject } from 'helius-sdk/auth/getProject';
@@ -45,6 +46,13 @@ const BILLING_FETCH_ERROR =
   '- `lookupHeliusDocs({ topic: \'billing\' })` for full billing documentation\n' +
   '- Visit https://www.helius.dev/docs/billing directly';
 
+const BILLING_FETCH_META: ErrorMeta = {
+  type: 'API',
+  code: 'FETCH_FAILED',
+  retryable: true,
+  recovery: 'Try lookupHeliusDocs({ topic: "billing" }) or visit https://www.helius.dev/docs/billing directly',
+};
+
 /**
  * Detect the user's current Helius plan from their JWT session.
  * Returns the plan key (e.g. "developer") or undefined if unavailable.
@@ -78,13 +86,13 @@ export function registerPlanTools(server: McpServer) {
       try {
         billingDoc = await fetchDoc('billing');
       } catch {
-        return mcpError(BILLING_FETCH_ERROR);
+        return mcpError(BILLING_FETCH_ERROR, BILLING_FETCH_META);
       }
 
       // Required: plans table
       const plansTable = extractSections(billingDoc, ['standard plans', 'standard pricing'], { includeLooseMatches: false });
       if (!plansTable) {
-        return mcpError(BILLING_FETCH_ERROR);
+        return mcpError(BILLING_FETCH_ERROR, BILLING_FETCH_META);
       }
 
       // Optional sections
@@ -138,7 +146,7 @@ export function registerPlanTools(server: McpServer) {
       try {
         billingDoc = await fetchDoc('billing');
       } catch {
-        return mcpError(BILLING_FETCH_ERROR);
+        return mcpError(BILLING_FETCH_ERROR, BILLING_FETCH_META);
       }
 
       const sectionMap: Record<string, string[]> = {
@@ -149,7 +157,7 @@ export function registerPlanTools(server: McpServer) {
 
       const extracted = extractSections(billingDoc, sectionMap[category], { includeLooseMatches: false });
       if (!extracted) {
-        return mcpError(BILLING_FETCH_ERROR);
+        return mcpError(BILLING_FETCH_ERROR, BILLING_FETCH_META);
       }
 
       const lines: string[] = [];

--- a/helius-mcp/src/tools/shared.ts
+++ b/helius-mcp/src/tools/shared.ts
@@ -1,3 +1,12 @@
+import type { ErrorMeta } from '../utils/errors.js';
+
+const NO_API_KEY_META: ErrorMeta = {
+  type: 'AUTH',
+  code: 'NO_API_KEY',
+  retryable: false,
+  recovery: 'Call generateKeypair + agenticSignup, or setHeliusApiKey',
+};
+
 const NO_API_KEY_MESSAGE = `**Helius API Key Required**
 
 I need a Helius API key to query the Solana blockchain.
@@ -13,7 +22,9 @@ I need a Helius API key to query the Solana blockchain.
 3. Call \`setHeliusApiKey\` with your key`;
 
 export function noApiKeyResponse() {
+  const body = '```json\n' + JSON.stringify(NO_API_KEY_META) + '\n```\n\n' + NO_API_KEY_MESSAGE;
   return {
-    content: [{ type: 'text' as const, text: NO_API_KEY_MESSAGE }]
+    content: [{ type: 'text' as const, text: body }],
+    isError: true,
   };
 }

--- a/helius-mcp/src/tools/solana-knowledge.ts
+++ b/helius-mcp/src/tools/solana-knowledge.ts
@@ -308,8 +308,9 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
             .map((e) => `  SIMD-${e.number}: ${e.slug}`)
             .join('\n');
 
-          return mcpText(
-            `SIMD-${paddedNumber} not found.\n\n${nearby ? `Nearby proposals:\n${nearby}` : `Total proposals available: ${index.length}`}`
+          return mcpError(
+            `SIMD-${paddedNumber} not found.\n\n${nearby ? `Nearby proposals:\n${nearby}` : `Total proposals available: ${index.length}`}`,
+            { type: 'NOT_FOUND', code: 'RESOURCE_NOT_FOUND', retryable: false, recovery: 'Check the SIMD number. Use listSIMDs to see available proposals.' }
           );
         }
 
@@ -389,7 +390,10 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
     async ({ path, repo, branch }) => {
       try {
         if (path.includes('..')) {
-          return mcpText('Invalid path: must not contain ".." segments.');
+          return mcpError(
+            'Invalid path: must not contain ".." segments.',
+            { type: 'VALIDATION', code: 'INVALID_PARAM', retryable: false, recovery: 'Remove ".." segments from the path.' }
+          );
         }
 
         const repoMap: Record<string, { fullName: string; defaultBranch: string }> = {
@@ -429,8 +433,9 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
           {
             match: (msg) => msg.includes('404'),
             respond: () =>
-              mcpText(
-                `**File not found:** \`${path}\`\n\nTips:\n- Check the path is correct\n- Browse https://github.com/${repoInfo} to find the right path\n- The default branch for ${repo} is "${defaultBr}"`
+              mcpError(
+                `**File not found:** \`${path}\`\n\nTips:\n- Check the path is correct\n- Browse https://github.com/${repoInfo} to find the right path\n- The default branch for ${repo} is "${defaultBr}"`,
+                { type: 'NOT_FOUND', code: 'HTTP_404', retryable: false, recovery: `Check the file path. Browse https://github.com/${repoInfo} to find the right path.` }
               ),
           },
         ]);
@@ -626,8 +631,9 @@ export function registerSolanaKnowledgeTools(server: McpServer) {
 
         // Fetch a specific post
         if (!slug) {
-          return mcpText(
-            'Please provide a slug. Use `fetchHeliusBlog` with action "list" to see available posts.'
+          return mcpError(
+            'Please provide a slug. Use `fetchHeliusBlog` with action "list" to see available posts.',
+            { type: 'VALIDATION', code: 'MISSING_PARAM', retryable: false, recovery: 'Provide a slug. Use fetchHeliusBlog with action "list" to see available posts.' }
           );
         }
 

--- a/helius-mcp/src/tools/transfers.ts
+++ b/helius-mcp/src/tools/transfers.ts
@@ -45,14 +45,16 @@ export function registerTransferTools(server: McpServer) {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before sending.'
+            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before sending.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
           );
         }
 
         // Validate recipient address
         if (!isValidAddressFormat(recipientAddress)) {
           return mcpError(
-            `Invalid recipient address "${recipientAddress}". Expected a valid Solana address (32-44 base58 characters).`
+            `Invalid recipient address "${recipientAddress}". Expected a valid Solana address (32-44 base58 characters).`,
+            { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address (32-44 characters).' }
           );
         }
 
@@ -80,13 +82,17 @@ export function registerTransferTools(server: McpServer) {
             const available = Number(balanceLamports) / 1_000_000_000;
             return mcpError(
               `Balance too low to cover the transaction fee. You have ${available} SOL.\n\n` +
-              `Wallet: \`${signerData.walletAddress}\``
+              `Wallet: \`${signerData.walletAddress}\``,
+              { type: 'INSUFFICIENT_FUNDS', code: 'LOW_SOL', retryable: false, recovery: `Fund the wallet with more SOL. Current balance: ${available} SOL.` }
             );
           }
           sendAmount = Number(lamports) / 1_000_000_000;
         } else {
           if (amount === undefined) {
-            return mcpError('Either `amount` must be specified or `sendMax` must be true.');
+            return mcpError(
+              'Either `amount` must be specified or `sendMax` must be true.',
+              { type: 'VALIDATION', code: 'MISSING_PARAM', retryable: false, recovery: 'Provide `amount` or set `sendMax` to true.' }
+            );
           }
           lamports = BigInt(Math.round(amount * 1_000_000_000));
           sendAmount = amount;
@@ -96,7 +102,8 @@ export function registerTransferTools(server: McpServer) {
             const available = Number(balanceLamports) / 1_000_000_000;
             return mcpError(
               `Insufficient SOL balance. You have ${available} SOL but need ${sendAmount} SOL plus ~0.005 SOL for transaction fees.\n\n` +
-              `Wallet: \`${signerData.walletAddress}\``
+              `Wallet: \`${signerData.walletAddress}\``,
+              { type: 'INSUFFICIENT_FUNDS', code: 'LOW_SOL', retryable: false, recovery: `Fund the wallet with at least ${sendAmount + 0.005} SOL.` }
             );
           }
         }
@@ -171,19 +178,22 @@ export function registerTransferTools(server: McpServer) {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before sending.'
+            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before sending.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
           );
         }
 
         // Validate addresses
         if (!isValidAddressFormat(recipientAddress)) {
           return mcpError(
-            `Invalid recipient address "${recipientAddress}". Expected a valid Solana address (32-44 base58 characters).`
+            `Invalid recipient address "${recipientAddress}". Expected a valid Solana address (32-44 base58 characters).`,
+            { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded Solana address (32-44 characters).' }
           );
         }
         if (!isValidAddressFormat(mintAddress)) {
           return mcpError(
-            `Invalid mint address "${mintAddress}". Expected a valid Solana address (32-44 base58 characters).`
+            `Invalid mint address "${mintAddress}". Expected a valid Solana address (32-44 base58 characters).`,
+            { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery: 'Provide a valid base58-encoded token mint address (32-44 characters).' }
           );
         }
 
@@ -194,13 +204,15 @@ export function registerTransferTools(server: McpServer) {
           asset = await helius.getAsset({ id: mintAddress });
         } catch {
           return mcpError(
-            `Could not fetch token metadata for mint \`${mintAddress}\`. Verify the mint address is correct.`
+            `Could not fetch token metadata for mint \`${mintAddress}\`. Verify the mint address is correct.`,
+            { type: 'NOT_FOUND', code: 'RESOURCE_NOT_FOUND', retryable: false, recovery: 'Verify the mint address is correct. Use `getAsset` to check if the mint exists.' }
           );
         }
 
         if (!asset?.token_info?.decimals && asset?.token_info?.decimals !== 0) {
           return mcpError(
-            `Mint \`${mintAddress}\` does not appear to be a fungible token (no decimals info found). Use \`getAsset\` to inspect it.`
+            `Mint \`${mintAddress}\` does not appear to be a fungible token (no decimals info found). Use \`getAsset\` to inspect it.`,
+            { type: 'NOT_FOUND', code: 'RESOURCE_NOT_FOUND', retryable: false, recovery: 'This mint may not be a fungible token. Use `getAsset` to inspect it.' }
           );
         }
 
@@ -212,7 +224,8 @@ export function registerTransferTools(server: McpServer) {
         // Token-2022 check
         if (tokenProgram === TOKEN_2022_PROGRAM_ID) {
           return mcpError(
-            `Token-2022 transfers are not yet supported. This token (\`${tokenName}\`${tokenSymbol ? ` / ${tokenSymbol}` : ''}) uses the Token-2022 program. Standard SPL Token transfers are supported.`
+            `Token-2022 transfers are not yet supported. This token (\`${tokenName}\`${tokenSymbol ? ` / ${tokenSymbol}` : ''}) uses the Token-2022 program. Standard SPL Token transfers are supported.`,
+            { type: 'UNSUPPORTED', code: 'TOKEN_2022', retryable: false, recovery: 'Token-2022 transfers are not yet supported. Only standard SPL Token transfers are available.' }
           );
         }
 
@@ -245,7 +258,8 @@ export function registerTransferTools(server: McpServer) {
             return mcpError(
               `No token account found for ${tokenSymbol || tokenName}. You may not hold this token.\n\n` +
               `Wallet: \`${signerData.walletAddress}\`\n` +
-              `Mint: \`${mintAddress}\``
+              `Mint: \`${mintAddress}\``,
+              { type: 'INSUFFICIENT_FUNDS', code: 'LOW_TOKEN', retryable: false, recovery: `You may not hold ${tokenSymbol || tokenName}. Check your token balances with getTokenBalances.` }
             );
           }
           rawAmount = BigInt(tokenBalance.value.amount);
@@ -253,13 +267,17 @@ export function registerTransferTools(server: McpServer) {
             return mcpError(
               `${tokenSymbol || tokenName} balance is 0. Nothing to send.\n\n` +
               `Wallet: \`${signerData.walletAddress}\`\n` +
-              `Mint: \`${mintAddress}\``
+              `Mint: \`${mintAddress}\``,
+              { type: 'INSUFFICIENT_FUNDS', code: 'ZERO_BALANCE', retryable: false, recovery: `${tokenSymbol || tokenName} balance is zero. Fund the wallet with tokens before sending.` }
             );
           }
           sendAmount = Number(rawAmount) / 10 ** decimals;
         } else {
           if (amount === undefined) {
-            return mcpError('Either `amount` must be specified or `sendMax` must be true.');
+            return mcpError(
+              'Either `amount` must be specified or `sendMax` must be true.',
+              { type: 'VALIDATION', code: 'MISSING_PARAM', retryable: false, recovery: 'Provide `amount` or set `sendMax` to true.' }
+            );
           }
           rawAmount = BigInt(Math.round(amount * 10 ** decimals));
           sendAmount = amount;
@@ -273,7 +291,8 @@ export function registerTransferTools(server: McpServer) {
               return mcpError(
                 `Insufficient ${tokenSymbol || tokenName} balance. You have ${currentHuman} but are trying to send ${sendAmount}.\n\n` +
                 `Wallet: \`${signerData.walletAddress}\`\n` +
-                `Mint: \`${mintAddress}\``
+                `Mint: \`${mintAddress}\``,
+                { type: 'INSUFFICIENT_FUNDS', code: 'LOW_TOKEN', retryable: false, recovery: `You have ${currentHuman} ${tokenSymbol || tokenName} but need ${sendAmount}. Fund the wallet with more tokens.` }
               );
             }
           } catch {

--- a/helius-mcp/src/tools/wallet.ts
+++ b/helius-mcp/src/tools/wallet.ts
@@ -48,7 +48,10 @@ export function registerWalletTools(server: McpServer) {
       if (!hasApiKey()) return noApiKeyResponse();
 
       if (addresses.length > 100) {
-        return mcpError('Error: Maximum 100 addresses per batch request.');
+        return mcpError(
+          'Maximum 100 addresses per batch request.',
+          { type: 'VALIDATION', code: 'TOO_MANY_ITEMS', retryable: false, recovery: 'Reduce batch to 100 or fewer addresses.' }
+        );
       }
 
       try {

--- a/helius-mcp/src/tools/webhooks.ts
+++ b/helius-mcp/src/tools/webhooks.ts
@@ -95,7 +95,10 @@ export function registerWebhookTools(server: McpServer) {
       if (transactionTypes) {
         const invalid = transactionTypes.filter(t => !(TRANSACTION_TYPES as readonly string[]).includes(t));
         if (invalid.length > 0) {
-          return mcpText(`**Create Webhook Error**\n\nInvalid transaction type(s): ${invalid.join(', ')}. See valid types: https://www.helius.dev/docs/webhooks/transaction-types`);
+          return mcpError(
+            `**Create Webhook Error**\n\nInvalid transaction type(s): ${invalid.join(', ')}. See valid types: https://www.helius.dev/docs/webhooks/transaction-types`,
+            { type: 'VALIDATION', code: 'INVALID_ENUM', retryable: false, recovery: `Remove invalid transaction types: ${invalid.join(', ')}. See https://www.helius.dev/docs/webhooks/transaction-types for valid types.` }
+          );
         }
       }
       try {
@@ -135,7 +138,10 @@ export function registerWebhookTools(server: McpServer) {
       if (transactionTypes) {
         const invalid = transactionTypes.filter(t => !(TRANSACTION_TYPES as readonly string[]).includes(t));
         if (invalid.length > 0) {
-          return mcpText(`**Update Webhook Error**\n\nInvalid transaction type(s): ${invalid.join(', ')}. See valid types: https://www.helius.dev/docs/webhooks/transaction-types`);
+          return mcpError(
+            `**Update Webhook Error**\n\nInvalid transaction type(s): ${invalid.join(', ')}. See valid types: https://www.helius.dev/docs/webhooks/transaction-types`,
+            { type: 'VALIDATION', code: 'INVALID_ENUM', retryable: false, recovery: `Remove invalid transaction types: ${invalid.join(', ')}. See https://www.helius.dev/docs/webhooks/transaction-types for valid types.` }
+          );
         }
       }
       try {

--- a/helius-mcp/src/utils/errors.ts
+++ b/helius-mcp/src/utils/errors.ts
@@ -5,12 +5,22 @@ type McpToolResponse = {
   isError?: boolean;
 };
 
+export type ErrorMeta = {
+  type: 'VALIDATION' | 'NOT_FOUND' | 'AUTH' | 'RATE_LIMIT' | 'INSUFFICIENT_FUNDS' | 'UNSUPPORTED' | 'HTTP' | 'API';
+  code: string;
+  retryable: boolean;
+  recovery: string;
+};
+
 export function mcpText(text: string): McpToolResponse {
   return { content: [{ type: 'text', text }] };
 }
 
-export function mcpError(text: string): McpToolResponse {
-  return { content: [{ type: 'text', text }], isError: true };
+export function mcpError(text: string, meta?: ErrorMeta): McpToolResponse {
+  const body = meta
+    ? '```json\n' + JSON.stringify(meta) + '\n```\n\n' + text
+    : text;
+  return { content: [{ type: 'text', text: body }], isError: true };
 }
 
 // ─── Error Message Extraction ───
@@ -70,7 +80,10 @@ export function validateEnum(
   fieldName: string
 ): McpToolResponse | null {
   if (!validOptions.includes(value)) {
-    return mcpText(`**${context}**\n\nInvalid ${fieldName} "${value}". Valid options: ${validOptions.join(', ')}`);
+    return mcpError(
+      `**${context}**\n\nInvalid ${fieldName} "${value}". Valid options: ${validOptions.join(', ')}`,
+      { type: 'VALIDATION', code: 'INVALID_ENUM', retryable: false, recovery: `Use one of: ${validOptions.join(', ')}` }
+    );
   }
   return null;
 }
@@ -94,6 +107,23 @@ function extractHttpGuidance(msg: string): string | null {
   return null;
 }
 
+const HTTP_META: Record<string, ErrorMeta> = {
+  '401': { type: 'AUTH', code: 'HTTP_401', retryable: false, recovery: HTTP_GUIDANCE['401'] },
+  '403': { type: 'AUTH', code: 'HTTP_403', retryable: false, recovery: HTTP_GUIDANCE['403'] },
+  '429': { type: 'RATE_LIMIT', code: 'HTTP_429', retryable: true, recovery: HTTP_GUIDANCE['429'] },
+  '502': { type: 'HTTP', code: 'HTTP_502', retryable: true, recovery: HTTP_GUIDANCE['502'] },
+  '504': { type: 'HTTP', code: 'HTTP_504', retryable: true, recovery: HTTP_GUIDANCE['504'] },
+};
+
+function extractHttpMeta(msg: string, _guidance: string): ErrorMeta {
+  for (const [status, meta] of Object.entries(HTTP_META)) {
+    if (msg.includes(`HTTP ${status}`) || msg.includes(`status: ${status}`) || msg.includes(`(${status})`)) {
+      return meta;
+    }
+  }
+  return { type: 'API', code: 'UNKNOWN', retryable: false, recovery: 'Check the error message for details' };
+}
+
 // ─── Catch-Block Handler Chain ───
 
 type ErrorHandler = {
@@ -114,38 +144,54 @@ export function handleToolError(
   }
   const guidance = extractHttpGuidance(msg);
   if (guidance) {
-    return mcpError(`**${fallbackPrefix}:** ${msg}\n\n${guidance}`);
+    const meta = extractHttpMeta(msg, guidance);
+    return mcpError(`**${fallbackPrefix}:** ${msg}\n\n${guidance}`, meta);
   }
-  return mcpError(`**${fallbackPrefix}:** ${msg}`);
+  return mcpError(`**${fallbackPrefix}:** ${msg}`, { type: 'API', code: 'UNKNOWN', retryable: false, recovery: 'Check the error message for details' });
 }
 
 // ─── Pre-built Handler Factories ───
 
 export function addressError(header: string, detail?: string): ErrorHandler {
+  const recovery = detail || 'Invalid Solana address. Please provide a valid base58-encoded address.';
   return {
     match: isAddressError,
-    respond: () => mcpText(`**${header}**\n\n${detail || 'Invalid Solana address. Please provide a valid base58-encoded address.'}`),
+    respond: () => mcpError(
+      `**${header}**\n\n${recovery}`,
+      { type: 'VALIDATION', code: 'INVALID_ADDRESS', retryable: false, recovery }
+    ),
   };
 }
 
 export function paginationError(header: string, detail?: string): ErrorHandler {
+  const recovery = detail || 'Invalid pagination parameters. Page must be at least 1 and limit must be between 1 and 1000.';
   return {
     match: isPaginationError,
-    respond: () => mcpText(`**${header}**\n\n${detail || 'Invalid pagination parameters. Page must be at least 1 and limit must be between 1 and 1000.'}`),
+    respond: () => mcpError(
+      `**${header}**\n\n${recovery}`,
+      { type: 'VALIDATION', code: 'INVALID_PAGINATION', retryable: false, recovery }
+    ),
   };
 }
 
 export function notFoundError(header: string, detail?: string): ErrorHandler {
+  const recovery = detail || 'Asset not found. This mint address does not exist or has not been indexed.';
   return {
     match: isNotFoundError,
-    respond: () => mcpText(`**${header}**\n\n${detail || 'Asset not found. This mint address does not exist or has not been indexed.'}`),
+    respond: () => mcpError(
+      `**${header}**\n\n${recovery}`,
+      { type: 'NOT_FOUND', code: 'RESOURCE_NOT_FOUND', retryable: false, recovery }
+    ),
   };
 }
 
 export function http404Error(header: string, detail: string): ErrorHandler {
   return {
     match: isHttp404Error,
-    respond: () => header ? mcpText(`**${header}**\n\n${detail}`) : mcpText(detail),
+    respond: () => mcpError(
+      header ? `**${header}**\n\n${detail}` : detail,
+      { type: 'NOT_FOUND', code: 'HTTP_404', retryable: false, recovery: detail }
+    ),
   };
 }
 
@@ -155,9 +201,15 @@ export function http400Error(header: string): ErrorHandler {
     respond: (msg) => {
       const messages = parseHttp400Messages(msg);
       if (messages) {
-        return mcpText(`**${header}**\n\n${messages.map((m: string) => `- ${m}`).join('\n')}`);
+        return mcpError(
+          `**${header}**\n\n${messages.map((m: string) => `- ${m}`).join('\n')}`,
+          { type: 'API', code: 'BAD_REQUEST', retryable: false, recovery: 'Fix the request parameters' }
+        );
       }
-      return mcpError(`**${header}:** ${msg}`);
+      return mcpError(
+        `**${header}:** ${msg}`,
+        { type: 'API', code: 'BAD_REQUEST', retryable: false, recovery: 'Fix the request parameters' }
+      );
     },
   };
 }
@@ -204,6 +256,31 @@ export function warnAddressConflicts(
     return `${overlap.length} address(es) appear in both ${includeName} and ${excludeName}: ${overlap.slice(0, 3).map(a => `"${a}"`).join(', ')}${overlap.length > 3 ? `, ... (${overlap.length} total)` : ''}. These addresses will be included and excluded simultaneously, which may cause unexpected behavior.`;
   }
   return null;
+}
+
+// ─── Convenience Error Helpers ───
+
+export function missingParamError(toolName: string, recovery: string): McpToolResponse {
+  return mcpError(
+    `**${toolName} Error**\n\n${recovery}`,
+    { type: 'VALIDATION', code: 'MISSING_PARAM', retryable: false, recovery }
+  );
+}
+
+export function exclusiveParamError(toolName: string, paramA: string, paramB: string): McpToolResponse {
+  const recovery = `Provide either \`${paramA}\` or \`${paramB}\`, not both.`;
+  return mcpError(
+    `**${toolName} Error**\n\n${recovery}`,
+    { type: 'VALIDATION', code: 'EXCLUSIVE_PARAMS', retryable: false, recovery }
+  );
+}
+
+export function batchLimitError(toolName: string, max: number, actual: number): McpToolResponse {
+  const recovery = `Reduce batch to ${max} or fewer items.`;
+  return mcpError(
+    `**${toolName} Error**\n\nMaximum ${max} items per request. You provided ${actual}.`,
+    { type: 'VALIDATION', code: 'TOO_MANY_ITEMS', retryable: false, recovery }
+  );
 }
 
 export type { ErrorHandler, McpToolResponse };

--- a/helius-mcp/tests/errors.test.ts
+++ b/helius-mcp/tests/errors.test.ts
@@ -169,7 +169,7 @@ describe('handleToolError', () => {
   it('dispatches to the first matching handler', () => {
     const handler = addressError('My Tool');
     const result = handleToolError(new Error('Invalid pubkey format'), 'Fallback', [handler]);
-    expect(result.isError).toBeUndefined();
+    expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('My Tool');
   });
 

--- a/helius-mcp/tests/tools.test.ts
+++ b/helius-mcp/tests/tools.test.ts
@@ -139,6 +139,6 @@ describe('noApiKey guard', () => {
     expect(tool, `tool not found: ${toolName}`).toBeDefined();
     const result = await tool!.handler({});
     expect(result.content[0].text).toContain('Helius API Key Required');
-    expect(result.isError).toBeUndefined(); // noApiKeyResponse is not an error, just a guide
+    expect(result.isError).toBe(true); // noApiKeyResponse is an auth error with structured metadata
   });
 });


### PR DESCRIPTION
## Summary

- All error responses now use `mcpError()` (`isError: true`) instead of `mcpText()`, so AI agents can distinguish errors from success responses
- Added `ErrorMeta` type with structured `{ type, code, retryable, recovery }` JSON prefix to all error text for programmatic recovery
- Updated core infrastructure (`errors.ts`, `shared.ts`) and all 12 tool files (~50 error sites total)
- Added convenience helpers: `missingParamError()`, `exclusiveParamError()`, `batchLimitError()`

### Error code reference

| type | code | retryable | Used for |
|------|------|-----------|----------|
| VALIDATION | MISSING_PARAM, EXCLUSIVE_PARAMS, TOO_MANY_ITEMS, INVALID_ENUM, INVALID_ADDRESS, INVALID_PAGINATION, INVALID_PARAM | false | Input validation |
| NOT_FOUND | RESOURCE_NOT_FOUND, HTTP_404 | false | Missing resources |
| AUTH | NO_API_KEY, INVALID_API_KEY, NO_KEYPAIR, NOT_AUTHENTICATED, NO_PROJECT, HTTP_401, HTTP_403 | false | Authentication |
| RATE_LIMIT | HTTP_429 | true | Rate limiting |
| INSUFFICIENT_FUNDS | LOW_SOL, LOW_TOKEN, ZERO_BALANCE | false | Balance checks |
| UNSUPPORTED | TOKEN_2022 | false | Unsupported features |
| HTTP | HTTP_502, HTTP_504 | true | Transient failures |
| API | BAD_REQUEST, FETCH_FAILED, OPERATION_FAILED, UNKNOWN | varies | API errors |

### What stays as `mcpText()` (not errors)

Zero-result query responses remain as success responses: "No assets found", "No transactions found", "Account not found or has no data", etc.

### Follow-up needed after branch merges

- **`zk-compression.ts`** (PR #69) — 5 `mcpText()` → `missingParamError()` conversions needed once ZK compression tools merge
- **`staking.ts`** (PR #68, `nathanliow/gex-546-featmcp-add-staking-functionality`) — ~7 `mcpError()` calls need structured meta added once staking tools merge

## Test plan

- [x] `pnpm build` passes with no TypeScript errors
- [x] All 122 tests pass
- [x] Verified all `mcpError()` calls have structured metadata
- [x] Verified all remaining `mcpText()` calls are legitimate success responses
- [ ] Manual smoke test: trigger a validation error and verify `isError: true` + JSON prefix in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)