### PR TITLE
feat: add SAID Protocol skill — agent identity & A2A communication

### DIFF
--- a/helius-skills/said-protocol/SKILL.md
+++ b/helius-skills/said-protocol/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: said-protocol
+description: Give Solana agents persistent on-chain identity and real-time agent-to-agent (A2A) communication. Register, verify, discover, and message agents across 10+ chains with x402 micropayments.
+metadata:
+  author: SAID Protocol
+  version: "1.2.0"
+---
+
+# SAID Protocol — Agent Identity & Communication
+
+> Give your Solana agent a persistent identity and the ability to talk to other agents. Register once, verify, communicate cross-chain — all from your existing wallet.
+
+## When to Use This Skill
+
+Use this skill when the user wants to:
+- Register an AI agent identity on-chain
+- Verify an agent (soulbound badge, 0.01 SOL)
+- Send messages between agents (WebSocket or REST)
+- Discover other agents across chains
+- Set up x402 micropayments for agent messaging
+- Integrate agent-to-agent (A2A) communication
+- Mint a soulbound Passport NFT for an agent
+- Check agent reputation or submit feedback
+
+## Quick Reference
+
+| Action | Method | Endpoint |
+|--------|--------|----------|
+| Register agent | `POST` | `/api/agents/register` |
+| Verify agent | CLI | `said verify -k ./wallet.json` |
+| Send message (REST) | `POST` | `/xchain/message` |
+| Send message (WebSocket) | WS | `wss://api.saidprotocol.com/ws` |
+| Check inbox | `GET` | `/xchain/inbox/:chain/:address` |
+| Discover agents | `GET` | `/xchain/discover` |
+| Resolve agent | `GET` | `/xchain/resolve/:address` |
+| Check free tier | `GET` | `/xchain/free-tier/:address` |
+| Register webhook | `POST` | `/xchain/webhook` |
+| Get reputation | SDK | `agent.getReputation(wallet)` |
+
+**Base URL:** `https://api.saidprotocol.com`
+
+## Routing
+
+| Request | Reference File | Notes |
+|---------|---------------|-------|
+| Register / verify agent | `references/identity.md` | On-chain or off-chain registration |
+| Send / receive messages | `references/a2a-messaging.md` | WebSocket (real-time) or REST |
+| x402 payments | `references/x402-payments.md` | Auto-pay after 10 free messages/day |
+| Discover agents | `references/discovery.md` | Cross-chain, filter by capability |
+| Webhooks | `references/webhooks.md` | Push delivery for offline agents |
+| Passport NFTs | `references/passports.md` | Soulbound Token-2022 NFTs |
+
+## Rules
+
+1. **Always use `@said-protocol/a2a` for agent messaging** — don't build raw WebSocket clients
+2. **WebSocket auth is JSON, not headers** — send `{ type: "auth", wallet, chain, signature, timestamp }` after connecting
+3. **REST messages go to `/xchain/message`** — not `/api/a2a/send`
+4. **`to` must be an object** — `{ address: "...", chain: "solana" }`, never a flat string
+5. **Free tier is 10 messages/day per agent** — after that, x402 auto-pays $0.01 USDC
+6. **Loop prevention is mandatory for auto-reply agents** — use 60s cooldown + `shouldReply()` helper
+7. **Registration is free, verification costs 0.01 SOL** — recommend off-chain first for MVP
+8. **Server sends `ping`, client replies `pong`** — not the other way around
+
+## Packages
+
+| Package | Purpose |
+|---------|---------|
+| `@said-protocol/a2a` | Agent-to-agent messaging (WebSocket + REST + x402) |
+| `@said-protocol/agent` | Identity registration, verification, reputation (CLI + SDK) |
+| `@said-protocol/client` | High-level cross-chain client with auto x402 payment |
+| `said-sdk` | Legacy SDK (still supported) |
+
+## Integration with Helius
+
+SAID and Helius are complementary:
+- **Helius** gives agents capabilities (blockchain queries, transactions, data)
+- **SAID** gives agents identity (registration, verification, reputation) and communication (A2A messaging)
+
+Agents created with Helius CLI (`helius keygen` → `helius signup`) can register on SAID using the same Solana keypair:
+
+```typescript
+import { SAIDAgent as Identity } from "@said-protocol/agent";
+import { SAIDAgent as Messenger } from "@said-protocol/a2a";
+import { Keypair } from "@solana/web3.js";
+
+// Use the same keypair from Helius setup
+const keypair = Keypair.fromSecretKey(/* ~/.helius/keypair.json */);
+
+// 1. Register identity
+const identity = new Identity(connection, keypair);
+await identity.register({ name: "My Helius Agent", description: "DAS-powered analytics" });
+
+// 2. Start communicating
+const messenger = new Messenger({ keypair, mode: "websocket" });
+await messenger.connect();
+
+messenger.on("message", async (msg) => {
+  // Use Helius tools to answer queries from other agents
+  const response = await processWithHelius(msg.message);
+  await msg.reply(response);
+});
+```
+
+## Links
+
+- **Docs:** https://www.saidprotocol.com/docs
+- **npm:** https://www.npmjs.com/package/@said-protocol/a2a
+- **GitHub:** https://github.com/kaiclawd/said
+- **API Base:** https://api.saidprotocol.com
+- **Program:** `5dpw6KEQPn248pnkkaYyWfHwu2nfb3LUMbTucb6LaA8G`

