### PR TITLE
feat(cli): Add `helius update` Self-update Command

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -53,6 +53,7 @@ import { sendBroadcastCommand, sendRawCommand, sendSenderCommand, sendPollComman
 import { wsAccountCommand, wsLogsCommand, wsSlotCommand, wsSignatureCommand, wsProgramCommand } from "../src/commands/ws.js";
 import { simdListCommand, simdGetCommand } from "../src/commands/simd.js";
 import { owsLinkCommand, owsUnlinkCommand, owsStatusCommand } from "../src/commands/ows.js";
+import { updateCommand } from "../src/commands/update.js";
 import { VERSION } from "../src/constants.js";
 import { sendCommandEvent, sendCliFeedback, setCurrentCommand } from "../src/lib/feedback.js";
 
@@ -836,6 +837,15 @@ simdCmd
   .description("Read a specific SIMD proposal by number")
   .option("--json", "Output in JSON format")
   .action(function(this: any, number: string) { simdGetCommand(number, opts(this)); });
+
+// ── Update ──
+
+program
+  .command("update")
+  .description("Check for and install CLI updates")
+  .option("--check", "Check for updates without installing")
+  .option("--json", "Output in JSON format")
+  .action(function(this: any) { updateCommand(opts(this)); });
 
 // ── Feedback ──
 

--- a/helius-cli/src/commands/update.ts
+++ b/helius-cli/src/commands/update.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import chalk from "chalk";
 import { VERSION } from "../constants.js";
-import { outputJson, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, createSpinner, handleCommandError, type OutputOptions } from "../lib/output.js";
 
 interface UpdateOptions extends OutputOptions {
   check?: boolean;
@@ -95,17 +95,7 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<void> 
     } catch (execError: any) {
       const stderr = execError?.stderr?.toString() || "";
       if (stderr.includes("EACCES") || stderr.includes("permission denied")) {
-        spinner?.fail("Permission denied");
-        if (options.json) {
-          outputJson({
-            error: "PERMISSION_DENIED",
-            message: `Permission denied. Try: sudo ${cmd}`,
-            retryable: true,
-          });
-        } else {
-          console.error(chalk.yellow(`\n  Hint: Run with elevated permissions: ${chalk.cyan("sudo " + cmd)}`));
-        }
-        process.exit(1);
+        throw new Error(`Permission denied. Try: sudo ${cmd}`);
       }
       throw execError;
     }
@@ -116,11 +106,6 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<void> 
       outputJson({ previous: VERSION, current: latest, updated: true, packageManager: pm });
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    spinner?.fail(message);
-    if (options.json) {
-      outputJson({ error: "UPDATE_FAILED", message, retryable: true });
-    }
-    process.exit(1);
+    handleCommandError(error, options, spinner);
   }
 }

