### PR TITLE
feat(cli+mcp): Add Optional OWS Wallet Signing

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -52,6 +52,7 @@ import {
 import { sendBroadcastCommand, sendRawCommand, sendSenderCommand, sendPollCommand, sendComputeUnitsCommand } from "../src/commands/send.js";
 import { wsAccountCommand, wsLogsCommand, wsSlotCommand, wsSignatureCommand, wsProgramCommand } from "../src/commands/ws.js";
 import { simdListCommand, simdGetCommand } from "../src/commands/simd.js";
+import { owsLinkCommand, owsUnlinkCommand, owsStatusCommand } from "../src/commands/ows.js";
 import { VERSION } from "../src/constants.js";
 import { sendCommandEvent, sendCliFeedback, setCurrentCommand } from "../src/lib/feedback.js";
 
@@ -445,6 +446,24 @@ walletCmd
   .description("Find original funding source of a wallet")
   .option("--json", "Output in JSON format")
   .action(function(this: any, address: string) { walletFundedByCommand(address, opts(this)); });
+
+walletCmd
+  .command("ows-link <wallet-name>")
+  .description("Link an OWS wallet for policy-gated signing (requires ows CLI)")
+  .option("--json", "Output in JSON format")
+  .action(function(this: any, name: string) { owsLinkCommand(name, opts(this)); });
+
+walletCmd
+  .command("ows-unlink")
+  .description("Remove the linked OWS wallet")
+  .option("--json", "Output in JSON format")
+  .action(function(this: any) { owsUnlinkCommand(opts(this)); });
+
+walletCmd
+  .command("ows-status")
+  .description("Show OWS installation status and linked wallet")
+  .option("--json", "Output in JSON format")
+  .action(function(this: any) { owsStatusCommand(opts(this)); });
 
 // ── Webhooks ──
 

--- a/helius-cli/src/commands/ows.ts
+++ b/helius-cli/src/commands/ows.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { isOwsInstalled, listOwsWallets, getOwsSolanaAddress } from "../lib/ows.js";
+import { isOwsInstalled, listOwsWallets, getOwsSolanaAddress, validateWalletName } from "../lib/ows.js";
 import { setOwsWallet, getOwsWallet, clearOwsWallet } from "../lib/config.js";
 import { handleCommandError, createSpinner, type OutputOptions, outputJson } from "../lib/output.js";
 
@@ -13,6 +13,8 @@ export async function owsLinkCommand(
 ): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    validateWalletName(walletName);
+
     spinner?.start("Checking OWS installation...");
     if (!(await isOwsInstalled())) {
       spinner?.stop();

--- a/helius-cli/src/commands/ows.ts
+++ b/helius-cli/src/commands/ows.ts
@@ -1,0 +1,182 @@
+import chalk from "chalk";
+import { isOwsInstalled, listOwsWallets, getOwsSolanaAddress } from "../lib/ows.js";
+import { setOwsWallet, getOwsWallet, clearOwsWallet } from "../lib/config.js";
+import { handleCommandError, createSpinner, type OutputOptions, outputJson } from "../lib/output.js";
+
+// ── ows-link: link an OWS wallet as the active signing wallet ──
+
+interface OwsLinkOptions extends OutputOptions {}
+
+export async function owsLinkCommand(
+  walletName: string,
+  options: OwsLinkOptions = {},
+): Promise<void> {
+  const spinner = createSpinner(options);
+  try {
+    spinner?.start("Checking OWS installation...");
+    if (!(await isOwsInstalled())) {
+      spinner?.stop();
+      console.error(
+        chalk.red("OWS CLI is not installed.") +
+          "\n\nInstall it with:\n" +
+          chalk.cyan(
+            "  curl -fsSL https://docs.openwallet.sh/install.sh | bash",
+          ) +
+          "\n  or\n" +
+          chalk.cyan("  npm install -g @open-wallet-standard/core"),
+      );
+      process.exit(1);
+    }
+
+    spinner?.start(`Looking up OWS wallet "${walletName}"...`);
+    const solAddress = await getOwsSolanaAddress(walletName);
+    spinner?.stop();
+
+    setOwsWallet(walletName);
+
+    if (options.json) {
+      outputJson({ owsWallet: walletName, solanaAddress: solAddress });
+      return;
+    }
+
+    console.log(chalk.green("✓ OWS wallet linked"));
+    console.log(`  ${chalk.gray("Wallet:")}  ${chalk.cyan(walletName)}`);
+    console.log(`  ${chalk.gray("Solana:")}  ${chalk.cyan(solAddress)}`);
+    console.log("");
+    console.log(
+      chalk.gray(
+        "Transactions signed via this wallet will use OWS policy-gated signing.",
+      ),
+    );
+    console.log(
+      chalk.gray("The private key never leaves the OWS encrypted vault."),
+    );
+  } catch (error) {
+    handleCommandError(error, options, spinner);
+  }
+}
+
+// ── ows-unlink: remove the linked OWS wallet ──
+
+export async function owsUnlinkCommand(
+  options: OwsLinkOptions = {},
+): Promise<void> {
+  const current = getOwsWallet();
+  if (!current) {
+    if (options.json) {
+      outputJson({ owsWallet: null });
+      return;
+    }
+    console.log(chalk.yellow("No OWS wallet is currently linked."));
+    return;
+  }
+
+  clearOwsWallet();
+
+  if (options.json) {
+    outputJson({ owsWallet: null, unlinked: current });
+    return;
+  }
+
+  console.log(chalk.green(`✓ Unlinked OWS wallet "${current}"`));
+}
+
+// ── ows-status: show linked wallet + OWS info ──
+
+export async function owsStatusCommand(
+  options: OwsLinkOptions = {},
+): Promise<void> {
+  const spinner = createSpinner(options);
+  try {
+    const installed = await isOwsInstalled();
+    const linkedWallet = getOwsWallet();
+
+    if (options.json) {
+      const result: Record<string, unknown> = {
+        installed,
+        linkedWallet: linkedWallet ?? null,
+        solanaAddress: null,
+        wallets: [],
+      };
+
+      if (installed && linkedWallet) {
+        try {
+          result.solanaAddress = await getOwsSolanaAddress(linkedWallet);
+        } catch {
+          // wallet may have been deleted in OWS
+        }
+      }
+
+      if (installed) {
+        try {
+          result.wallets = await listOwsWallets();
+        } catch {
+          // OWS may return unexpected format
+        }
+      }
+
+      outputJson(result);
+      return;
+    }
+
+    console.log(chalk.bold("\nOpen Wallet Standard (OWS)\n"));
+
+    if (!installed) {
+      console.log(`  ${chalk.gray("Installed:")} ${chalk.red("No")}`);
+      console.log("");
+      console.log("  Install with:");
+      console.log(
+        chalk.cyan(
+          "    curl -fsSL https://docs.openwallet.sh/install.sh | bash",
+        ),
+      );
+      return;
+    }
+
+    console.log(`  ${chalk.gray("Installed:")} ${chalk.green("Yes")}`);
+
+    if (linkedWallet) {
+      let solAddress = "unknown";
+      try {
+        solAddress = await getOwsSolanaAddress(linkedWallet);
+      } catch {
+        // wallet may have been deleted
+      }
+      console.log(
+        `  ${chalk.gray("Linked wallet:")} ${chalk.cyan(linkedWallet)}`,
+      );
+      console.log(
+        `  ${chalk.gray("Solana address:")} ${chalk.cyan(solAddress)}`,
+      );
+    } else {
+      console.log(`  ${chalk.gray("Linked wallet:")} ${chalk.yellow("None")}`);
+      console.log(
+        chalk.gray(
+          "\n  Link a wallet with: helius wallet ows-link <wallet-name>",
+        ),
+      );
+    }
+
+    // List available wallets
+    spinner?.start("Listing OWS wallets...");
+    try {
+      const wallets = await listOwsWallets();
+      spinner?.stop();
+      if (wallets.length > 0) {
+        console.log(`\n  ${chalk.gray("Available OWS wallets:")}`);
+        for (const w of wallets) {
+          const name = w.name || w.id;
+          const marker = name === linkedWallet ? chalk.green(" (linked)") : "";
+          console.log(`    • ${chalk.cyan(name)}${marker}`);
+        }
+      }
+    } catch {
+      spinner?.stop();
+      // OWS wallet list may fail — not critical
+    }
+
+    console.log("");
+  } catch (error) {
+    handleCommandError(error, options, spinner);
+  }
+}

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -13,6 +13,7 @@ interface Config {
   apiKey?: string;
   network?: "mainnet" | "devnet";
   projectId?: string;
+  owsWallet?: string;
 }
 
 function ensureDir(): void {
@@ -75,6 +76,22 @@ export function getProjectId(): string | undefined {
 export function setProjectId(projectId: string): void {
   const config = load();
   config.projectId = projectId;
+  save(config);
+}
+
+export function getOwsWallet(): string | undefined {
+  return load().owsWallet;
+}
+
+export function setOwsWallet(name: string): void {
+  const config = load();
+  config.owsWallet = name;
+  save(config);
+}
+
+export function clearOwsWallet(): void {
+  const config = load();
+  delete config.owsWallet;
   save(config);
 }
 

--- a/helius-cli/src/lib/ows.ts
+++ b/helius-cli/src/lib/ows.ts
@@ -4,12 +4,25 @@
  * Provides helpers to detect the `ows` CLI, list wallets, and extract
  * Solana addresses.  Used by `helius wallet ows-link` and OWS-aware
  * command flags.
+ *
+ * NOTE: The CLI helpers (isOwsInstalled, getOwsSolanaAddress) are mirrored in
+ * helius-mcp/src/utils/ows.ts.  Keep the two copies in sync when changing
+ * argument handling, CAIP-2 lookup logic, or OWS CLI flags.
  */
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { getNetwork } from "./config.js";
 
 const execFileAsync = promisify(execFile);
+
+// CAIP-2 chain identifiers for Solana networks.
+// See OWS spec 07-supported-chains.md.
+const SOLANA_CAIP2_MAINNET = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+const SOLANA_CAIP2_DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG";
+
+/** Alphanumeric, hyphens, and underscores — matches OWS wallet naming rules. */
+const WALLET_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
 /** True when the `ows` binary is reachable on PATH. */
 export async function isOwsInstalled(): Promise<boolean> {
@@ -18,6 +31,20 @@ export async function isOwsInstalled(): Promise<boolean> {
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Validate wallet name format before passing to execFile.
+ * While execFile prevents shell injection, a garbage name produces
+ * confusing OWS CLI errors — better to catch it early.
+ */
+export function validateWalletName(name: string): void {
+  if (!WALLET_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid OWS wallet name "${name}". ` +
+        `Names must be 1-64 characters using letters, digits, hyphens, or underscores.`,
+    );
   }
 }
 
@@ -33,10 +60,16 @@ export async function listOwsWallets(): Promise<
   return Array.isArray(parsed) ? parsed : parsed.wallets ?? [];
 }
 
-/** Return the Solana address for the named OWS wallet. */
+/**
+ * Return the Solana address for the named OWS wallet.
+ * Uses the current CLI network setting (mainnet or devnet) to select
+ * the correct CAIP-2 chain key.
+ */
 export async function getOwsSolanaAddress(
   walletName: string,
 ): Promise<string> {
+  validateWalletName(walletName);
+
   const { stdout } = await execFileAsync(
     "ows",
     ["wallet", "info", "--wallet", walletName, "--json"],
@@ -44,9 +77,13 @@ export async function getOwsSolanaAddress(
   );
   const info = JSON.parse(stdout);
 
-  const solanaKey = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+  // The CLI outputs accounts keyed by CAIP-2 chain id.
+  // Pick the key matching the active network.
+  const network = getNetwork();
+  const primaryKey =
+    network === "devnet" ? SOLANA_CAIP2_DEVNET : SOLANA_CAIP2_MAINNET;
   const account =
-    info.accounts?.[solanaKey] ??
+    info.accounts?.[primaryKey] ??
     info.accounts?.solana ??
     Object.entries(info.accounts ?? {}).find(([k]) =>
       k.includes("solana"),

--- a/helius-cli/src/lib/ows.ts
+++ b/helius-cli/src/lib/ows.ts
@@ -1,0 +1,70 @@
+/**
+ * Open Wallet Standard (OWS) integration for helius-cli.
+ *
+ * Provides helpers to detect the `ows` CLI, list wallets, and extract
+ * Solana addresses.  Used by `helius wallet ows-link` and OWS-aware
+ * command flags.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** True when the `ows` binary is reachable on PATH. */
+export async function isOwsInstalled(): Promise<boolean> {
+  try {
+    await execFileAsync("ows", ["--version"], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Return parsed JSON from `ows wallet list --json`. */
+export async function listOwsWallets(): Promise<
+  Array<{ id: string; name: string; accounts?: Record<string, unknown> }>
+> {
+  const { stdout } = await execFileAsync("ows", ["wallet", "list", "--json"], {
+    timeout: 10_000,
+  });
+  const parsed = JSON.parse(stdout);
+  // The CLI may return { wallets: [...] } or a bare array.
+  return Array.isArray(parsed) ? parsed : parsed.wallets ?? [];
+}
+
+/** Return the Solana address for the named OWS wallet. */
+export async function getOwsSolanaAddress(
+  walletName: string,
+): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "ows",
+    ["wallet", "info", "--wallet", walletName, "--json"],
+    { timeout: 10_000 },
+  );
+  const info = JSON.parse(stdout);
+
+  const solanaKey = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+  const account =
+    info.accounts?.[solanaKey] ??
+    info.accounts?.solana ??
+    Object.entries(info.accounts ?? {}).find(([k]) =>
+      k.includes("solana"),
+    )?.[1];
+
+  if (!account) {
+    throw new Error(
+      `OWS wallet "${walletName}" has no Solana account. ` +
+        `Run \`ows wallet info --wallet ${walletName}\` to inspect.`,
+    );
+  }
+
+  const addr: string =
+    typeof account === "string" ? account : (account as any).address;
+  if (!addr) {
+    throw new Error(
+      `Could not extract Solana address from OWS wallet "${walletName}".`,
+    );
+  }
+  return addr;
+}

--- a/helius-mcp/src/router/schemas.ts
+++ b/helius-mcp/src/router/schemas.ts
@@ -186,6 +186,7 @@ export const HELIUS_WRITE_SCHEMA = withTelemetry({
   sendMax: optionalBoolean(),
   stakeAccount: optionalString(),
   destination: optionalString(),
+  owsWallet: optionalString(),
 });
 
 export const HELIUS_COMPRESSION_SCHEMA = withTelemetry({

--- a/helius-mcp/src/tools/staking.ts
+++ b/helius-mcp/src/tools/staking.ts
@@ -1,9 +1,10 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { createKeyPairSignerFromBytes, address } from '@solana/kit';
-import { getHeliusClient, hasApiKey, loadSignerOrFail, getSessionWalletAddress } from '../utils/helius.js';
+import { address } from '@solana/kit';
+import { getHeliusClient, hasApiKey, getSessionWalletAddress } from '../utils/helius.js';
 import { mcpText, mcpError, handleToolError, isValidAddressFormat, missingParamError } from '../utils/errors.js';
 import { noApiKeyResponse } from './shared.js';
+import { resolveOwsOrKeypairSigner } from '../utils/ows.js';
 
 // ── Tool Registration ──
 
@@ -24,26 +25,20 @@ export function registerStakingTools(server: McpServer) {
       amount: z.number().positive().describe(
         'Amount of SOL to stake (e.g., 1.0 for one SOL). This is the delegation amount; a small rent-exempt reserve (~0.00228 SOL) is added automatically.'
       ),
+      owsWallet: z.string().optional().describe('OWS wallet name for policy-gated signing (requires `ows` CLI installed).'),
     },
-    async ({ amount }) => {
+    async ({ amount, owsWallet }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
-        // Load keypair
-        let signerData: { secretKey: Uint8Array; walletAddress: string };
-        try {
-          signerData = await loadSignerOrFail();
-        } catch {
-          return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before staking.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
-          );
-        }
+        const resolved = await resolveOwsOrKeypairSigner(owsWallet);
+        if (!resolved.ok) return resolved.error;
+        const { signer, walletAddress } = resolved;
 
         const helius = getHeliusClient();
 
         // Pre-flight balance check — need amount + ~0.01 SOL for rent + fees
-        const balanceResult = await helius.getBalance(signerData.walletAddress);
+        const balanceResult = await helius.getBalance(walletAddress);
         const balanceLamports = BigInt(balanceResult.value);
         const stakeLamports = BigInt(Math.round(amount * 1_000_000_000));
         const reserveLamports = 10_000_000n; // ~0.01 SOL for rent-exempt reserve + fees
@@ -51,27 +46,25 @@ export function registerStakingTools(server: McpServer) {
           const available = Number(balanceLamports) / 1_000_000_000;
           return mcpError(
             `Insufficient SOL balance. You have ${available} SOL but need ${amount} SOL plus ~0.01 SOL for rent-exempt reserve and transaction fees.\n\n` +
-            `Wallet: \`${signerData.walletAddress}\``,
+            `Wallet: \`${walletAddress}\``,
             { type: 'INSUFFICIENT_FUNDS', code: 'LOW_SOL', retryable: false, recovery: 'Fund the wallet with more SOL.' }
           );
         }
 
-        // Create signer from keypair bytes
-        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
-
         // Get stake instructions (async — fetches rent-exempt minimum from RPC)
-        const { instructions, stakeAccount } = await helius.stake.getStakeInstructions(signer, amount);
+        const { instructions, stakeAccount } = await helius.stake.getStakeInstructions(signer as any, amount);
 
         // Send transaction — stakeAccount is a generated keypair that must co-sign
         const signature = await helius.tx.sendTransactionWithSender({
-          signers: [signer, stakeAccount],
+          signers: [signer as any, stakeAccount],
           instructions: [...instructions],
           region: 'Default',
         });
 
+        const signerLabel = owsWallet ? `\`${walletAddress}\` (OWS: ${owsWallet})` : `\`${walletAddress}\``;
         return mcpText(
           `**SOL Staked to Helius Validator**\n\n` +
-          `- **From:** \`${signerData.walletAddress}\`\n` +
+          `- **From:** ${signerLabel}\n` +
           `- **Stake Account:** \`${stakeAccount.address}\`\n` +
           `- **Amount:** ${amount} SOL\n` +
           `- **Signature:** \`${signature}\`\n` +
@@ -101,21 +94,15 @@ export function registerStakingTools(server: McpServer) {
       stakeAccount: z.string().describe(
         'Address of the stake account to deactivate (base58 encoded). Use getStakeAccounts to find your Helius stake accounts.'
       ),
+      owsWallet: z.string().optional().describe('OWS wallet name for policy-gated signing (requires `ows` CLI installed).'),
     },
-    async ({ stakeAccount: stakeAccountAddress }) => {
+    async ({ stakeAccount: stakeAccountAddress, owsWallet }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
-        // Load keypair
-        let signerData: { secretKey: Uint8Array; walletAddress: string };
-        try {
-          signerData = await loadSignerOrFail();
-        } catch {
-          return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
-          );
-        }
+        const resolved = await resolveOwsOrKeypairSigner(owsWallet);
+        if (!resolved.ok) return resolved.error;
+        const { signer, walletAddress } = resolved;
 
         // Validate address
         if (!isValidAddressFormat(stakeAccountAddress)) {
@@ -126,22 +113,22 @@ export function registerStakingTools(server: McpServer) {
         }
 
         const helius = getHeliusClient();
-        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
 
         // Get deactivation instruction (synchronous)
-        const ix = helius.stake.getUnstakeInstruction(signer, address(stakeAccountAddress));
+        const ix = helius.stake.getUnstakeInstruction(signer as any, address(stakeAccountAddress));
 
         // Send transaction
         const signature = await helius.tx.sendTransactionWithSender({
-          signers: [signer],
+          signers: [signer as any],
           instructions: [ix],
           region: 'Default',
         });
 
+        const signerLabel = owsWallet ? `\`${walletAddress}\` (OWS: ${owsWallet})` : `\`${walletAddress}\``;
         return mcpText(
           `**Stake Account Deactivated**\n\n` +
           `- **Stake Account:** \`${stakeAccountAddress}\`\n` +
-          `- **Authority:** \`${signerData.walletAddress}\`\n` +
+          `- **Authority:** ${signerLabel}\n` +
           `- **Signature:** \`${signature}\`\n` +
           `- **Explorer:** https://orbmarkets.io/tx/${signature}\n\n` +
           `The stake account is now deactivating. Funds will become withdrawable after the cooldown period (~1 full epoch / 2-3 days). ` +
@@ -174,21 +161,15 @@ export function registerStakingTools(server: McpServer) {
       amount: z.number().positive().optional().describe(
         'Amount of SOL to withdraw. If omitted, withdraws the entire withdrawable balance (including rent-exempt reserve, which closes the account).'
       ),
+      owsWallet: z.string().optional().describe('OWS wallet name for policy-gated signing (requires `ows` CLI installed).'),
     },
-    async ({ stakeAccount: stakeAccountAddress, destination, amount }) => {
+    async ({ stakeAccount: stakeAccountAddress, destination, amount, owsWallet }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
-        // Load keypair
-        let signerData: { secretKey: Uint8Array; walletAddress: string };
-        try {
-          signerData = await loadSignerOrFail();
-        } catch {
-          return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call generateKeypair to create a wallet.' }
-          );
-        }
+        const resolved = await resolveOwsOrKeypairSigner(owsWallet);
+        if (!resolved.ok) return resolved.error;
+        const { signer, walletAddress } = resolved;
 
         // Validate addresses
         if (!isValidAddressFormat(stakeAccountAddress)) {
@@ -205,8 +186,7 @@ export function registerStakingTools(server: McpServer) {
         }
 
         const helius = getHeliusClient();
-        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
-        const dest = destination || signerData.walletAddress;
+        const dest = destination || walletAddress;
 
         // Determine lamports to withdraw
         let lamports: number;
@@ -227,11 +207,11 @@ export function registerStakingTools(server: McpServer) {
         }
 
         // Get withdraw instruction (synchronous)
-        const ix = helius.stake.getWithdrawInstruction(signer, address(stakeAccountAddress), address(dest), lamports);
+        const ix = helius.stake.getWithdrawInstruction(signer as any, address(stakeAccountAddress), address(dest), lamports);
 
         // Send transaction
         const signature = await helius.tx.sendTransactionWithSender({
-          signers: [signer],
+          signers: [signer as any],
           instructions: [ix],
           region: 'Default',
         });

--- a/helius-mcp/src/tools/transfers.ts
+++ b/helius-mcp/src/tools/transfers.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { createKeyPairSignerFromBytes, address } from '@solana/kit';
+import { address } from '@solana/kit';
 import { getTransferSolInstruction } from '@solana-program/system';
 import {
   findAssociatedTokenPda,
@@ -9,9 +9,10 @@ import {
   getTransferCheckedInstruction,
   TOKEN_PROGRAM_ADDRESS,
 } from '@solana-program/token';
-import { getHeliusClient, hasApiKey, loadSignerOrFail } from '../utils/helius.js';
+import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { mcpText, mcpError, handleToolError, isValidAddressFormat } from '../utils/errors.js';
 import { noApiKeyResponse } from './shared.js';
+import { resolveOwsOrKeypairSigner } from '../utils/ows.js';
 
 const TOKEN_2022_PROGRAM_ID = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb';
 
@@ -34,21 +35,16 @@ export function registerTransferTools(server: McpServer) {
       recipientAddress: z.string().describe('Recipient Solana wallet address (base58 encoded)'),
       amount: z.number().positive().optional().describe('Amount of SOL to send (e.g., 0.5 for half a SOL). Required unless sendMax is true.'),
       sendMax: z.boolean().optional().default(false).describe('Send the maximum possible amount (entire balance minus transaction fees). When true, amount is ignored.'),
+      owsWallet: z.string().optional().describe('OWS wallet name for policy-gated signing (requires `ows` CLI installed). When provided, signs via Open Wallet Standard instead of the local keypair.'),
     },
-    async ({ recipientAddress, amount, sendMax }) => {
+    async ({ recipientAddress, amount, sendMax, owsWallet }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
-        // Load keypair
-        let signerData: { secretKey: Uint8Array; walletAddress: string };
-        try {
-          signerData = await loadSignerOrFail();
-        } catch {
-          return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before sending.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
-          );
-        }
+        // Load signer — OWS wallet or local keypair
+        const resolved = await resolveOwsOrKeypairSigner(owsWallet);
+        if (!resolved.ok) return resolved.error;
+        const { signer, walletAddress } = resolved;
 
         // Validate recipient address
         if (!isValidAddressFormat(recipientAddress)) {
@@ -59,7 +55,7 @@ export function registerTransferTools(server: McpServer) {
         }
 
         const helius = getHeliusClient();
-        const balanceResult = await helius.getBalance(signerData.walletAddress);
+        const balanceResult = await helius.getBalance(walletAddress);
         const balanceLamports = BigInt(balanceResult.value);
 
         let lamports: bigint;
@@ -82,7 +78,7 @@ export function registerTransferTools(server: McpServer) {
             const available = Number(balanceLamports) / 1_000_000_000;
             return mcpError(
               `Balance too low to cover the transaction fee. You have ${available} SOL.\n\n` +
-              `Wallet: \`${signerData.walletAddress}\``,
+              `Wallet: \`${walletAddress}\``,
               { type: 'INSUFFICIENT_FUNDS', code: 'LOW_SOL', retryable: false, recovery: `Fund the wallet with more SOL. Current balance: ${available} SOL.` }
             );
           }
@@ -102,14 +98,11 @@ export function registerTransferTools(server: McpServer) {
             const available = Number(balanceLamports) / 1_000_000_000;
             return mcpError(
               `Insufficient SOL balance. You have ${available} SOL but need ${sendAmount} SOL plus ~0.005 SOL for transaction fees.\n\n` +
-              `Wallet: \`${signerData.walletAddress}\``,
+              `Wallet: \`${walletAddress}\``,
               { type: 'INSUFFICIENT_FUNDS', code: 'LOW_SOL', retryable: false, recovery: `Fund the wallet with at least ${sendAmount + 0.005} SOL.` }
             );
           }
         }
-
-        // Create signer from keypair bytes
-        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
 
         // Build transfer instruction
         const ix = getTransferSolInstruction({
@@ -136,9 +129,10 @@ export function registerTransferTools(server: McpServer) {
           });
         }
 
+        const signerLabel = owsWallet ? `\`${walletAddress}\` (OWS: ${owsWallet})` : `\`${walletAddress}\``;
         return mcpText(
           `**SOL Transfer Sent**\n\n` +
-          `- **From:** \`${signerData.walletAddress}\`\n` +
+          `- **From:** ${signerLabel}\n` +
           `- **To:** \`${recipientAddress}\`\n` +
           `- **Amount:** ${sendAmount} SOL${sendMax ? ' (max)' : ''}\n` +
           `- **Signature:** \`${signature}\`\n` +
@@ -167,21 +161,16 @@ export function registerTransferTools(server: McpServer) {
       mintAddress: z.string().describe('Token mint address (base58 encoded, e.g., EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v for USDC)'),
       amount: z.number().positive().optional().describe('Amount of tokens to send in human-readable units (e.g., 10 for 10 USDC). Required unless sendMax is true.'),
       sendMax: z.boolean().optional().default(false).describe('Send the entire token balance and close the sender token account to reclaim rent. When true, amount is ignored.'),
+      owsWallet: z.string().optional().describe('OWS wallet name for policy-gated signing (requires `ows` CLI installed). When provided, signs via Open Wallet Standard instead of the local keypair.'),
     },
-    async ({ recipientAddress, mintAddress, amount, sendMax }) => {
+    async ({ recipientAddress, mintAddress, amount, sendMax, owsWallet }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
       try {
-        // Load keypair
-        let signerData: { secretKey: Uint8Array; walletAddress: string };
-        try {
-          signerData = await loadSignerOrFail();
-        } catch {
-          return mcpError(
-            'No keypair found. Call `generateKeypair` first to create a wallet, then fund it before sending.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
-          );
-        }
+        // Load signer — OWS wallet or local keypair
+        const resolved = await resolveOwsOrKeypairSigner(owsWallet);
+        if (!resolved.ok) return resolved.error;
+        const { signer, walletAddress } = resolved;
 
         // Validate addresses
         if (!isValidAddressFormat(recipientAddress)) {
@@ -229,8 +218,6 @@ export function registerTransferTools(server: McpServer) {
           );
         }
 
-        // Create signer from keypair bytes
-        const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
         const mint = address(mintAddress);
         const recipient = address(recipientAddress);
 
@@ -257,7 +244,7 @@ export function registerTransferTools(server: McpServer) {
           } catch {
             return mcpError(
               `No token account found for ${tokenSymbol || tokenName}. You may not hold this token.\n\n` +
-              `Wallet: \`${signerData.walletAddress}\`\n` +
+              `Wallet: \`${walletAddress}\`\n` +
               `Mint: \`${mintAddress}\``,
               { type: 'INSUFFICIENT_FUNDS', code: 'LOW_TOKEN', retryable: false, recovery: `You may not hold ${tokenSymbol || tokenName}. Check your token balances with getTokenBalances.` }
             );
@@ -266,7 +253,7 @@ export function registerTransferTools(server: McpServer) {
           if (rawAmount === 0n) {
             return mcpError(
               `${tokenSymbol || tokenName} balance is 0. Nothing to send.\n\n` +
-              `Wallet: \`${signerData.walletAddress}\`\n` +
+              `Wallet: \`${walletAddress}\`\n` +
               `Mint: \`${mintAddress}\``,
               { type: 'INSUFFICIENT_FUNDS', code: 'ZERO_BALANCE', retryable: false, recovery: `${tokenSymbol || tokenName} balance is zero. Fund the wallet with tokens before sending.` }
             );
@@ -290,7 +277,7 @@ export function registerTransferTools(server: McpServer) {
               const currentHuman = Number(currentRaw) / 10 ** decimals;
               return mcpError(
                 `Insufficient ${tokenSymbol || tokenName} balance. You have ${currentHuman} but are trying to send ${sendAmount}.\n\n` +
-                `Wallet: \`${signerData.walletAddress}\`\n` +
+                `Wallet: \`${walletAddress}\`\n` +
                 `Mint: \`${mintAddress}\``,
                 { type: 'INSUFFICIENT_FUNDS', code: 'LOW_TOKEN', retryable: false, recovery: `You have ${currentHuman} ${tokenSymbol || tokenName} but need ${sendAmount}. Fund the wallet with more tokens.` }
               );
@@ -340,9 +327,10 @@ export function registerTransferTools(server: McpServer) {
           ? `${sendAmount} ${tokenSymbol} (${tokenName})`
           : `${sendAmount} ${tokenName}`;
 
+        const signerLabel = owsWallet ? `\`${walletAddress}\` (OWS: ${owsWallet})` : `\`${walletAddress}\``;
         return mcpText(
           `**Token Transfer Sent**\n\n` +
-          `- **From:** \`${signerData.walletAddress}\`\n` +
+          `- **From:** ${signerLabel}\n` +
           `- **To:** \`${recipientAddress}\`\n` +
           `- **Amount:** ${displayName}${sendMax ? ' (max)' : ''}\n` +
           `- **Mint:** \`${mintAddress}\`\n` +

--- a/helius-mcp/src/utils/ows.ts
+++ b/helius-mcp/src/utils/ows.ts
@@ -11,15 +11,27 @@
  * expects ({ address, signTransactions, signMessages }), so it plugs directly
  * into the Helius SDK's sendTransactionWithSender / sendSmartTransaction
  * without losing priority-fee estimation, SWQoS routing, or Jito tips.
+ *
+ * NOTE: The CLI helpers (isOwsInstalled, getOwsSolanaAddress) are mirrored in
+ * helius-cli/src/lib/ows.ts.  Keep the two copies in sync when changing
+ * argument handling, CAIP-2 lookup logic, or OWS CLI flags.
  */
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { address, createKeyPairSignerFromBytes, type Address } from '@solana/kit';
-import { loadSignerOrFail } from './helius.js';
+import { loadSignerOrFail, getNetwork } from './helius.js';
 import { mcpError } from './errors.js';
 
 const execFileAsync = promisify(execFile);
+
+// CAIP-2 chain identifiers for Solana networks.
+// See OWS spec 07-supported-chains.md.
+const SOLANA_CAIP2_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+const SOLANA_CAIP2_DEVNET = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG';
+
+/** Alphanumeric, hyphens, and underscores — matches OWS wallet naming rules. */
+const WALLET_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
 // ── CLI helpers ──
 
@@ -36,9 +48,27 @@ export async function isOwsInstalled(): Promise<boolean> {
 }
 
 /**
+ * Validate wallet name format before passing to execFile.
+ * While execFile prevents shell injection, a garbage name produces
+ * confusing OWS CLI errors — better to catch it early.
+ */
+function validateWalletName(name: string): void {
+  if (!WALLET_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid OWS wallet name "${name}". ` +
+      `Names must be 1-64 characters using letters, digits, hyphens, or underscores.`,
+    );
+  }
+}
+
+/**
  * Return the Solana address for the named OWS wallet.
+ * Uses the current MCP session network (mainnet or devnet) to select
+ * the correct CAIP-2 chain key.
  */
 export async function getOwsSolanaAddress(walletName: string): Promise<string> {
+  validateWalletName(walletName);
+
   const { stdout } = await execFileAsync(
     'ows',
     ['wallet', 'info', '--wallet', walletName, '--json'],
@@ -47,10 +77,11 @@ export async function getOwsSolanaAddress(walletName: string): Promise<string> {
   const info = JSON.parse(stdout);
 
   // The CLI outputs accounts keyed by CAIP-2 chain id.
-  // Look for the Solana mainnet account.
-  const solanaKey = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+  // Pick the key matching the active network.
+  const network = getNetwork();
+  const primaryKey = network === 'devnet' ? SOLANA_CAIP2_DEVNET : SOLANA_CAIP2_MAINNET;
   const account =
-    info.accounts?.[solanaKey] ??
+    info.accounts?.[primaryKey] ??
     info.accounts?.solana ??
     // Fallback: scan for any key containing "solana"
     Object.entries(info.accounts ?? {}).find(([k]) => k.includes('solana'))?.[1];
@@ -72,6 +103,7 @@ export async function getOwsSolanaAddress(walletName: string): Promise<string> {
 
 /**
  * Sign raw message bytes via OWS.  Returns the 64-byte Ed25519 signature.
+ * Assumes walletName was already validated by the caller (createOwsSigner).
  */
 async function owsSignBytes(walletName: string, messageHex: string): Promise<Uint8Array> {
   const { stdout } = await execFileAsync(
@@ -119,6 +151,12 @@ export interface OwsSigner {
  *
  * The returned `signer` is typed as `any` to avoid @solana/kit branded-type
  * friction — it satisfies `isTransactionSigner()` at runtime.
+ *
+ * ⚠ If @solana/kit changes its signer interface (signTransactions /
+ * signMessages argument or return shapes), these casts will pass type-checking
+ * but fail at runtime.  After any @solana/kit upgrade, verify the OWS signer
+ * still passes `isTransactionSigner()` and produces valid signatures in the
+ * full `signTransactionMessageWithSigners` pipeline.
  */
 export async function resolveOwsOrKeypairSigner(owsWallet?: string): Promise<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,6 +164,12 @@ export async function resolveOwsOrKeypairSigner(owsWallet?: string): Promise<
   | { ok: false; error: ReturnType<typeof mcpError> }
 > {
   if (owsWallet) {
+    if (!WALLET_NAME_RE.test(owsWallet)) {
+      return { ok: false, error: mcpError(
+        `Invalid OWS wallet name "${owsWallet}". Names must be 1-64 characters using letters, digits, hyphens, or underscores.`,
+        { type: 'VALIDATION', code: 'INVALID_WALLET_NAME', retryable: false, recovery: 'Provide a valid wallet name (letters, digits, hyphens, underscores).' },
+      ) };
+    }
     if (!await isOwsInstalled()) {
       return { ok: false, error: mcpError(
         'OWS CLI is not installed. Install it with `curl -fsSL https://docs.openwallet.sh/install.sh | bash` or `npm install -g @open-wallet-standard/core`.',

--- a/helius-mcp/src/utils/ows.ts
+++ b/helius-mcp/src/utils/ows.ts
@@ -1,0 +1,189 @@
+/**
+ * Open Wallet Standard (OWS) integration.
+ *
+ * Provides an optional, additive signing path that delegates to the `ows` CLI
+ * for policy-gated, key-isolated transaction signing.  When an `owsWallet`
+ * parameter is supplied, transfers and staking tools use an OWS-backed signer
+ * instead of the local keypair.  If OWS is not installed, callers get a clear
+ * error — existing keypair flows are unaffected.
+ *
+ * The adapter implements the same duck-typed signer interface that @solana/kit
+ * expects ({ address, signTransactions, signMessages }), so it plugs directly
+ * into the Helius SDK's sendTransactionWithSender / sendSmartTransaction
+ * without losing priority-fee estimation, SWQoS routing, or Jito tips.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { address, createKeyPairSignerFromBytes, type Address } from '@solana/kit';
+import { loadSignerOrFail } from './helius.js';
+import { mcpError } from './errors.js';
+
+const execFileAsync = promisify(execFile);
+
+// ── CLI helpers ──
+
+/**
+ * True when the `ows` binary is reachable on PATH.
+ */
+export async function isOwsInstalled(): Promise<boolean> {
+  try {
+    await execFileAsync('ows', ['--version'], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return the Solana address for the named OWS wallet.
+ */
+export async function getOwsSolanaAddress(walletName: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    'ows',
+    ['wallet', 'info', '--wallet', walletName, '--json'],
+    { timeout: 10_000 },
+  );
+  const info = JSON.parse(stdout);
+
+  // The CLI outputs accounts keyed by CAIP-2 chain id.
+  // Look for the Solana mainnet account.
+  const solanaKey = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+  const account =
+    info.accounts?.[solanaKey] ??
+    info.accounts?.solana ??
+    // Fallback: scan for any key containing "solana"
+    Object.entries(info.accounts ?? {}).find(([k]) => k.includes('solana'))?.[1];
+
+  if (!account) {
+    throw new Error(
+      `OWS wallet "${walletName}" has no Solana account.  ` +
+      `Run \`ows wallet info --wallet ${walletName}\` to inspect.`,
+    );
+  }
+
+  // Account may be a string (address) or an object with an address field.
+  const addr: string = typeof account === 'string' ? account : account.address;
+  if (!addr) {
+    throw new Error(`Could not extract Solana address from OWS wallet "${walletName}".`);
+  }
+  return addr;
+}
+
+/**
+ * Sign raw message bytes via OWS.  Returns the 64-byte Ed25519 signature.
+ */
+async function owsSignBytes(walletName: string, messageHex: string): Promise<Uint8Array> {
+  const { stdout } = await execFileAsync(
+    'ows',
+    ['sign', 'message', '--wallet', walletName, '--chain', 'solana', '--message', messageHex, '--encoding', 'hex', '--json'],
+    { timeout: 30_000 },
+  );
+  const result = JSON.parse(stdout);
+  const sigHex: string = result.signature;
+  if (!sigHex) {
+    throw new Error('OWS sign returned no signature');
+  }
+  return Uint8Array.from(Buffer.from(sigHex, 'hex'));
+}
+
+// ── Signer adapter ──
+
+/**
+ * A duck-typed @solana/kit TransactionPartialSigner backed by OWS.
+ *
+ * Passes `isTransactionSigner()` checks and works with
+ * `setTransactionMessageFeePayerSigner`, `signTransactionMessageWithSigners`,
+ * `sendTransactionWithSender`, and `sendSmartTransaction`.
+ *
+ * IMPORTANT: `signTransactions` and `signMessages` return **partial signature
+ * maps** (`{ [address]: signatureBytes }`), NOT full transaction/message objects.
+ * This matches the contract that `@solana/kit`'s `signTransactionMessageWithSigners`
+ * expects — it merges the partial maps back into the compiled transaction itself.
+ */
+export interface OwsSigner {
+  address: Address;
+  signTransactions: (
+    transactions: readonly { messageBytes: Uint8Array }[],
+  ) => Promise<readonly Record<string, Uint8Array>[]>;
+  signMessages: (
+    messages: readonly { content: Uint8Array }[],
+  ) => Promise<readonly Record<string, Uint8Array>[]>;
+}
+
+// ── Shared signer resolution ──
+
+/**
+ * Resolve a signer from an OWS wallet name or the local Helius keypair.
+ * Returns a result-union so callers can return the MCP error directly.
+ *
+ * The returned `signer` is typed as `any` to avoid @solana/kit branded-type
+ * friction — it satisfies `isTransactionSigner()` at runtime.
+ */
+export async function resolveOwsOrKeypairSigner(owsWallet?: string): Promise<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | { ok: true; signer: any; walletAddress: string; owsWallet?: string }
+  | { ok: false; error: ReturnType<typeof mcpError> }
+> {
+  if (owsWallet) {
+    if (!await isOwsInstalled()) {
+      return { ok: false, error: mcpError(
+        'OWS CLI is not installed. Install it with `curl -fsSL https://docs.openwallet.sh/install.sh | bash` or `npm install -g @open-wallet-standard/core`.',
+        { type: 'AUTH', code: 'OWS_NOT_INSTALLED', retryable: false, recovery: 'Install the OWS CLI, then retry.' },
+      ) };
+    }
+    try {
+      const signer = await createOwsSigner(owsWallet);
+      return { ok: true, signer, walletAddress: signer.address, owsWallet };
+    } catch (err: any) {
+      return { ok: false, error: mcpError(
+        `Failed to load OWS wallet "${owsWallet}": ${err.message}`,
+        { type: 'AUTH', code: 'OWS_WALLET_ERROR', retryable: false, recovery: 'Run `ows wallet list` to see available wallets.' },
+      ) };
+    }
+  }
+
+  try {
+    const signerData = await loadSignerOrFail();
+    const signer = await createKeyPairSignerFromBytes(signerData.secretKey);
+    return { ok: true, signer, walletAddress: signerData.walletAddress };
+  } catch {
+    return { ok: false, error: mcpError(
+      'No keypair found. Call `generateKeypair` first to create a wallet.',
+      { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' },
+    ) };
+  }
+}
+
+export async function createOwsSigner(walletName: string): Promise<OwsSigner> {
+  const solAddress = await getOwsSolanaAddress(walletName);
+  const addr = address(solAddress);
+
+  return {
+    address: addr,
+
+    async signTransactions(
+      transactions: readonly { messageBytes: Uint8Array }[],
+    ): Promise<readonly Record<string, Uint8Array>[]> {
+      return Promise.all(
+        transactions.map(async (tx) => {
+          const msgHex = Buffer.from(tx.messageBytes).toString('hex');
+          const sig = await owsSignBytes(walletName, msgHex);
+          return { [addr]: sig };
+        }),
+      );
+    },
+
+    async signMessages(
+      messages: readonly { content: Uint8Array }[],
+    ): Promise<readonly Record<string, Uint8Array>[]> {
+      return Promise.all(
+        messages.map(async (msg) => {
+          const hex = Buffer.from(msg.content).toString('hex');
+          const sig = await owsSignBytes(walletName, hex);
+          return { [addr]: sig };
+        }),
+      );
+    },
+  };
+}


### PR DESCRIPTION
This PR adds Open Wallet Standard (OWS) as an optional, additive signing backend for MCP transfer/staking tools and CLI wallet commands. When `owsWallet` is provided, signing delegates to the `ows` CLI's policy-gated, key-isolated path. When omitted, the existing keypair flow is unchanged 