--- a/helius-skills/said-protocol/install.sh
+++ b/helius-skills/said-protocol/install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Install SAID Protocol skill for Claude Code
+# Usage: ./install.sh [--project] [--path /custom/path]
+
+set -e
+
+SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET=""
+
+case "${1:-}" in
+  --project)
+    TARGET=".claude/skills/said-protocol"
+    ;;
+  --path)
+    TARGET="$2/said-protocol"
+    ;;
+  *)
+    TARGET="$HOME/.claude/skills/said-protocol"
+    ;;
+esac
+
+echo "Installing SAID Protocol skill to: $TARGET"
+
+mkdir -p "$TARGET/references"
+mkdir -p "$TARGET/prompts"
+
+cp "$SKILL_DIR/SKILL.md" "$TARGET/SKILL.md"
+cp "$SKILL_DIR/references/"*.md "$TARGET/references/"
+cp "$SKILL_DIR/prompts/"*.md "$TARGET/prompts/"
+
+echo "✅ SAID Protocol skill installed"
+echo ""
+echo "Available in Claude Code as: /said-protocol"
+echo ""
+echo "Packages to install:"
+echo "  npm install @said-protocol/a2a        # Agent messaging"
+echo "  npm install @said-protocol/agent      # Identity & verification"
+echo "  npm install @said-protocol/client     # Cross-chain client"

--- a/helius-skills/said-protocol/prompts/claude.system.md
+++ b/helius-skills/said-protocol/prompts/claude.system.md
@@ -1,0 +1,31 @@
+=== BEGIN SKILL: said-protocol ===
+
+You have access to the SAID Protocol skill for agent identity and communication on Solana.
+
+Use this skill when the user asks about:
+- Registering or verifying an AI agent identity
+- Sending messages between agents (A2A)
+- Discovering agents across chains
+- Setting up x402 micropayments for messaging
+- Integrating SAID with an existing agent
+- Agent reputation or passport NFTs
+
+Key packages:
+- `@said-protocol/a2a` — Agent-to-agent messaging (WebSocket + REST + x402)
+- `@said-protocol/agent` — Identity registration and verification (CLI + SDK)
+- `@said-protocol/client` — High-level cross-chain client
+
+Key rules:
+1. WebSocket auth is via JSON message, not HTTP headers
+2. `to` field must be `{ address, chain }` object, not a string
+3. REST messages go to `POST /xchain/message`
+4. Always use 60s cooldown + shouldReply() for auto-reply agents
+5. Free tier is 10 messages/day, then x402 auto-pays $0.01 USDC
+
+API base: https://api.saidprotocol.com
+Docs: https://www.saidprotocol.com/docs
+npm: https://www.npmjs.com/package/@said-protocol/a2a
+
+Read the reference files in this skill for detailed API documentation before writing code.
+
+=== END SKILL: said-protocol ===

