### PR TITLE
feat(mcp): add getAccountPlan tool

### DIFF
--- a/.agents/skills/helius/SKILL.md
+++ b/.agents/skills/helius/SKILL.md
@@ -86,7 +86,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -94,7 +94,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/.agents/skills/helius/prompts/claude.system.md
+++ b/.agents/skills/helius/prompts/claude.system.md
@@ -87,7 +87,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -95,7 +95,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/.agents/skills/helius/prompts/full.md
+++ b/.agents/skills/helius/prompts/full.md
@@ -77,7 +77,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md (inlined below)
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -85,7 +85,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/.agents/skills/helius/prompts/openai.developer.md
+++ b/.agents/skills/helius/prompts/openai.developer.md
@@ -87,7 +87,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -95,7 +95,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/helius-cursor/skills/build/SKILL.md
+++ b/helius-cursor/skills/build/SKILL.md
@@ -82,7 +82,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -90,7 +90,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/helius-mcp/src/index.ts
+++ b/helius-mcp/src/index.ts
@@ -44,6 +44,7 @@ const server = new McpServer(
 | block data by slot | getBlock | 1 |
 | plans/pricing | getHeliusPlanInfo | 0 |
 | plan comparison | compareHeliusPlans | 0 |
+| pre-flight plan/feature check | getAccountPlan | 0 |
 | plan upgrade / billing | previewUpgrade, upgradePlan, payRenewal | 0 |
 | rate limits/credits | getRateLimitInfo | 0 |
 | API docs by topic | lookupHeliusDocs | 0 |
@@ -69,6 +70,7 @@ Rules:
 - For errors, use troubleshootError first.
 - When a user describes ANY project they want to build ("I want to build/make/create...", "help me build...", "I need a..."), call recommendStack immediately with their description — do not ask clarifying questions first. After recommendations, use getHeliusPlanInfo for pricing and lookupHeliusDocs for API details.
 - "send SOL" / "transfer SOL" → transferSol (~3 credits). "send tokens" / "transfer USDC/BONK/etc" → transferToken (~13 credits). Both require a configured keypair (generateKeypair) and use Helius Sender.
+- Before calling gated tools (transactionSubscribe, accountSubscribe, laserstreamSubscribe), call getAccountPlan to verify eligibility.
 
 ## Feedback
 Every tool accepts \`_feedback\` and \`_model\` params. Always include \`_model\` with your LLM model identifier (e.g. "claude-sonnet-4-20250514", "gpt-4o"). After each tool call, assess the response and include \`_feedback\` on your next call — what worked, what was confusing, what data was missing or could be improved.`

--- a/helius-mcp/src/tools/plans.ts
+++ b/helius-mcp/src/tools/plans.ts
@@ -1,11 +1,14 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { fetchDoc, extractSections } from '../utils/docs.js';
-import { mcpError } from '../utils/errors.js';
+import { mcpText, mcpError } from '../utils/errors.js';
+import { hasApiKey } from '../utils/helius.js';
 import { getJwt } from '../utils/config.js';
 import { listProjects } from 'helius-sdk/auth/listProjects';
 import { getProject } from 'helius-sdk/auth/getProject';
 import { MCP_USER_AGENT } from '../http.js';
+import { PRODUCT_CATALOG } from './product-catalog.js';
+import { PLAN_RANK } from './product-catalog.js';
 
 /**
  * Static plan metadata — NOT the source of truth for pricing or billing data.
@@ -166,4 +169,171 @@ export function registerPlanTools(server: McpServer) {
       return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
     }
   );
+
+  // ── getAccountPlan — lightweight pre-flight check ──
+
+  server.tool(
+    'getAccountPlan',
+    'Lightweight pre-flight check: returns current plan, credit balance, and which MCP tools require an upgrade. 0 credits. Call before gated tools (transactionSubscribe, laserstreamSubscribe, etc.).',
+    {},
+    async () => {
+      // ── Tier 1: not authenticated at all ──
+      if (!hasApiKey()) {
+        return mcpText(
+          `## Account Plan\n\n` +
+          `**Auth:** Not authenticated\n\n` +
+          `No API key or session found. To get started:\n` +
+          `- If you have a key: use the \`setHeliusApiKey\` tool\n` +
+          `- If you need an account: use \`generateKeypair\` → fund wallet → \`agenticSignup\``
+        );
+      }
+
+      // ── Tier 2: API key present but no JWT ──
+      const jwt = getJwt();
+      if (!jwt) {
+        return mcpText(
+          `## Account Plan\n\n` +
+          `**Auth:** API key configured, plan unknown\n\n` +
+          `To see your plan and tool eligibility, call \`agenticSignup\`.\n` +
+          `Your existing account will be detected automatically — no payment needed.`
+        );
+      }
+
+      // ── Tier 3: full status via JWT ──
+      try {
+        const projects = await listProjects(jwt, MCP_USER_AGENT);
+        if (projects.length === 0) {
+          return mcpError('No projects found. Call `agenticSignup` to create an account first.');
+        }
+
+        const projectId = projects[0].id;
+        const details = await getProject(jwt, projectId, MCP_USER_AGENT);
+
+        const planKey = (details.subscriptionPlanDetails?.currentPlan?.trim().toLowerCase()) ?? 'unknown';
+        const planInfo = HELIUS_PLANS[planKey];
+        const planName = planInfo?.name ?? planKey;
+
+        // Credit info
+        const totalCredits = details.subscriptionPlanDetails?.totalCredits ?? 0;
+        const usedCredits = details.subscriptionPlanDetails?.usedCredits ?? 0;
+        const remainingCredits = totalCredits - usedCredits;
+        const usedPct = totalCredits > 0 ? ((usedCredits / totalCredits) * 100).toFixed(1) : '0.0';
+
+        // Tool eligibility
+        const eligibility = computeToolEligibility(planKey);
+
+        const lines: string[] = [
+          `## Account Plan`,
+          ``,
+          `**Plan:** ${planName}`,
+          ``,
+          `### Credits`,
+          `- **Remaining:** ${remainingCredits.toLocaleString()} / ${totalCredits.toLocaleString()} (${usedPct}% used)`,
+          ``,
+          `### Gated Tool Eligibility`,
+          `All Free-tier tools are available on every plan.`,
+          ``,
+        ];
+
+        if (eligibility.length > 0) {
+          lines.push(
+            `| Tool | Status | Requires |`,
+            `|------|--------|----------|`,
+          );
+          for (const e of eligibility) {
+            lines.push(`| ${e.tool} | ${e.status} | ${e.requires} |`);
+          }
+        } else {
+          lines.push(`All tools are available on your plan.`);
+        }
+
+        // Next steps — find tools that need upgrade
+        const upgradeNeeded = eligibility.filter(e => e.status.includes('UPGRADE REQUIRED'));
+        if (upgradeNeeded.length > 0) {
+          lines.push(``, `### Next Steps`);
+          const toolNames = upgradeNeeded.map(e => e.tool);
+          const uniqueRequires = [...new Set(upgradeNeeded.map(e => e.requires))];
+          lines.push(`To unlock ${toolNames.join(', ')}, upgrade to ${uniqueRequires.join(' or ')}.`);
+          lines.push(`→ Use \`previewUpgrade\` to see pricing`);
+        }
+
+        return mcpText(lines.join('\n'));
+      } catch (err) {
+        return mcpError(`Failed to fetch account plan: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  );
+}
+
+// ─── Tool Eligibility Helper ───
+
+interface ToolEligibilityEntry {
+  tool: string;
+  status: string;
+  requires: string;
+}
+
+function computeToolEligibility(planKey: string): ToolEligibilityEntry[] {
+  const userRank = PLAN_RANK[planKey] ?? 0;
+
+  // Collect all non-free product entries per tool
+  const toolProducts: Record<string, { productName: string; minimumPlan: string }[]> = {};
+
+  for (const product of Object.values(PRODUCT_CATALOG)) {
+    if (product.minimumPlan === 'free') continue;
+    for (const tool of product.mcpTools) {
+      if (!toolProducts[tool]) toolProducts[tool] = [];
+      toolProducts[tool].push({ productName: product.name, minimumPlan: product.minimumPlan });
+    }
+  }
+
+  const results: ToolEligibilityEntry[] = [];
+
+  for (const [tool, products] of Object.entries(toolProducts)) {
+    // Also check if this tool appears in any free product (e.g. transactionSubscribe in standard-websockets)
+    const inFreeToo = Object.values(PRODUCT_CATALOG).some(
+      p => p.minimumPlan === 'free' && p.mcpTools.includes(tool)
+    );
+
+    if (products.length === 1) {
+      const p = products[0];
+      const available = userRank >= (PLAN_RANK[p.minimumPlan] ?? 99);
+      const planDisplay = HELIUS_PLANS[p.minimumPlan]?.name ?? p.minimumPlan;
+
+      if (inFreeToo && available) {
+        // Tool is available at free tier AND at this gated tier — show available
+        results.push({ tool, status: 'AVAILABLE', requires: planDisplay });
+      } else if (inFreeToo && !available) {
+        // Tool works at free tier but the enhanced version needs upgrade
+        results.push({ tool, status: `AVAILABLE (basic) / UPGRADE REQUIRED (${p.productName})`, requires: planDisplay });
+      } else {
+        results.push({ tool, status: available ? 'AVAILABLE' : 'UPGRADE REQUIRED', requires: planDisplay });
+      }
+    } else {
+      // Multiple non-free products (e.g. laserstreamSubscribe in devnet + mainnet)
+      const statuses: string[] = [];
+      const requires: string[] = [];
+
+      for (const p of products) {
+        const available = userRank >= (PLAN_RANK[p.minimumPlan] ?? 99);
+        const planDisplay = HELIUS_PLANS[p.minimumPlan]?.name ?? p.minimumPlan;
+        const label = p.productName.includes('(') ? p.productName.replace(/.*\(/, '').replace(/\).*/, '').toLowerCase() : p.productName;
+        statuses.push(available ? `AVAILABLE (${label})` : `UPGRADE REQUIRED (${label})`);
+        requires.push(planDisplay);
+      }
+
+      const allAvailable = statuses.every(s => s.startsWith('AVAILABLE'));
+      const allUnavailable = statuses.every(s => s.startsWith('UPGRADE'));
+
+      if (allAvailable) {
+        results.push({ tool, status: 'AVAILABLE', requires: requires.join(' / ') });
+      } else if (allUnavailable) {
+        results.push({ tool, status: 'UPGRADE REQUIRED', requires: requires[requires.length - 1] });
+      } else {
+        results.push({ tool, status: statuses.join(' / '), requires: requires.join(' / ') });
+      }
+    }
+  }
+
+  return results;
 }

