### PR TITLE
feat(cli): Add NO_DNA Support

### DIFF
--- a/helius-cli/README.md
+++ b/helius-cli/README.md
@@ -223,6 +223,12 @@ Keypair commands (`signup`, `login`, `upgrade`, `pay`, `stake`) also accept:
 |---|---|
 | `-k, --keypair <path>` | Path to Solana keypair file (default: `~/.helius/keypair.json`) |
 
+## NO_DNA Support
+
+Helius CLI supports the [NO_DNA](https://no-dna.org) convention. When the `NO_DNA` environment variable is set, the CLI adapts its behavior for non-human callers:
+- **Spinners suppressed** — no terminal animations polluting agent output
+- **Interactive prompts blocked** — commands that require confirmation (`upgrade`, `pay`) exit with a clear error instead of hanging on stdin; pass `--yes` to skip confirmation
+
 ## Exit Codes
 
 | Code | Meaning | Retryable |

--- a/helius-cli/README.md
+++ b/helius-cli/README.md
@@ -227,7 +227,7 @@ Keypair commands (`signup`, `login`, `upgrade`, `pay`, `stake`) also accept:
 
 Helius CLI supports the [NO_DNA](https://no-dna.org) convention. When the `NO_DNA` environment variable is set, the CLI adapts its behavior for non-human callers:
 - **Spinners suppressed** — no terminal animations polluting agent output
-- **Interactive prompts blocked** — commands that require confirmation (`upgrade`, `pay`) exit with a clear error instead of hanging on stdin; pass `--yes` to skip confirmation
+- **Interactive prompts return preview** — commands that require confirmation (`upgrade`, `pay`) exit with a JSON preview instead of hanging on stdin; pass `--yes` to skip confirmation
 
 ## Exit Codes
 

--- a/helius-cli/src/commands/account.ts
+++ b/helius-cli/src/commands/account.ts
@@ -1,13 +1,12 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface AccountOptions extends OutputOptions, ResolveOptions {}
 
 export async function accountCommand(address: string, options: AccountOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/apikeys.ts
+++ b/helius-cli/src/commands/apikeys.ts
@@ -1,8 +1,7 @@
 import chalk from "chalk";
-import ora from "ora";
 import { getProject, listProjects, createApiKey } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 async function resolveProjectId(jwt: string, projectId?: string, json?: boolean): Promise<string> {
   if (projectId) {
@@ -41,7 +40,7 @@ interface ApikeysOptions extends OutputOptions {
 }
 
 export async function apikeysCommand(projectId?: string, options: ApikeysOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     const jwt = getJwt();
@@ -102,7 +101,7 @@ interface CreateApiKeyOptions extends OutputOptions {
 }
 
 export async function createApiKeyCommand(projectId?: string, options: CreateApiKeyOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     const jwt = getJwt();

--- a/helius-cli/src/commands/asset.ts
+++ b/helius-cli/src/commands/asset.ts
@@ -1,12 +1,11 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface AssetOptions extends OutputOptions, ResolveOptions {}
 
-async function setup(spinner: ReturnType<typeof ora> | null, options: AssetOptions, message: string) {
+async function setup(spinner: any, options: AssetOptions, message: string) {
   spinner?.start("Resolving API key...");
   const apiKey = await resolveApiKey(options);
   const network = resolveNetwork(options);
@@ -52,7 +51,7 @@ function printAssetList(items: any[], label: string): void {
 }
 
 export async function assetGetCommand(id: string, options: AssetOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching asset...");
     const result = await helius.getAsset({ id });
@@ -66,7 +65,7 @@ export async function assetGetCommand(id: string, options: AssetOptions = {}): P
 }
 
 export async function assetBatchCommand(ids: string[], options: AssetOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching ${ids.length} asset(s)...`);
     const result = await helius.getAssetBatch({ ids });
@@ -81,7 +80,7 @@ export async function assetBatchCommand(ids: string[], options: AssetOptions = {
 }
 
 export async function assetOwnerCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by owner...");
     const result = await helius.getAssetsByOwner({
@@ -99,7 +98,7 @@ export async function assetOwnerCommand(address: string, options: AssetOptions &
 }
 
 export async function assetCreatorCommand(address: string, options: AssetOptions & { page?: string; limit?: string; verified?: boolean } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by creator...");
     const result = await helius.getAssetsByCreator({
@@ -118,7 +117,7 @@ export async function assetCreatorCommand(address: string, options: AssetOptions
 }
 
 export async function assetAuthorityCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by authority...");
     const result = await helius.getAssetsByAuthority({
@@ -136,7 +135,7 @@ export async function assetAuthorityCommand(address: string, options: AssetOptio
 }
 
 export async function assetCollectionCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching collection assets...");
     const result = await helius.getAssetsByGroup({
@@ -159,7 +158,7 @@ export async function assetSearchCommand(options: AssetOptions & {
   compressed?: boolean; burnt?: boolean; frozen?: boolean;
   page?: string; limit?: string;
 } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Searching assets...");
     const params: any = {
@@ -183,7 +182,7 @@ export async function assetSearchCommand(options: AssetOptions & {
 }
 
 export async function assetProofCommand(id: string, options: AssetOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching asset proof...");
     const result = await helius.getAssetProof({ id });
@@ -204,7 +203,7 @@ export async function assetProofCommand(id: string, options: AssetOptions = {}):
 }
 
 export async function assetProofBatchCommand(ids: string[], options: AssetOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching proofs for ${ids.length} asset(s)...`);
     const result = await helius.getAssetProofBatch({ ids });
@@ -221,7 +220,7 @@ export async function assetProofBatchCommand(ids: string[], options: AssetOption
 }
 
 export async function assetEditionsCommand(mint: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching NFT editions...");
     const result = await helius.getNftEditions({
@@ -246,7 +245,7 @@ export async function assetEditionsCommand(mint: string, options: AssetOptions &
 }
 
 export async function assetSignaturesCommand(id: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching signatures for asset...");
     const result = await helius.getSignaturesForAsset({
@@ -272,7 +271,7 @@ export async function assetSignaturesCommand(id: string, options: AssetOptions &
 }
 
 export async function assetTokenAccountsCommand(options: AssetOptions & { owner?: string; mint?: string; page?: string; limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching token accounts...");
     const params: any = {

--- a/helius-cli/src/commands/balance.ts
+++ b/helius-cli/src/commands/balance.ts
@@ -1,13 +1,12 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatAddress, formatTokenAmount, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface BalanceOptions extends OutputOptions, ResolveOptions {}
 
 export async function balanceCommand(address: string, options: BalanceOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -34,7 +33,7 @@ export async function balanceCommand(address: string, options: BalanceOptions = 
 }
 
 export async function tokensCommand(address: string, options: BalanceOptions & { limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -88,7 +87,7 @@ export async function tokensCommand(address: string, options: BalanceOptions & {
 }
 
 export async function tokenHoldersCommand(mint: string, options: BalanceOptions & { limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/block.ts
+++ b/helius-cli/src/commands/block.ts
@@ -1,13 +1,12 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatTimestamp } from "../lib/formatters.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface BlockOptions extends OutputOptions, ResolveOptions {}
 
 export async function blockCommand(slot: string, options: BlockOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -1,17 +1,16 @@
 import chalk from "chalk";
-import ora from "ora";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
 import { signup } from "../lib/api.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
-import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface LoginOptions extends OutputOptions {
   keypair: string;
 }
 
 export async function loginCommand(options: LoginOptions): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     // Check keypair exists

--- a/helius-cli/src/commands/network-status.ts
+++ b/helius-cli/src/commands/network-status.ts
@@ -1,12 +1,11 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface NetworkOptions extends OutputOptions, ResolveOptions {}
 
 export async function networkStatusCommand(options: NetworkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -1,12 +1,11 @@
 import chalk from "chalk";
-import ora from "ora";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
 import { signup } from "../lib/api.js";
 import { getPaymentIntent, executeRenewal } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
 
 interface PayOptions extends OutputOptions {
@@ -25,7 +24,7 @@ function confirm(question: string): Promise<boolean> {
 }
 
 export async function payCommand(paymentIntentId: string, options: PayOptions): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     // Check keypair exists
@@ -67,6 +66,9 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
     }
 
     if (!options.yes) {
+      if (isAgent) {
+        exitWithError("INVALID_INPUT", "Interactive confirmation required. Pass --yes to skip.", undefined, options.json);
+      }
       const ok = await confirm(`  Pay $${amountUsdc.toFixed(2)} USDC? (y/N) `);
       if (!ok) {
         console.log(chalk.gray("  Cancelled."));

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -67,7 +67,15 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
 
     if (!options.yes) {
       if (isAgent) {
-        exitWithError("INVALID_INPUT", "Interactive confirmation required. Pass --yes to skip.", undefined, options.json);
+        outputJson({
+          action: "preview",
+          paymentIntentId: intent.id,
+          amount: intent.amount,
+          amountUsdc,
+          status: intent.status,
+          expiresAt: intent.expiresAt,
+        });
+        return;
       }
       const ok = await confirm(`  Pay $${amountUsdc.toFixed(2)} USDC? (y/N) `);
       if (!ok) {

--- a/helius-cli/src/commands/program.ts
+++ b/helius-cli/src/commands/program.ts
@@ -1,13 +1,12 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface ProgramOptions extends OutputOptions, ResolveOptions {}
 
 export async function programAccountsCommand(programId: string, options: ProgramOptions & { dataSize?: string; limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -48,7 +47,7 @@ export async function programAccountsCommand(programId: string, options: Program
 }
 
 export async function programAccountsAllCommand(programId: string, options: ProgramOptions & { dataSize?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -72,7 +71,7 @@ export async function programAccountsAllCommand(programId: string, options: Prog
 }
 
 export async function programTokenAccountsCommand(owner: string, options: ProgramOptions & { limit?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/project.ts
+++ b/helius-cli/src/commands/project.ts
@@ -1,12 +1,11 @@
 import chalk from "chalk";
-import ora from "ora";
 import { getProject, listProjects } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 export async function projectCommand(projectId?: string, options: OutputOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     const jwt = getJwt();

--- a/helius-cli/src/commands/projects.ts
+++ b/helius-cli/src/commands/projects.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
-import ora from "ora";
 import { listProjects } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
-import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 export async function projectsCommand(options: OutputOptions): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     const jwt = getJwt();

--- a/helius-cli/src/commands/rpc.ts
+++ b/helius-cli/src/commands/rpc.ts
@@ -1,12 +1,11 @@
 import chalk from "chalk";
-import ora from "ora";
 import { listProjects, getProject } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 export async function rpcCommand(projectId?: string, options: OutputOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     const jwt = getJwt();

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -1,12 +1,11 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface SendOptions extends OutputOptions, ResolveOptions {}
 
 export async function sendBroadcastCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -26,7 +25,7 @@ export async function sendBroadcastCommand(base64Tx: string, options: SendOption
 }
 
 export async function sendRawCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -46,7 +45,7 @@ export async function sendRawCommand(base64Tx: string, options: SendOptions = {}
 }
 
 export async function sendSenderCommand(base64Tx: string, options: SendOptions & { region?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -70,7 +69,7 @@ export async function sendSenderCommand(base64Tx: string, options: SendOptions &
 }
 
 export async function sendPollCommand(signature: string, options: SendOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -90,7 +89,7 @@ export async function sendPollCommand(signature: string, options: SendOptions = 
 }
 
 export async function sendComputeUnitsCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
-import ora from "ora";
 import { loadKeypairFromFile, getAddress } from "../lib/wallet.js";
 import { agenticSignup, listProjects } from "../lib/api.js";
 import { setJwt, setApiKey, setSharedApiKey, setProjectId, getSharedApiKey, SHARED_CONFIG_PATH } from "../lib/config.js";
 import { keypairExists, keygenCommand } from "./keygen.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
 import { PLAN_CATALOG } from "../lib/checkout.js";
 import { sendDiscoveryEvent } from "../lib/feedback.js";
@@ -82,7 +81,7 @@ async function waitForFunding(
 }
 
 export async function signupCommand(options: SignupOptions): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     // Validate plan and period upfront

--- a/helius-cli/src/commands/simd.ts
+++ b/helius-cli/src/commands/simd.ts
@@ -1,7 +1,6 @@
 import chalk from "chalk";
-import ora from "ora";
 import { CLI_USER_AGENT } from "../http.js";
-import { outputJson, handleCommandError, exitWithError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, exitWithError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 // ---------------------------------------------------------------------------
 // GitHub constants
@@ -78,7 +77,7 @@ function extractFrontMatter(markdown: string): { title: string; status: string; 
 interface SimdListOptions extends OutputOptions {}
 
 export async function simdListCommand(options: SimdListOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Fetching SIMD index from GitHub...");
     const index = await fetchSimdIndex();
@@ -105,7 +104,7 @@ export async function simdListCommand(options: SimdListOptions = {}): Promise<vo
 interface SimdGetOptions extends OutputOptions {}
 
 export async function simdGetCommand(number: string, options: SimdGetOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     if (!/^\d+$/.test(number)) {
       exitWithError("INVALID_INPUT", `Invalid SIMD number: "${number}". Must be numeric.`, undefined, options.json);

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -1,13 +1,12 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface StakeOptions extends OutputOptions, ResolveOptions {}
 
 export async function stakeAccountsCommand(wallet: string, options: StakeOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -35,7 +34,7 @@ export async function stakeAccountsCommand(wallet: string, options: StakeOptions
 }
 
 export async function stakeWithdrawableCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -56,7 +55,7 @@ export async function stakeWithdrawableCommand(stakeAccount: string, options: St
 }
 
 export async function stakeInstructionsCommand(amount: string, options: StakeOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -78,7 +77,7 @@ export async function stakeInstructionsCommand(amount: string, options: StakeOpt
 }
 
 export async function stakeUnstakeInstructionCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -99,7 +98,7 @@ export async function stakeUnstakeInstructionCommand(stakeAccount: string, optio
 }
 
 export async function stakeWithdrawInstructionCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -120,7 +119,7 @@ export async function stakeWithdrawInstructionCommand(stakeAccount: string, opti
 }
 
 export async function stakeCreateCommand(amount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   if (!options.keypair) {
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
   }
@@ -146,7 +145,7 @@ export async function stakeCreateCommand(amount: string, options: StakeOptions &
 }
 
 export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   if (!options.keypair) {
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
   }
@@ -170,7 +169,7 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
 }
 
 export async function stakeWithdrawCommand(stakeAccount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   if (!options.keypair) {
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
   }

--- a/helius-cli/src/commands/status.ts
+++ b/helius-cli/src/commands/status.ts
@@ -1,12 +1,11 @@
 import chalk from "chalk";
-import ora from "ora";
 import { listProjects, getProject } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 export async function statusCommand(options: OutputOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     const jwt = getJwt();

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -1,13 +1,12 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatTimestamp, formatAddress, formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface TxOptions extends OutputOptions, ResolveOptions {}
 
 export async function txParseCommand(signatures: string[], options: TxOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -59,7 +58,7 @@ export async function txParseCommand(signatures: string[], options: TxOptions = 
 }
 
 export async function txHistoryCommand(address: string, options: TxOptions & { limit?: string; before?: string; type?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -103,7 +102,7 @@ export async function txHistoryCommand(address: string, options: TxOptions & { l
 }
 
 export async function txFeesCommand(options: TxOptions & { accounts?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
-import ora from "ora";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
 import { signup, listProjects, getProject } from "../lib/api.js";
 import { getCheckoutPreview, executeCheckout, PLAN_CATALOG } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
-import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
 import { validateUpgradePlan, validatePeriod, validateEmail } from "../lib/validation.js";
 
@@ -31,7 +30,7 @@ function confirm(question: string): Promise<boolean> {
 }
 
 export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     // Validate plan, period, and email upfront
@@ -132,6 +131,9 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     }
 
     if (!options.yes) {
+      if (isAgent) {
+        exitWithError("INVALID_INPUT", "Interactive confirmation required. Pass --yes to skip.", undefined, options.json);
+      }
       const ok = await confirm("  Proceed with upgrade? (y/N) ");
       if (!ok) {
         console.log(chalk.gray("  Cancelled."));

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -4,7 +4,7 @@ import { signup, listProjects, getProject } from "../lib/api.js";
 import { getCheckoutPreview, executeCheckout, PLAN_CATALOG } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
-import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
 import { validateUpgradePlan, validatePeriod, validateEmail } from "../lib/validation.js";
 
@@ -131,9 +131,6 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     }
 
     if (!options.yes) {
-      if (isAgent) {
-        exitWithError("INVALID_INPUT", "Interactive confirmation required. Pass --yes to skip.", undefined, options.json);
-      }
       const ok = await confirm("  Proceed with upgrade? (y/N) ");
       if (!ok) {
         console.log(chalk.gray("  Cancelled."));

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -4,7 +4,7 @@ import { signup, listProjects, getProject } from "../lib/api.js";
 import { getCheckoutPreview, executeCheckout, PLAN_CATALOG } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
-import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, type OutputOptions } from "../lib/output.js";
 import readline from "readline";
 import { validateUpgradePlan, validatePeriod, validateEmail } from "../lib/validation.js";
 

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -131,6 +131,21 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     }
 
     if (!options.yes) {
+      if (isAgent) {
+        outputJson({
+          action: "preview",
+          currentPlan,
+          upgradeTo: preview.planName,
+          period: preview.period,
+          subtotal: preview.subtotal,
+          proratedCredits: preview.proratedCredits,
+          appliedCredits: preview.appliedCredits,
+          discounts: preview.discounts,
+          coupon: preview.coupon,
+          dueToday: preview.dueToday,
+        });
+        return;
+      }
       const ok = await confirm("  Proceed with upgrade? (y/N) ");
       if (!ok) {
         console.log(chalk.gray("  Cancelled."));

--- a/helius-cli/src/commands/usage.ts
+++ b/helius-cli/src/commands/usage.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
-import ora from "ora";
 import { getProject, listProjects } from "../lib/api.js";
 import { getJwt } from "../lib/config.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, ExitCode, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 export async function usageCommand(projectId?: string, options: OutputOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
 
   try {
     const jwt = getJwt();

--- a/helius-cli/src/commands/wallet.ts
+++ b/helius-cli/src/commands/wallet.ts
@@ -1,13 +1,12 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, restRequest, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, formatEnumLabel, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface WalletOptions extends OutputOptions, ResolveOptions {}
 
 export async function walletIdentityCommand(address: string, options: WalletOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -30,7 +29,7 @@ export async function walletIdentityCommand(address: string, options: WalletOpti
 }
 
 export async function walletIdentityBatchCommand(addresses: string[], options: WalletOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -58,7 +57,7 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
 }
 
 export async function walletBalancesCommand(address: string, options: WalletOptions & { showNfts?: boolean } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -101,7 +100,7 @@ export async function walletBalancesCommand(address: string, options: WalletOpti
 }
 
 export async function walletHistoryCommand(address: string, options: WalletOptions & { limit?: string; type?: string; before?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -136,7 +135,7 @@ export async function walletHistoryCommand(address: string, options: WalletOptio
 }
 
 export async function walletTransfersCommand(address: string, options: WalletOptions & { limit?: string; cursor?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -169,7 +168,7 @@ export async function walletTransfersCommand(address: string, options: WalletOpt
 }
 
 export async function walletFundedByCommand(address: string, options: WalletOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -1,14 +1,13 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 import { validateSolanaAddresses } from "../lib/validation.js";
 
 interface WebhookOptions extends OutputOptions, ResolveOptions {}
 
 export async function webhookListCommand(options: WebhookOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -41,7 +40,7 @@ export async function webhookListCommand(options: WebhookOptions = {}): Promise<
 }
 
 export async function webhookGetCommand(webhookId: string, options: WebhookOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -72,7 +71,7 @@ export async function webhookGetCommand(webhookId: string, options: WebhookOptio
 export async function webhookCreateCommand(options: WebhookOptions & {
   url: string; accounts: string; types: string; webhookType?: string;
 }): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -109,7 +108,7 @@ export async function webhookCreateCommand(options: WebhookOptions & {
 export async function webhookUpdateCommand(webhookId: string, options: WebhookOptions & {
   url?: string; accounts?: string; types?: string;
 }): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -138,7 +137,7 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
 }
 
 export async function webhookDeleteCommand(webhookId: string, options: WebhookOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);

--- a/helius-cli/src/commands/zk.ts
+++ b/helius-cli/src/commands/zk.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
-import ora from "ora";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, handleCommandError, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface ZkOptions extends OutputOptions, ResolveOptions {}
 
-async function setup(spinner: ReturnType<typeof ora> | null, options: ZkOptions, message: string) {
+async function setup(spinner: any, options: ZkOptions, message: string) {
   spinner?.start("Resolving API key...");
   const apiKey = await resolveApiKey(options);
   const network = resolveNetwork(options);
@@ -22,7 +21,7 @@ function handleResult(spinner: any, result: any, options: ZkOptions, label: stri
 }
 
 export async function zkAccountCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed account...");
     const result = await helius.zk.getCompressedAccount({ address: addressOrHash });
@@ -33,7 +32,7 @@ export async function zkAccountCommand(addressOrHash: string, options: ZkOptions
 }
 
 export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed accounts by owner...");
     const result = await helius.zk.getCompressedAccountsByOwner({ owner });
@@ -44,7 +43,7 @@ export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions
 }
 
 export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed balance...");
     const result = await helius.zk.getCompressedBalance({ address: addressOrHash });
@@ -55,7 +54,7 @@ export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions
 }
 
 export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed balance by owner...");
     const result = await helius.zk.getCompressedBalanceByOwner({ owner });
@@ -66,7 +65,7 @@ export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions 
 }
 
 export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token holders...");
     const result = await helius.zk.getCompressedMintTokenHolders({ mint });
@@ -77,7 +76,7 @@ export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {
 }
 
 export async function zkTokenBalanceCommand(account: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token account balance...");
     const result = await helius.zk.getCompressedTokenAccountBalance({ address: account });
@@ -88,7 +87,7 @@ export async function zkTokenBalanceCommand(account: string, options: ZkOptions 
 }
 
 export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token accounts by owner...");
     const result = await helius.zk.getCompressedTokenAccountsByOwner({ owner });
@@ -99,7 +98,7 @@ export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOp
 }
 
 export async function zkTokenAccountsByDelegateCommand(delegate: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token accounts by delegate...");
     const result = await helius.zk.getCompressedTokenAccountsByDelegate({ delegate });
@@ -110,7 +109,7 @@ export async function zkTokenAccountsByDelegateCommand(delegate: string, options
 }
 
 export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token balances by owner (V2)...");
     const result = await helius.zk.getCompressedTokenBalancesByOwnerV2({ owner });
@@ -121,7 +120,7 @@ export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOp
 }
 
 export async function zkProofCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed account proof...");
     const result = await helius.zk.getCompressedAccountProof({ hash: addressOrHash });
@@ -132,7 +131,7 @@ export async function zkProofCommand(addressOrHash: string, options: ZkOptions =
 }
 
 export async function zkProofsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching proofs for ${addresses.length} account(s)...`);
     const result = await helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses });
@@ -143,7 +142,7 @@ export async function zkProofsCommand(addresses: string[], options: ZkOptions = 
 }
 
 export async function zkMultipleAccountsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching ${addresses.length} compressed account(s)...`);
     const result = await helius.zk.getMultipleCompressedAccounts({ addresses });
@@ -154,7 +153,7 @@ export async function zkMultipleAccountsCommand(addresses: string[], options: Zk
 }
 
 export async function zkAddressProofsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching address proofs (V2)...`);
     const result = await helius.zk.getMultipleNewAddressProofsV2(addresses);
@@ -165,7 +164,7 @@ export async function zkAddressProofsCommand(addresses: string[], options: ZkOpt
 }
 
 export async function zkSignaturesAccountCommand(account: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for account...");
     const result = await helius.zk.getCompressionSignaturesForAccount({ hash: account });
@@ -176,7 +175,7 @@ export async function zkSignaturesAccountCommand(account: string, options: ZkOpt
 }
 
 export async function zkSignaturesAddressCommand(address: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for address...");
     const result = await helius.zk.getCompressionSignaturesForAddress({ address });
@@ -187,7 +186,7 @@ export async function zkSignaturesAddressCommand(address: string, options: ZkOpt
 }
 
 export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for owner...");
     const result = await helius.zk.getCompressionSignaturesForOwner({ owner });
@@ -198,7 +197,7 @@ export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions
 }
 
 export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for token owner...");
     const result = await helius.zk.getCompressionSignaturesForTokenOwner({ owner });
@@ -209,7 +208,7 @@ export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOp
 }
 
 export async function zkLatestSignaturesCommand(options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching latest compression signatures...");
     const result = await helius.zk.getLatestCompressionSignatures({});
@@ -220,7 +219,7 @@ export async function zkLatestSignaturesCommand(options: ZkOptions = {}): Promis
 }
 
 export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching latest non-voting signatures...");
     const result = await helius.zk.getLatestNonVotingSignatures({});
@@ -231,7 +230,7 @@ export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise
 }
 
 export async function zkTxCommand(signature: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching transaction with compression info...");
     const result = await helius.zk.getTransactionWithCompressionInfo({ signature });
@@ -242,7 +241,7 @@ export async function zkTxCommand(signature: string, options: ZkOptions = {}): P
 }
 
 export async function zkValidityProofCommand(options: ZkOptions & { hashes?: string; addresses?: string } = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching validity proof...");
     const params: any = {};
@@ -256,7 +255,7 @@ export async function zkValidityProofCommand(options: ZkOptions & { hashes?: str
 }
 
 export async function zkIndexerHealthCommand(options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Checking indexer health...");
     const result = await helius.zk.getIndexerHealth();
@@ -267,7 +266,7 @@ export async function zkIndexerHealthCommand(options: ZkOptions = {}): Promise<v
 }
 
 export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching indexer slot...");
     const result = await helius.zk.getIndexerSlot();
@@ -278,7 +277,7 @@ export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<voi
 }
 
 export async function zkSignaturesForAssetCommand(id: string, options: ZkOptions = {}): Promise<void> {
-  const spinner = options.json ? null : ora();
+  const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching signatures for asset...");
     const result = await helius.zk.getSignaturesForAsset({ id, page: 1 });

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -1,9 +1,18 @@
 // Output utilities for JSON mode
 import chalk from "chalk";
+import ora from "ora";
 import { sendCommandEvent, getCurrentCommand } from "./feedback.js";
 
 export interface OutputOptions {
   json?: boolean;
+}
+
+/** True when the caller is a non-human agent (NO_DNA convention). */
+export const isAgent = !!process.env.NO_DNA;
+
+/** Create a spinner, suppressed when --json is set or NO_DNA is detected. */
+export function createSpinner(options: OutputOptions = {}): ReturnType<typeof ora> | null {
+  return options.json || isAgent ? null : ora();
 }
 
 // Exit codes for machine-readable error handling


### PR DESCRIPTION
This PR adds support for the [NO_DNA](https://no-dna.org/) convention to the CLI. When the `NO_DNA` env var is set, spinners are suppressed, and interactive confirmations (e.g., `upgrade`, `pay`) return a structured JSON preview instead of hanging on stdin. Agents can then re-run with `--yes` to confirm. This centralizes spinner creation via `createSpinner()` in `output.ts`