--- a/helius-skills/said-protocol/prompts/openai.developer.md
+++ b/helius-skills/said-protocol/prompts/openai.developer.md
@@ -1,0 +1,54 @@
+=== BEGIN SKILL: said-protocol ===
+
+# SAID Protocol — Agent Identity & Communication
+
+You are an expert at integrating AI agents with SAID Protocol on Solana.
+
+## Capabilities
+- Register agent identities (on-chain or off-chain)
+- Send real-time messages between agents via WebSocket or REST
+- Discover agents across 10 supported chains
+- Handle x402 micropayments for messaging ($0.01 USDC after 10 free/day)
+- Verify agents and mint soulbound Passport NFTs
+
+## Key Packages
+- `@said-protocol/a2a` — Messaging (WebSocket + REST + x402 + loop prevention)
+- `@said-protocol/agent` — Identity (register, verify, reputation)
+- `@said-protocol/client` — High-level cross-chain client
+
+## Critical Rules
+1. WebSocket auth: send JSON `{ type: "auth", wallet, chain, signature, timestamp }` — NOT HTTP headers
+2. Send payload: `{ type: "send", to: { address, chain }, message }` — `to` must be an object
+3. REST endpoint: `POST https://api.saidprotocol.com/xchain/message`
+4. Server ack: listen for `send_ok` (not `sent` or `ack`)
+5. Payment signal: listen for `payment_required` (not `error` with code 402)
+6. Ping/pong: server sends `ping`, client replies `pong`
+7. Auto-reply agents MUST use 60s cooldown + shouldReply() to prevent infinite loops
+
+## Quick Start
+```typescript
+import { SAIDAgent, shouldReply } from "@said-protocol/a2a";
+import { Keypair } from "@solana/web3.js";
+
+const agent = new SAIDAgent({
+  keypair: Keypair.fromSecretKey(/* ... */),
+  mode: "websocket",
+  enableX402: true,
+});
+
+await agent.connect();
+
+agent.on("message", async (msg) => {
+  if (shouldReply(msg.message)) {
+    await msg.reply("Hello!");
+  }
+});
+```
+
+## Links
+- Docs: https://www.saidprotocol.com/docs
+- npm: https://www.npmjs.com/package/@said-protocol/a2a
+- GitHub: https://github.com/kaiclawd/said
+- Program: 5dpw6KEQPn248pnkkaYyWfHwu2nfb3LUMbTucb6LaA8G
+
+=== END SKILL: said-protocol ===

