### PR TITLE
fix(cli): Improve WS Error Handling With Guidance Hints and Telemetry

### DIFF
--- a/helius-cli/src/commands/ws.ts
+++ b/helius-cli/src/commands/ws.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { jsonReplacer, classifyError, type OutputOptions } from "../lib/output.js";
+import { jsonReplacer, classifyError, CLI_GUIDANCE, type OutputOptions } from "../lib/output.js";
+import { sendCommandEvent, getCurrentCommand } from "../lib/feedback.js";
 
 interface WsOptions extends OutputOptions, ResolveOptions {}
 
@@ -30,19 +31,27 @@ async function streamSubscription(
 }
 
 function handleWsError(error: unknown, options: WsOptions): void {
-  if ((error as any)?.name === "AbortError") return;
+  if (error instanceof Error && error.name === "AbortError") return;
   const { exitCode, errorCode, retryable } = classifyError(error);
   const message = error instanceof Error ? error.message : String(error);
+  const guidance = CLI_GUIDANCE[errorCode];
+
+  const cmdName = getCurrentCommand() || "unknown";
+  sendCommandEvent(cmdName, { exitCode, success: false });
+
   if (options.json) {
-    emitEvent("error", { error: errorCode, message, retryable });
+    emitEvent("error", { error: errorCode, message, retryable, ...(guidance ? { guidance } : {}) });
   } else {
     const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
     console.error(chalk.red(`Error: ${message}${hint}`));
+    if (guidance) {
+      console.error(chalk.yellow(`\n  Hint: ${guidance}`));
+    }
   }
   process.exit(exitCode);
 }
 
-function setupShutdown(helius: any, abortController: AbortController, label: string, options: WsOptions): void {
+function setupShutdown(helius: { ws: { close(): void } }, abortController: AbortController, label: string, options: WsOptions): void {
   if (options.json) {
     emitEvent("connected", { subscription: label });
   } else {

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -213,7 +213,7 @@ export function classifyError(error: unknown): ErrorClassification {
  *
  *   handleCommandError(error, options, spinner, "AUTH_FAILED");
  */
-const CLI_GUIDANCE: Record<string, string> = {
+export const CLI_GUIDANCE: Record<string, string> = {
   INVALID_API_KEY: 'Run `helius config set-api-key <key>` with a valid key, or `helius usage` to check your current plan and credits.',
   RATE_LIMITED: 'Run `helius usage` to check remaining credits. Back off and retry, or upgrade your plan for higher limits.',
   NO_API_KEY: 'Run `helius config set-api-key <key>` or set HELIUS_API_KEY env var. Get a key at https://dashboard.helius.dev.',


### PR DESCRIPTION
This PR aims to improve our CLI's WebSocket error handling with guidance hints and telemetry. We:
- Add `CLI_GUIDANCE` hints to error output (JSON and formatted)
- Add telemetry tracking for `ws` command errors via `sendCommandEvent`
- Fix `AbortError` type check from unsafe `as any` cast to `instanceof Error`
- Type `setupShutdown` helius param instead of `any`
- Export `CLI_GUIDANCE` from `output.ts` for reuse 