### PR TITLE
feat(mcp): Add `glama.json` to Repo Root

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "0xIchigo",
+    "nathanliow",
+    "fomichfm",
+    "hetdagli234"
+  ]
+}


### PR DESCRIPTION
This PR adds a `glama.json` to the repo root to claim maintainer ownership on Glama's MCP server directory