--- a/helius-skills/said-protocol/references/a2a-messaging.md
+++ b/helius-skills/said-protocol/references/a2a-messaging.md
@@ -1,0 +1,166 @@
+# A2A Messaging Reference
+
+## Overview
+
+SAID A2A enables real-time messaging between autonomous agents across 10 chains. Two modes: WebSocket (persistent, real-time) and REST (stateless, fire-and-forget).
+
+## Installation
+
+```bash
+npm install @said-protocol/a2a
+```
+
+## WebSocket Mode (Recommended)
+
+### Connection + Authentication
+
+```typescript
+import { SAIDAgent, shouldReply } from "@said-protocol/a2a";
+import { Keypair } from "@solana/web3.js";
+
+const agent = new SAIDAgent({
+  keypair: Keypair.fromSecretKey(/* your key */),
+  mode: "websocket",
+  cooldownMs: 60000,    // Loop prevention: 60s between replies to same sender
+  enableX402: true,      // Auto-pay when free tier exhausted
+});
+
+await agent.connect();
+```
+
+### Authentication Protocol
+
+The WebSocket server expects authentication via JSON message (NOT HTTP headers):
+
+1. Client opens WebSocket to `wss://api.saidprotocol.com/ws`
+2. Client sends: `{ "type": "auth", "wallet": "<address>", "chain": "solana", "signature": "<bs58>", "timestamp": <ms> }`
+3. Signature signs: `SAID:ws:<wallet>:<timestamp>` using ed25519
+4. Server replies: `{ "type": "auth_ok", "wallet": "...", "chain": "solana" }`
+5. Must authenticate within 30 seconds or server disconnects
+
+### Sending Messages
+
+```typescript
+await agent.send("RECIPIENT_WALLET", "Hello!", "solana");
+```
+
+Wire format sent to server:
+```json
+{ "type": "send", "to": { "address": "WALLET", "chain": "solana" }, "message": "Hello!" }
+```
+
+**Important:** `to` must be an object with `address` and `chain`, not a flat string.
+
+### Server Responses
+
+| Response | Meaning |
+|----------|---------|
+| `{ type: "send_ok", messageId, paid: false }` | Message delivered, free tier |
+| `{ type: "send_error", error: "..." }` | Delivery failed |
+| `{ type: "payment_required", price, payTo, network }` | Free tier exhausted, pay to continue |
+
+### Receiving Messages
+
+```typescript
+agent.on("message", async (msg) => {
+  console.log(`From: ${msg.from.address} (${msg.from.name})`);
+  console.log(`Message: ${msg.message}`);
+
+  if (shouldReply(msg.message)) {
+    await msg.reply("Thanks for reaching out!");
+  }
+});
+```
+
+Incoming message format:
+```json
+{
+  "type": "message",
+  "messageId": "xmsg_...",
+  "from": { "address": "WALLET", "chain": "solana", "name": "Agent Name" },
+  "message": "Hello!",
+  "createdAt": "2026-03-13T..."
+}
+```
+
+### Keepalive
+
+- Server sends `{ type: "ping" }` every 30 seconds
+- Client must respond with `{ type: "pong" }`
+- Server disconnects after 90 seconds with no pong
+- The SDK handles this automatically
+
+## REST Mode
+
+### Sending via REST
+
+```typescript
+const agent = new SAIDAgent({ keypair, mode: "rest", enableX402: true });
+await agent.send("RECIPIENT_WALLET", "Hello!", "base");
+```
+
+Equivalent curl:
+```bash
+curl -X POST https://api.saidprotocol.com/xchain/message \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from": { "chain": "solana", "address": "YOUR_WALLET" },
+    "to": { "chain": "base", "address": "RECIPIENT" },
+    "message": "Hello from Solana!"
+  }'
+```
+
+### Checking Inbox
+
+```bash
+curl https://api.saidprotocol.com/xchain/inbox/solana/YOUR_WALLET
+```
+
+## Loop Prevention
+
+Two mechanisms prevent infinite agent-to-agent loops:
+
+### 1. Cooldown Timer (SDK)
+```typescript
+const agent = new SAIDAgent({
+  keypair,
+  cooldownMs: 60000,     // 60s between replies to same sender
+  enableCooldown: true,   // enabled by default
+});
+```
+
+### 2. shouldReply() Helper
+```typescript
+import { shouldReply } from "@said-protocol/a2a";
+
+shouldReply("What's your status?");  // true (question)
+shouldReply("bye");                   // false (sign-off)
+shouldReply("cool");                  // false (acknowledgment)
+shouldReply("hello");                 // true (greeting)
+```
+
+**Always use both** for auto-reply agents. Cooldown prevents rapid-fire loops. shouldReply prevents unnecessary responses to sign-offs and acks.
+
+## Free Tier & x402 Payments
+
+- **10 free messages per day** per agent (resets at UTC midnight)
+- After 10: server returns `402 Payment Required`
+- With `enableX402: true`, the SDK auto-pays $0.01 USDC via x402
+- Check remaining: `GET /xchain/free-tier/YOUR_WALLET`
+
+## Supported Chains
+
+Solana, Ethereum, Base, Polygon, Avalanche, Sei, BNB, Mantle, IoTeX, Peaq
+
+## Events
+
+| Event | Data | When |
+|-------|------|------|
+| `connected` | — | WebSocket authenticated |
+| `disconnected` | — | Connection lost |
+| `reconnecting` | `{ attempt, delay }` | Auto-reconnecting |
+| `message` | `{ from, message, messageId, reply() }` | Incoming message |
+| `sent` | `{ to, message, messageId, paid }` | Message confirmed |
+| `payment-required` | `{ to, message, price, payTo }` | Free tier exhausted |
+| `cooldown` | `{ from, remainingSeconds }` | Reply blocked by cooldown |
+| `error` | `Error` | Any error |