--- a/helius-mcp/src/tools/product-catalog.ts
+++ b/helius-mcp/src/tools/product-catalog.ts
@@ -14,6 +14,11 @@ export interface CatalogProduct {
   description: string;
 }
 
+// ─── Plan Ranking ───
+// Pure data constant — lives here (zero imports) to avoid circular dependencies.
+
+export const PLAN_RANK: Record<string, number> = { free: 0, developer: 1, business: 2, professional: 3 };
+
 export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
   'das-api': {
     name: 'DAS API',

--- a/helius-mcp/src/tools/recommend.ts
+++ b/helius-mcp/src/tools/recommend.ts
@@ -4,7 +4,8 @@ import { mcpText } from '../utils/errors.js';
 import { hasApiKey } from '../utils/helius.js';
 import { getPreferences, savePreferences } from '../utils/config.js';
 import { HELIUS_PLANS, detectCurrentPlan } from './plans.js';
-import { PRODUCT_CATALOG, CatalogProduct } from './product-catalog.js';
+import { PRODUCT_CATALOG, CatalogProduct, PLAN_RANK } from './product-catalog.js';
+export { PLAN_RANK };
 // fetchDoc/extractSections no longer needed — live billing fetch removed
 
 
@@ -24,16 +25,14 @@ export const KNOWN_TOOLS = new Set([
   'transactionSubscribe', 'accountSubscribe', 'getEnhancedWebSocketInfo',
   'laserstreamSubscribe', 'getLaserstreamInfo',
   'getWalletIdentity', 'batchWalletIdentity', 'getWalletFundedBy',
-  'getHeliusPlanInfo', 'compareHeliusPlans',
+  'getHeliusPlanInfo', 'compareHeliusPlans', 'getAccountPlan',
   'lookupHeliusDocs', 'listHeliusDocTopics', 'getHeliusCreditsInfo', 'getRateLimitInfo',
   'troubleshootError', 'getSenderInfo', 'getWebhookGuide', 'getLatencyComparison', 'getPumpFunGuide',
   'recommendStack',
   'transferSol', 'transferToken',
 ]);
 
-// ─── Plan Ranking ───
-
-export const PLAN_RANK: Record<string, number> = { free: 0, developer: 1, business: 2, professional: 3 };
+// ─── Plan Ranking (re-exported from product-catalog.ts) ───
 
 function planAtOrBelow(plan: string, maxPlan: string): boolean {
   return (PLAN_RANK[plan] ?? 99) <= (PLAN_RANK[maxPlan] ?? 99);

--- a/helius-mcp/src/utils/errors.ts
+++ b/helius-mcp/src/utils/errors.ts
@@ -79,7 +79,7 @@ export function validateEnum(
 
 const HTTP_GUIDANCE: Record<string, string> = {
   '401': 'API key is invalid or expired. Call `setHeliusApiKey` with a valid key, or call `getAccountStatus` to check your current auth state.',
-  '403': 'This endpoint is restricted on your current plan. Call `getAccountStatus` to check your plan tier and remaining credits. Some endpoints (Enhanced Transactions, Token API) require Developer plan or higher. Call `getHeliusPlanInfo` to compare plans, or `previewUpgrade` to see upgrade pricing.',
+  '403': 'This endpoint is restricted on your current plan. Call `getAccountPlan` for a quick plan/feature check, or `getAccountStatus` for full details. Some endpoints require Developer plan or higher. Call `getHeliusPlanInfo` to compare plans, or `previewUpgrade` to see upgrade pricing.',
   '429': 'Rate limited. Call `getAccountStatus` to check your remaining credits and rate limits. Back off and retry, or call `previewUpgrade` to see upgrade options for higher limits.',
   '502': 'Backend temporarily unavailable. Retry after a few seconds.',
   '504': 'Gateway timeout — the request took too long. Try reducing the query scope (fewer addresses, smaller limit, narrower time range).',

--- a/helius-mcp/system-prompts/helius/claude.system.md
+++ b/helius-mcp/system-prompts/helius/claude.system.md
@@ -87,7 +87,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -95,7 +95,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/helius-mcp/system-prompts/helius/full.md
+++ b/helius-mcp/system-prompts/helius/full.md
@@ -77,7 +77,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md (inlined below)
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -85,7 +85,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/helius-mcp/system-prompts/helius/openai.developer.md
+++ b/helius-mcp/system-prompts/helius/openai.developer.md
@@ -87,7 +87,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -95,7 +95,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/helius-mcp/tests/tools.test.ts
+++ b/helius-mcp/tests/tools.test.ts
@@ -35,7 +35,7 @@ describe('Helius MCP Tools', () => {
   });
 
   it('registers 63 tools', () => {
-    expect(tools.size).toBe(63);
+    expect(tools.size).toBe(64);
   });
 
   it('all tools have descriptions', () => {
@@ -55,7 +55,7 @@ describe('Helius MCP Tools', () => {
       // Onboarding
       'getStarted', 'setHeliusApiKey', 'generateKeypair', 'checkSignupBalance', 'agenticSignup', 'getAccountStatus',
       // Plans & billing
-      'getHeliusPlanInfo', 'compareHeliusPlans', 'previewUpgrade', 'upgradePlan', 'payRenewal',
+      'getHeliusPlanInfo', 'compareHeliusPlans', 'getAccountPlan', 'previewUpgrade', 'upgradePlan', 'payRenewal',
       // Balance
       'getBalance', 'getTokenBalances',
       // DAS

--- a/helius-plugin/skills/build/SKILL.md
+++ b/helius-plugin/skills/build/SKILL.md
@@ -82,7 +82,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -90,7 +90,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research

--- a/helius-skills/helius/SKILL.md
+++ b/helius-skills/helius/SKILL.md
@@ -82,7 +82,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
-**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools**: `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -90,7 +90,7 @@ Enhanced WebSockets (Business+) for most needs; Laserstream gRPC (Professional) 
 **When**: API details, pricing, rate limits, error troubleshooting, credit costs, pump.fun tokens. Prefer `lookupHeliusDocs` with `section` parameter for targeted lookups.
 
 ### Plans & Billing
-**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getHeliusCreditsInfo`, `getRateLimitInfo`
+**MCP tools**: `getHeliusPlanInfo`, `compareHeliusPlans`, `getAccountPlan`, `getHeliusCreditsInfo`, `getRateLimitInfo`
 **When**: pricing, plans, or rate limit questions.
 
 ### Solana Knowledge & Research


### PR DESCRIPTION
## Summary
- Adds `getAccountPlan` MCP tool — a 0-credit pre-flight check that returns plan tier, credit balance, and per-tool eligibility
- Moves `PLAN_RANK` to `product-catalog.ts` to avoid circular dependency between `recommend.ts` and `plans.ts`
- Updates routing table, 403 error guidance, SKILL.md files, and compiler-generated outputs

## Test plan
- [x] `pnpm build` — compiles cleanly (no circular dependency)
- [x] `pnpm test` — 122 tests pass, tool count updated to 64
- [x] `pnpm validate` — catalog validation passes with `getAccountPlan` in `KNOWN_TOOLS`
- [x] `npx tsx scripts/compile-skills.ts` — compiler runs cleanly
- [ ] Manual test: call `getAccountPlan` with no auth → tier 1 response
- [ ] Manual test: call `getAccountPlan` with API key only → tier 2 response
- [ ] Manual test: call `getAccountPlan` with JWT → tier 3 with eligibility table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1134" height="542" alt="Screenshot 2026-03-12 at 10 14 08 PM" src="https://github.com/user-attachments/assets/890e0310-05a7-4d86-90b5-f2f38653daf0" />
<img width="890" height="435" alt="Screenshot 2026-03-12 at 11 09 13 PM" src="https://github.com/user-attachments/assets/5030adb4-1352-47cb-83e4-ec7c622e2bbb" />