--- a/helius-cli/src/commands/update.ts
+++ b/helius-cli/src/commands/update.ts
@@ -113,7 +113,7 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<void> 
     spinner?.succeed(`Updated helius-cli v${VERSION} → v${latest}`);
 
     if (options.json) {
-      outputJson({ current: VERSION, latest, updated: true, packageManager: pm });
+      outputJson({ previous: VERSION, current: latest, updated: true, packageManager: pm });
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/helius-cli/src/commands/update.ts
+++ b/helius-cli/src/commands/update.ts
@@ -38,9 +38,11 @@ function compareSemver(a: string, b: string): number {
  */
 function detectPackageManager(): "pnpm" | "volta" | "bun" | "npm" {
   const execPath = process.argv[1] || "";
-  if (execPath.includes(".pnpm") || execPath.includes("pnpm")) return "pnpm";
-  if (execPath.includes(".volta") || execPath.includes("volta")) return "volta";
-  if (execPath.includes(".bun") || execPath.includes("bun")) return "bun";
+  // Normalize to forward slashes for consistent matching
+  const normalized = execPath.replace(/\\/g, "/");
+  if (/[/]\.?pnpm[/]/.test(normalized)) return "pnpm";
+  if (/[/]\.?volta[/]/.test(normalized)) return "volta";
+  if (/[/]\.?bun[/]/.test(normalized)) return "bun";
   return "npm";
 }
 

--- a/helius-cli/src/commands/update.ts
+++ b/helius-cli/src/commands/update.ts
@@ -1,0 +1,124 @@
+import { execSync } from "child_process";
+import chalk from "chalk";
+import { VERSION } from "../constants.js";
+import { outputJson, createSpinner, type OutputOptions } from "../lib/output.js";
+
+interface UpdateOptions extends OutputOptions {
+  check?: boolean;
+}
+
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/helius-cli/latest";
+
+async function fetchLatestVersion(): Promise<string> {
+  const res = await fetch(NPM_REGISTRY_URL);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch latest version from npm (HTTP ${res.status})`);
+  }
+  const data = (await res.json()) as { version: string };
+  return data.version;
+}
+
+/**
+ * Compare two semver strings. Returns:
+ *   -1 if a < b, 0 if equal, 1 if a > b
+ */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1;
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Detect which package manager was used to install the CLI globally,
+ * based on the resolved path of the running binary.
+ */
+function detectPackageManager(): "pnpm" | "volta" | "bun" | "npm" {
+  const execPath = process.argv[1] || "";
+  if (execPath.includes(".pnpm") || execPath.includes("pnpm")) return "pnpm";
+  if (execPath.includes(".volta") || execPath.includes("volta")) return "volta";
+  if (execPath.includes(".bun") || execPath.includes("bun")) return "bun";
+  return "npm";
+}
+
+function getUpdateCommand(pm: string): string {
+  switch (pm) {
+    case "pnpm":  return "pnpm add -g helius-cli@latest";
+    case "volta":  return "volta install helius-cli@latest";
+    case "bun":    return "bun add -g helius-cli@latest";
+    default:       return "npm install -g helius-cli@latest";
+  }
+}
+
+export async function updateCommand(options: UpdateOptions = {}): Promise<void> {
+  const spinner = createSpinner(options);
+  try {
+    spinner?.start("Checking for updates...");
+    const latest = await fetchLatestVersion();
+    const cmp = compareSemver(VERSION, latest);
+
+    if (cmp >= 0) {
+      spinner?.stop();
+      if (options.json) {
+        outputJson({ current: VERSION, latest, upToDate: true });
+      } else {
+        console.log(chalk.green(`\n  helius-cli is up to date (v${VERSION})`));
+      }
+      return;
+    }
+
+    // Update available
+    if (options.check) {
+      spinner?.stop();
+      if (options.json) {
+        outputJson({ current: VERSION, latest, upToDate: false });
+      } else {
+        console.log(`\n  Current: ${chalk.gray("v" + VERSION)}`);
+        console.log(`  Latest:  ${chalk.green("v" + latest)}`);
+        console.log(`\n  Run ${chalk.cyan("helius update")} to install the latest version.`);
+      }
+      return;
+    }
+
+    // Perform the update
+    const pm = detectPackageManager();
+    const cmd = getUpdateCommand(pm);
+    spinner?.start(`Updating v${VERSION} → v${latest} via ${pm}...`);
+
+    try {
+      execSync(cmd, { stdio: "pipe" });
+    } catch (execError: any) {
+      const stderr = execError?.stderr?.toString() || "";
+      if (stderr.includes("EACCES") || stderr.includes("permission denied")) {
+        spinner?.fail("Permission denied");
+        if (options.json) {
+          outputJson({
+            error: "PERMISSION_DENIED",
+            message: `Permission denied. Try: sudo ${cmd}`,
+            retryable: true,
+          });
+        } else {
+          console.error(chalk.yellow(`\n  Hint: Run with elevated permissions: ${chalk.cyan("sudo " + cmd)}`));
+        }
+        process.exit(1);
+      }
+      throw execError;
+    }
+
+    spinner?.succeed(`Updated helius-cli v${VERSION} → v${latest}`);
+
+    if (options.json) {
+      outputJson({ current: VERSION, latest, updated: true, packageManager: pm });
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    spinner?.fail(message);
+    if (options.json) {
+      outputJson({ error: "UPDATE_FAILED", message, retryable: true });
+    }
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
This PR adds a `helius update` command that checks npm for the latest version and installs it. It also supports `--check` to report without installing and `--json` for machine-readable output. The command auto-detects the package manager from the install path and handles permission errors with an actionable `sudo` hint