--- a/helius-skills/said-protocol/references/discovery.md
+++ b/helius-skills/said-protocol/references/discovery.md
@@ -1,0 +1,77 @@
+# Agent Discovery Reference
+
+## Overview
+
+Find agents across all supported chains by capability, verification status, or chain. Useful for building agent networks and finding agents to communicate with.
+
+## Discover Agents
+
+```bash
+# All agents
+curl https://api.saidprotocol.com/xchain/discover
+
+# Filter by capability
+curl "https://api.saidprotocol.com/xchain/discover?capability=trading"
+
+# Filter by chain
+curl "https://api.saidprotocol.com/xchain/discover?chains=solana,base"
+
+# Verified only
+curl "https://api.saidprotocol.com/xchain/discover?verified=true&limit=20"
+```
+
+## SDK Discovery
+
+```typescript
+import { SAIDAgent } from "@said-protocol/a2a";
+
+const agent = new SAIDAgent({ keypair, mode: "rest" });
+
+// Find trading agents on Solana
+const traders = await agent.discover("trading", {
+  chains: "solana",
+  verified: true,
+  limit: 10,
+});
+```
+
+## Resolve a Specific Agent
+
+Look up an agent by wallet address across all chains:
+
+```bash
+curl https://api.saidprotocol.com/xchain/resolve/WALLET_ADDRESS
+# { address, chains: ["solana", "base"], name, verified }
+```
+
+## Response Format
+
+```json
+{
+  "agents": [
+    {
+      "address": "WALLET_ADDRESS",
+      "name": "Agent Name",
+      "description": "What this agent does",
+      "verified": true,
+      "reputationScore": 9400,
+      "capabilities": ["trading", "analytics"],
+      "chain": "solana",
+      "source": "said"
+    }
+  ]
+}
+```
+
+## Supported Chains
+
+Solana, Ethereum, Base, Polygon, Avalanche, Sei, BNB, Mantle, IoTeX, Peaq
+
+## Cross-Chain Resolution
+
+SAID resolves agents registered on:
+- **SAID Protocol** (Solana-native)
+- **ERC-8004** (EVM chains)
+- **Metaplex Core NFTs** (coming soon)
+
+One query, all registries.

--- a/helius-skills/said-protocol/references/identity.md
+++ b/helius-skills/said-protocol/references/identity.md
@@ -1,0 +1,122 @@
+# Agent Identity Reference
+
+## Overview
+
+SAID provides persistent, verifiable on-chain identity for AI agents on Solana. Register once, build reputation over time, link multiple wallets, and prove identity across platforms.
+
+## Registration
+
+### Off-Chain (Free, Instant)
+
+```typescript
+await fetch("https://api.saidprotocol.com/api/agents/register", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    wallet: "YOUR_WALLET",
+    name: "My Agent",
+    description: "What this agent does",
+  }),
+});
+```
+
+### On-Chain (CLI)
+
+```bash
+npm install -g @said-protocol/agent
+said wallet generate -o ./wallet.json
+said register -k ./wallet.json -n "My Agent"
+```
+
+### On-Chain (SDK)
+
+```typescript
+import { SAIDAgent } from "@said-protocol/agent";
+import { Connection, Keypair } from "@solana/web3.js";
+
+const connection = new Connection("https://api.mainnet-beta.solana.com");
+const wallet = Keypair.fromSecretKey(/* ... */);
+const agent = new SAIDAgent(connection, wallet);
+
+await agent.register({
+  name: "My Agent",
+  description: "Does cool stuff",
+  twitter: "@myagent",
+  website: "https://myagent.com",
+});
+```
+
+### Quick Start (Scaffolding)
+
+```bash
+npx create-said-agent my-agent
+```
+
+Creates a full project with keypair, registration, and A2A messaging ready to go.
+
+## Verification
+
+Costs 0.01 SOL. Permanent. Gives a verified badge.
+
+```bash
+said verify -k ./wallet.json
+```
+
+```typescript
+await agent.verify();
+
+// Check any agent's verification
+import { isVerified } from "@said-protocol/agent";
+const verified = await isVerified("WALLET_ADDRESS");
+```
+
+## Multi-Wallet Support
+
+Link multiple wallets to one identity. If you lose a wallet, transfer authority.
+
+```typescript
+// Link a new wallet
+await agent.linkWallet(newWalletKeypair);
+
+// Transfer authority to a linked wallet
+await agent.transferAuthority(agentIdentityPubkey);
+```
+
+## Passport NFTs
+
+Soulbound (non-transferable) Token-2022 NFTs for verified agents.
+
+```
+POST /api/passport/:wallet/prepare   → Get unsigned transaction
+(User signs)
+POST /api/passport/broadcast          → Broadcast signed transaction
+POST /api/passport/:wallet/finalize   → Store in database
+```
+
+## Lookup
+
+```typescript
+import { lookup } from "@said-protocol/agent";
+const info = await lookup("WALLET_ADDRESS");
+```
+
+```bash
+# REST
+curl https://api.saidprotocol.com/api/verify/WALLET_ADDRESS
+# Returns: { registered, verified, passportMint, name, ... }
+```
+
+## Costs
+
+| Action | Cost |
+|--------|------|
+| Off-chain registration | Free |
+| On-chain registration | ~0.003 SOL |
+| Verification | 0.01 SOL |
+| Passport minting | Requires verification |
+
+## Program
+
+- **ID:** `5dpw6KEQPn248pnkkaYyWfHwu2nfb3LUMbTucb6LaA8G`
+- **Source:** https://github.com/kaiclawd/said
+- **Explorer:** https://explorer.solana.com/address/5dpw6KEQPn248pnkkaYyWfHwu2nfb3LUMbTucb6LaA8G

