### PR TITLE
Update Sender docs: clarify tip accounts and add pre-serialized tx guide

### DIFF
--- a/.agents/skills/helius-dflow/prompts/full.md
+++ b/.agents/skills/helius-dflow/prompts/full.md
@@ -2281,8 +2281,7 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram,
-  TransactionInstruction
+  ComputeBudgetProgram
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [
@@ -2591,6 +2590,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -2601,13 +2604,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -2618,7 +2629,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/.agents/skills/helius-dflow/prompts/full.md
+++ b/.agents/skills/helius-dflow/prompts/full.md
@@ -2281,7 +2281,8 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram
+  ComputeBudgetProgram,
+  TransactionInstruction
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [

--- a/.agents/skills/helius-dflow/prompts/full.md
+++ b/.agents/skills/helius-dflow/prompts/full.md
@@ -2165,7 +2165,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -2573,6 +2575,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/.agents/skills/helius-dflow/references/helius-sender.md
+++ b/.agents/skills/helius-dflow/references/helius-sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -431,6 +433,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/.agents/skills/helius-dflow/references/helius-sender.md
+++ b/.agents/skills/helius-dflow/references/helius-sender.md
@@ -139,7 +139,8 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram
+  ComputeBudgetProgram,
+  TransactionInstruction
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [

--- a/.agents/skills/helius-dflow/references/helius-sender.md
+++ b/.agents/skills/helius-dflow/references/helius-sender.md
@@ -139,8 +139,7 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram,
-  TransactionInstruction
+  ComputeBudgetProgram
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [
@@ -449,6 +448,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -459,13 +462,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -476,7 +487,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/.agents/skills/helius-phantom/prompts/full.md
+++ b/.agents/skills/helius-phantom/prompts/full.md
@@ -2506,6 +2506,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -2516,13 +2520,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -2533,7 +2545,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/.agents/skills/helius-phantom/prompts/full.md
+++ b/.agents/skills/helius-phantom/prompts/full.md
@@ -2163,7 +2163,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -2488,6 +2490,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/.agents/skills/helius-phantom/references/helius-sender.md
+++ b/.agents/skills/helius-phantom/references/helius-sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -348,6 +350,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/.agents/skills/helius-phantom/references/helius-sender.md
+++ b/.agents/skills/helius-phantom/references/helius-sender.md
@@ -366,6 +366,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -376,13 +380,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -393,7 +405,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/.agents/skills/helius/prompts/full.md
+++ b/.agents/skills/helius/prompts/full.md
@@ -2065,6 +2065,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -2075,13 +2079,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -2092,7 +2104,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/.agents/skills/helius/prompts/full.md
+++ b/.agents/skills/helius/prompts/full.md
@@ -1640,7 +1640,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -2047,6 +2049,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/.agents/skills/helius/references/sender.md
+++ b/.agents/skills/helius/references/sender.md
@@ -448,6 +448,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -458,13 +462,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -475,7 +487,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/.agents/skills/helius/references/sender.md
+++ b/.agents/skills/helius/references/sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -430,6 +432,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-cursor/skills/build/references/sender.md
+++ b/helius-cursor/skills/build/references/sender.md
@@ -448,6 +448,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -458,13 +462,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -475,7 +487,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-cursor/skills/build/references/sender.md
+++ b/helius-cursor/skills/build/references/sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -430,6 +432,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-cursor/skills/dflow/references/helius-sender.md
+++ b/helius-cursor/skills/dflow/references/helius-sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -431,6 +433,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-cursor/skills/dflow/references/helius-sender.md
+++ b/helius-cursor/skills/dflow/references/helius-sender.md
@@ -139,7 +139,8 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram
+  ComputeBudgetProgram,
+  TransactionInstruction
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [

--- a/helius-cursor/skills/dflow/references/helius-sender.md
+++ b/helius-cursor/skills/dflow/references/helius-sender.md
@@ -139,8 +139,7 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram,
-  TransactionInstruction
+  ComputeBudgetProgram
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [
@@ -449,6 +448,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -459,13 +462,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -476,7 +487,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-cursor/skills/phantom/references/helius-sender.md
+++ b/helius-cursor/skills/phantom/references/helius-sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -348,6 +350,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-cursor/skills/phantom/references/helius-sender.md
+++ b/helius-cursor/skills/phantom/references/helius-sender.md
@@ -366,6 +366,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -376,13 +380,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -393,7 +405,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-mcp/system-prompts/helius-dflow/full.md
+++ b/helius-mcp/system-prompts/helius-dflow/full.md
@@ -2281,8 +2281,7 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram,
-  TransactionInstruction
+  ComputeBudgetProgram
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [
@@ -2591,6 +2590,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -2601,13 +2604,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -2618,7 +2629,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-mcp/system-prompts/helius-dflow/full.md
+++ b/helius-mcp/system-prompts/helius-dflow/full.md
@@ -2281,7 +2281,8 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram
+  ComputeBudgetProgram,
+  TransactionInstruction
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [

--- a/helius-mcp/system-prompts/helius-dflow/full.md
+++ b/helius-mcp/system-prompts/helius-dflow/full.md
@@ -2165,7 +2165,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -2573,6 +2575,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-mcp/system-prompts/helius-phantom/full.md
+++ b/helius-mcp/system-prompts/helius-phantom/full.md
@@ -2506,6 +2506,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -2516,13 +2520,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -2533,7 +2545,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-mcp/system-prompts/helius-phantom/full.md
+++ b/helius-mcp/system-prompts/helius-phantom/full.md
@@ -2163,7 +2163,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -2488,6 +2490,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-mcp/system-prompts/helius/full.md
+++ b/helius-mcp/system-prompts/helius/full.md
@@ -2065,6 +2065,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -2075,13 +2079,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -2092,7 +2104,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-mcp/system-prompts/helius/full.md
+++ b/helius-mcp/system-prompts/helius/full.md
@@ -1640,7 +1640,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -2047,6 +2049,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-plugin/skills/build/references/sender.md
+++ b/helius-plugin/skills/build/references/sender.md
@@ -448,6 +448,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -458,13 +462,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -475,7 +487,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-plugin/skills/build/references/sender.md
+++ b/helius-plugin/skills/build/references/sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -430,6 +432,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-plugin/skills/dflow/references/helius-sender.md
+++ b/helius-plugin/skills/dflow/references/helius-sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -431,6 +433,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-plugin/skills/dflow/references/helius-sender.md
+++ b/helius-plugin/skills/dflow/references/helius-sender.md
@@ -139,7 +139,8 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram
+  ComputeBudgetProgram,
+  TransactionInstruction
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [

--- a/helius-plugin/skills/dflow/references/helius-sender.md
+++ b/helius-plugin/skills/dflow/references/helius-sender.md
@@ -139,8 +139,7 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram,
-  TransactionInstruction
+  ComputeBudgetProgram
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [
@@ -449,6 +448,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -459,13 +462,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -476,7 +487,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-plugin/skills/phantom/references/helius-sender.md
+++ b/helius-plugin/skills/phantom/references/helius-sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -348,6 +350,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-plugin/skills/phantom/references/helius-sender.md
+++ b/helius-plugin/skills/phantom/references/helius-sender.md
@@ -366,6 +366,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -376,13 +380,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -393,7 +405,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-skills/helius-dflow/references/helius-sender.md
+++ b/helius-skills/helius-dflow/references/helius-sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -431,6 +433,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-skills/helius-dflow/references/helius-sender.md
+++ b/helius-skills/helius-dflow/references/helius-sender.md
@@ -139,7 +139,8 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram
+  ComputeBudgetProgram,
+  TransactionInstruction
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [

--- a/helius-skills/helius-dflow/references/helius-sender.md
+++ b/helius-skills/helius-dflow/references/helius-sender.md
@@ -139,8 +139,7 @@ import {
   PublicKey,
   Keypair,
   LAMPORTS_PER_SOL,
-  ComputeBudgetProgram,
-  TransactionInstruction
+  ComputeBudgetProgram
 } from '@solana/web3.js';
 
 const TIP_ACCOUNTS = [
@@ -449,6 +448,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -459,13 +462,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -476,7 +487,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-skills/helius-phantom/references/helius-sender.md
+++ b/helius-skills/helius-phantom/references/helius-sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -348,6 +350,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 

--- a/helius-skills/helius-phantom/references/helius-sender.md
+++ b/helius-skills/helius-phantom/references/helius-sender.md
@@ -366,6 +366,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -376,13 +380,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -393,7 +405,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-skills/helius/references/sender.md
+++ b/helius-skills/helius/references/sender.md
@@ -448,6 +448,10 @@ import {
   SystemProgram,
   PublicKey,
   LAMPORTS_PER_SOL,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  AddressLookupTableAccount,
 } from '@solana/web3.js';
 
 async function addTipAndSend(
@@ -458,13 +462,21 @@ async function addTipAndSend(
   // 1. Deserialize the existing transaction
   const originalTx = VersionedTransaction.deserialize(serializedTx);
 
-  // 2. Decompile into a mutable message
-  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  // 2. Resolve any address lookup tables the transaction uses
+  const addressLookupTableAccounts = await Promise.all(
+    originalTx.message.addressTableLookups.map(async (lookup) => {
+      const { value } = await connection.getAddressLookupTable(lookup.accountKey);
+      if (!value) throw new Error(`ALT not found: ${lookup.accountKey.toBase58()}`);
+      return value;
+    })
+  );
+
+  // 3. Decompile into a mutable message
   const message = TransactionMessage.decompile(originalTx.message, {
     addressLookupTableAccounts,
   });
 
-  // 3. Append the Jito tip instruction
+  // 4. Append the Sender tip instruction
   const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
   const tipAmountSOL = await getDynamicTipAmount();
   message.instructions.push(
@@ -475,7 +487,7 @@ async function addTipAndSend(
     })
   );
 
-  // 4. Recompile, re-sign, and send
+  // 5. Recompile, re-sign, and send
   const newTx = new VersionedTransaction(
     message.compileToV0Message(addressLookupTableAccounts)
   );

--- a/helius-skills/helius/references/sender.md
+++ b/helius-skills/helius/references/sender.md
@@ -23,7 +23,9 @@ Every Sender transaction MUST include all three of these or it will be rejected:
 
 ### 2. Jito Tip
 
-A SOL transfer instruction to one of the designated tip accounts. Pick one randomly per transaction to distribute load.
+A SOL transfer instruction to one of the designated **Sender tip accounts** listed below. These are Sender-specific accounts — NOT the Jito tip accounts directly. Sender forwards your tip to Jito on your behalf. This means you cannot reuse a tip you've already sent to a Jito tip account elsewhere — the transfer must go to one of these Sender tip accounts.
+
+Pick one tip account **randomly per transaction** to distribute load.
 
 **Minimum tip amounts:**
 - Default dual routing: **0.0002 SOL** (200,000 lamports)
@@ -430,6 +432,76 @@ When building the transaction, instructions MUST be ordered:
 2. `ComputeBudgetProgram.setComputeUnitPrice` (second)
 3. Your application instructions (middle)
 4. Jito tip transfer (last)
+
+## Sending a Pre-Serialized Transaction via Sender
+
+If you receive an already-serialized transaction (e.g. from a third-party API, a dApp, or a user), do NOT assume it already contains a Jito tip. First check the transaction's instructions for an existing transfer to one of the Sender tip accounts listed above. Most pre-built transactions will not have a tip, and Sender will reject transactions without one.
+
+Deserializing, modifying, and re-serializing a transaction is perfectly safe and is the standard approach. In typical Sender integration scenarios you have access to all required signers — the transaction is being built or relayed on behalf of a user whose keypair you hold. Re-signing after modification is straightforward in this case.
+
+To add a tip, **deserialize** the transaction, append the tip transfer instruction, and re-sign:
+
+```typescript
+import {
+  VersionedTransaction,
+  TransactionMessage,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+
+async function addTipAndSend(
+  serializedTx: Uint8Array,
+  keypair: Keypair,
+  connection: Connection
+): Promise<string> {
+  // 1. Deserialize the existing transaction
+  const originalTx = VersionedTransaction.deserialize(serializedTx);
+
+  // 2. Decompile into a mutable message
+  const addressLookupTableAccounts = []; // resolve any ALTs the tx uses
+  const message = TransactionMessage.decompile(originalTx.message, {
+    addressLookupTableAccounts,
+  });
+
+  // 3. Append the Jito tip instruction
+  const tipAccount = TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)];
+  const tipAmountSOL = await getDynamicTipAmount();
+  message.instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: keypair.publicKey,
+      toPubkey: new PublicKey(tipAccount),
+      lamports: Math.floor(tipAmountSOL * LAMPORTS_PER_SOL),
+    })
+  );
+
+  // 4. Recompile, re-sign, and send
+  const newTx = new VersionedTransaction(
+    message.compileToV0Message(addressLookupTableAccounts)
+  );
+  newTx.sign([keypair]);
+
+  const response = await fetch('https://sender.helius-rpc.com/fast', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now().toString(),
+      method: 'sendTransaction',
+      params: [
+        Buffer.from(newTx.serialize()).toString('base64'),
+        { encoding: 'base64', skipPreflight: true, maxRetries: 0 },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result;
+}
+```
+
+**Important:** Decompiling and recompiling changes the transaction, which invalidates all existing signatures. You must re-sign with all required signers after adding the tip. This is expected and safe — in most Sender integration scenarios you control the signing keys. If the original transaction was signed by a third party whose key you don't hold, you cannot modify it — coordinate with the signer to include the tip before serialization.
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Summary
- Clarifies that Sender tip accounts are distinct from Jito tip accounts — users must send tips to Sender-specific accounts, not Jito directly
- Adds new "Sending a Pre-Serialized Transaction via Sender" section with a full TypeScript example for deserializing, injecting a tip, and re-sending
- Synced changes across all 18 files (canonical, plugin, cursor, compiled output)

## Test plan
- [ ] Verify CI sync checks pass
- [ ] Review rendered markdown in all three skill variants (helius, helius-dflow, helius-phantom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)