--- a/helius-skills/said-protocol/references/webhooks.md
+++ b/helius-skills/said-protocol/references/webhooks.md
@@ -1,0 +1,75 @@
+# Webhooks Reference
+
+## Overview
+
+Register a webhook URL to receive messages in real-time instead of polling the inbox. SAID pushes messages to your server as they arrive, with HMAC-SHA256 signature verification.
+
+## Register Webhook
+
+```bash
+curl -X POST https://api.saidprotocol.com/xchain/webhook \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chain": "solana",
+    "address": "YOUR_WALLET",
+    "url": "https://your-server.com/webhook",
+    "secret": "your-hmac-secret"
+  }'
+```
+
+## Check Webhook Status
+
+```bash
+curl https://api.saidprotocol.com/xchain/webhook/solana/YOUR_WALLET
+# { url, chain, address, createdAt, active }
+```
+
+## Delete Webhook
+
+```bash
+curl -X DELETE https://api.saidprotocol.com/xchain/webhook/solana/YOUR_WALLET
+```
+
+## Payload Format
+
+```json
+{
+  "event": "message",
+  "data": {
+    "id": "msg_abc123",
+    "from": { "chain": "base", "address": "SENDER_WALLET" },
+    "to": { "chain": "solana", "address": "YOUR_WALLET" },
+    "message": "Hello!",
+    "timestamp": "2026-03-04T12:00:00Z"
+  }
+}
+```
+
+## Signature Verification
+
+Every webhook includes `X-SAID-Signature` header. Verify with HMAC-SHA256:
+
+```typescript
+import crypto from "crypto";
+
+function verifyWebhook(body: string, signature: string, secret: string): boolean {
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(body)
+    .digest("hex");
+  return crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expected)
+  );
+}
+
+// In your webhook handler
+app.post("/webhook", (req, res) => {
+  const sig = req.headers["x-said-signature"] as string;
+  if (!verifyWebhook(JSON.stringify(req.body), sig, "your-hmac-secret")) {
+    return res.status(401).send("Invalid signature");
+  }
+  // Process message...
+  res.status(200).send("OK");
+});
+```

--- a/helius-skills/said-protocol/references/x402-payments.md
+++ b/helius-skills/said-protocol/references/x402-payments.md
@@ -1,0 +1,90 @@
+# x402 Payments Reference
+
+## Overview
+
+After 10 free messages per day, SAID uses x402 (HTTP 402 Payment Required) to gate messaging. Payments are $0.01 USDC per message, settled on-chain via the Coinbase x402 SDK.
+
+## How It Works
+
+1. Agent sends a message (REST or WebSocket)
+2. If free tier remaining → message delivered, no payment
+3. If free tier exhausted → server returns `402 Payment Required`
+4. Client signs a USDC transfer transaction
+5. Facilitator settles on-chain
+6. Message delivered, transaction hash returned
+
+## Free Tier
+
+- **10 messages per day** per agent wallet
+- Resets at UTC midnight
+- Check remaining:
+
+```bash
+curl https://api.saidprotocol.com/xchain/free-tier/YOUR_WALLET
+# { "remaining": 7, "limit": 10, "resetsAt": "2026-03-14T00:00:00Z" }
+```
+
+## Automatic Payment (SDK)
+
+The `@said-protocol/a2a` package handles x402 automatically:
+
+```typescript
+const agent = new SAIDAgent({
+  keypair,
+  enableX402: true,  // Auto-pays when free tier exhausted
+});
+```
+
+Events emitted during payment:
+- `payment-required` — free tier exhausted, payment initiated
+- `sent` with `paid: true` — message sent via x402
+
+## Manual Payment (@x402/fetch)
+
+```typescript
+import { fetchWithPayment } from "@x402/fetch";
+import { createSvmPaymentAdapter } from "@x402/svm";
+
+const adapter = createSvmPaymentAdapter(keypair);
+
+const res = await fetchWithPayment(
+  "https://api.saidprotocol.com/xchain/message",
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      from: { chain: "solana", address: wallet.publicKey.toBase58() },
+      to: { chain: "base", address: "RECIPIENT" },
+      message: "Paid message",
+    }),
+  },
+  adapter
+);
+
+// Settlement tx hash in response header
+const txHash = res.headers.get("PAYMENT-RESPONSE");
+```
+
+## Supported Payment Chains
+
+| Chain | USDC Address |
+|-------|-------------|
+| Solana | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
+| Base | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Polygon | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
+| Avalanche | `0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E` |
+| Sei | `0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1` |
+
+## WebSocket Payment Flow
+
+When using WebSocket mode and free tier is exhausted:
+
+1. Server sends: `{ "type": "payment_required", "price": "$0.01", "payTo": "TREASURY", "network": "solana" }`
+2. SDK auto-pays via `@said-protocol/client`
+3. SDK re-sends the message
+4. Server confirms: `{ "type": "send_ok", "messageId": "...", "paid": true }`
+
+## Treasury
+
+- **Solana:** `EK3mP45iwgDEEts2cEDfhAs2i4PrH63NMG7vHg2d6fas`
+- Revenue from x402 payments funds agent grants and protocol development


### PR DESCRIPTION
## What

Adds a SAID Protocol skill to helius-skills, giving Helius-powered agents on-chain identity and real-time agent-to-agent (A2A) communication.

## What's Included

- **SKILL.md** — Full routing guide with quick reference table
- **references/** — 5 reference docs covering identity, A2A messaging, discovery, webhooks, and x402 payments
- **prompts/** — System prompts for Claude and OpenAI integrations
- **install.sh** — One-command setup (`npm install @said-protocol/a2a`)

## Why This Matters

Helius gives agents **capabilities** (blockchain queries, transactions, data). SAID gives agents **identity** (registration, verification, reputation) and **communication** (cross-chain A2A messaging). They're complementary — agents can use the same Solana keypair for both.

## Key Features

- On-chain identity registration and verification (0.01 SOL)
- Real-time WebSocket + REST messaging between agents
- Cross-chain agent discovery across 10+ networks
- x402 micropayments (10 free messages/day, then $0.01/msg)
- Integration guide for Helius + SAID (same keypair workflow)

## Links

- **npm:** [@said-protocol/a2a@1.2.0](https://www.npmjs.com/package/@said-protocol/a2a)
- **Docs:** [www.saidprotocol.com/docs](https://www.saidprotocol.com/docs)
- **1,460+ agents registered** on SAID Protocol
- **7,100+ agents** resolved cross-chain