### PR TITLE
fix(cli): `exitWithError` Outputting JSON in Non-JSON Mode

### DIFF
--- a/helius-cli/src/commands/apikeys.ts
+++ b/helius-cli/src/commands/apikeys.ts
@@ -45,11 +45,11 @@ export async function apikeysCommand(projectId?: string, options: ApikeysOptions
   try {
     const jwt = getJwt();
     if (!jwt) {
-      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, !!options.json);
     }
 
     spinner?.start("Fetching API keys...");
-    const id = await resolveProjectId(jwt, projectId, options.json);
+    const id = await resolveProjectId(jwt, projectId, !!options.json);
     const project = await getProject(jwt, id);
     spinner?.stop();
 
@@ -106,7 +106,7 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
   try {
     const jwt = getJwt();
     if (!jwt) {
-      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, !!options.json);
     }
 
     // Get wallet address from the first project's users (the owner)
@@ -114,14 +114,14 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
     const projects = await listProjects(jwt);
 
     if (projects.length === 0) {
-      exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
+      exitWithError("NO_PROJECTS", "No projects found", undefined, !!options.json);
     }
 
     const id = projectId || projects[0].id;
     const project = projects.find(p => p.id === id);
 
     if (!project) {
-      exitWithError("PROJECT_NOT_FOUND", `Project ${id} not found`, undefined, options.json);
+      exitWithError("PROJECT_NOT_FOUND", `Project ${id} not found`, undefined, !!options.json);
     }
 
     // Get wallet address from the project users (the owner)
@@ -129,7 +129,7 @@ export async function createApiKeyCommand(projectId?: string, options: CreateApi
     const walletAddress = owner?.id;
 
     if (!walletAddress) {
-      exitWithError("API_ERROR", "Could not determine wallet address from project", undefined, options.json);
+      exitWithError("API_ERROR", "Could not determine wallet address from project", undefined, !!options.json);
     }
 
     if (spinner) spinner.text = "Creating API key...";

--- a/helius-cli/src/commands/config-cmd.ts
+++ b/helius-cli/src/commands/config-cmd.ts
@@ -45,7 +45,7 @@ export function configSetApiKeyCommand(key: string, options: OutputOptions = {})
 
 export function configSetNetworkCommand(network: string, options: OutputOptions = {}): void {
   if (network !== "mainnet" && network !== "devnet") {
-    exitWithError("INVALID_INPUT", `Invalid network: ${network}. Use "mainnet" or "devnet".`, undefined, options.json);
+    exitWithError("INVALID_INPUT", `Invalid network: ${network}. Use "mainnet" or "devnet".`, undefined, !!options.json);
   }
   const resolved = network as "mainnet" | "devnet";
   setNetwork(resolved);

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -15,7 +15,7 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
   try {
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
-      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
+      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, !!options.json);
     }
 
     // Load keypair

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -29,7 +29,7 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
   try {
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
-      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
+      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, !!options.json);
     }
 
     // 1. Load keypair and authenticate
@@ -62,7 +62,7 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
     }
 
     if (intent.status !== "pending") {
-      exitWithError("PAYMENT_FAILED", `Payment intent is ${intent.status}, cannot pay`, { intentId: intent.id }, options.json);
+      exitWithError("PAYMENT_FAILED", `Payment intent is ${intent.status}, cannot pay`, { intentId: intent.id }, !!options.json);
     }
 
     if (!options.yes) {

--- a/helius-cli/src/commands/project.ts
+++ b/helius-cli/src/commands/project.ts
@@ -10,7 +10,7 @@ export async function projectCommand(projectId?: string, options: OutputOptions 
   try {
     const jwt = getJwt();
     if (!jwt) {
-      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, !!options.json);
     }
 
     // If no project ID provided, try to get the only project
@@ -22,14 +22,14 @@ export async function projectCommand(projectId?: string, options: OutputOptions 
       spinner?.stop();
 
       if (projects.length === 0) {
-        exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
+        exitWithError("NO_PROJECTS", "No projects found", undefined, !!options.json);
       }
 
       if (projects.length > 1) {
         if (options.json) {
           exitWithError("MULTIPLE_PROJECTS", "Multiple projects found, specify project ID", {
             projects: projects.map(p => ({ id: p.id, name: p.name })),
-          }, options.json);
+          }, !!options.json);
         }
         console.log(
           chalk.yellow(

--- a/helius-cli/src/commands/projects.ts
+++ b/helius-cli/src/commands/projects.ts
@@ -9,7 +9,7 @@ export async function projectsCommand(options: OutputOptions): Promise<void> {
   try {
     const jwt = getJwt();
     if (!jwt) {
-      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, !!options.json);
     }
 
     spinner?.start("Fetching projects...");

--- a/helius-cli/src/commands/rpc.ts
+++ b/helius-cli/src/commands/rpc.ts
@@ -10,7 +10,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
   try {
     const jwt = getJwt();
     if (!jwt) {
-      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, !!options.json);
     }
 
     spinner?.start("Fetching projects...");
@@ -18,34 +18,29 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
     spinner?.stop();
 
     if (projects.length === 0) {
-      exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
+      exitWithError("NO_PROJECTS", "No projects found", undefined, !!options.json);
     }
 
     // If no project ID provided, try to get the only project
     let project;
     if (!projectId) {
       if (projects.length > 1) {
-        if (options.json) {
-          exitWithError("MULTIPLE_PROJECTS", "Multiple projects found, specify project ID", {
-            projects: projects.map(p => ({ id: p.id, name: p.name })),
-          }, options.json);
+        if (!options.json) {
+          console.log(chalk.yellow("Multiple projects found. Please specify a project ID."));
+          console.log("\nAvailable projects:");
+          for (const p of projects) {
+            console.log(`  ${chalk.cyan(p.id)} - ${p.name || "Unnamed"}`);
+          }
         }
-        console.log(
-          chalk.yellow(
-            "Multiple projects found. Please specify a project ID."
-          )
-        );
-        console.log("\nAvailable projects:");
-        for (const p of projects) {
-          console.log(`  ${chalk.cyan(p.id)} - ${p.name || "Unnamed"}`);
-        }
-        process.exit(ExitCode.MULTIPLE_PROJECTS);
+        exitWithError("MULTIPLE_PROJECTS", "Multiple projects found, specify project ID", {
+          projects: projects.map(p => ({ id: p.id, name: p.name })),
+        }, !!options.json);
       }
       project = projects[0];
     } else {
       project = projects.find(p => p.id === projectId);
       if (!project) {
-        exitWithError("PROJECT_NOT_FOUND", `Project ${projectId} not found`, undefined, options.json);
+        exitWithError("PROJECT_NOT_FOUND", `Project ${projectId} not found`, undefined, !!options.json);
       }
     }
 
@@ -59,7 +54,7 @@ export async function rpcCommand(projectId?: string, options: OutputOptions = {}
       spinner?.stop();
 
       if (!fullProject.apiKeys || fullProject.apiKeys.length === 0) {
-        exitWithError("NO_API_KEYS", "No API keys found", undefined, options.json);
+        exitWithError("NO_API_KEYS", "No API keys found", undefined, !!options.json);
       }
 
       const apiKey = fullProject.apiKeys[0].keyId;

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -87,22 +87,22 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
     // Validate plan and period upfront
     if (options.plan) {
       const planErr = validateSignupPlan(options.plan);
-      if (planErr) exitWithError("INVALID_INPUT", planErr, undefined, options.json);
+      if (planErr) exitWithError("INVALID_INPUT", planErr, undefined, !!options.json);
     }
     if (options.period) {
       const periodErr = validatePeriod(options.period);
-      if (periodErr) exitWithError("INVALID_INPUT", periodErr, undefined, options.json);
+      if (periodErr) exitWithError("INVALID_INPUT", periodErr, undefined, !!options.json);
     }
     if (options.email) {
       const emailErr = validateEmail(options.email);
-      if (emailErr) exitWithError("INVALID_INPUT", emailErr, undefined, options.json);
+      if (emailErr) exitWithError("INVALID_INPUT", emailErr, undefined, !!options.json);
     }
 
     // Auto-generate keypair if none exists
     if (!keypairExists(options.keypair)) {
       if (options.json) {
         // In JSON mode, don't do interactive keygen — just error
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
+        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, !!options.json);
       }
       console.log(chalk.yellow("No keypair found. Generating one automatically...\n"));
       await keygenCommand({ output: options.keypair });
@@ -151,7 +151,7 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
           exitWithError("INSUFFICIENT_FUNDS", `Need more funds: ${missing.join(", ")}`, {
             wallet: walletAddress,
             required: { sol: solOk ? undefined : "~0.001 SOL", usdc: usdcOk ? undefined : requiredUsdcLabel },
-          }, options.json);
+          }, !!options.json);
         }
         console.error(chalk.red(`\nInsufficient funds. Send the following to ${chalk.cyan(walletAddress)}:`));
         for (const m of missing) {

--- a/helius-cli/src/commands/simd.ts
+++ b/helius-cli/src/commands/simd.ts
@@ -107,7 +107,7 @@ export async function simdGetCommand(number: string, options: SimdGetOptions = {
   const spinner = createSpinner(options);
   try {
     if (!/^\d+$/.test(number)) {
-      exitWithError("INVALID_INPUT", `Invalid SIMD number: "${number}". Must be numeric.`, undefined, options.json);
+      exitWithError("INVALID_INPUT", `Invalid SIMD number: "${number}". Must be numeric.`, undefined, !!options.json);
     }
 
     const paddedNumber = number.replace(/^0+/, "").padStart(4, "0");
@@ -131,7 +131,7 @@ export async function simdGetCommand(number: string, options: SimdGetOptions = {
         .join("\n");
 
       if (options.json) {
-        exitWithError("NOT_FOUND", `SIMD-${paddedNumber} not found`, undefined, options.json);
+        exitWithError("NOT_FOUND", `SIMD-${paddedNumber} not found`, undefined, !!options.json);
       }
 
       console.log(chalk.yellow(`\nSIMD-${paddedNumber} not found.`));

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -121,7 +121,7 @@ export async function stakeWithdrawInstructionCommand(stakeAccount: string, opti
 export async function stakeCreateCommand(amount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   if (!options.keypair) {
-    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
+    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
     spinner?.start("Resolving API key...");
@@ -147,7 +147,7 @@ export async function stakeCreateCommand(amount: string, options: StakeOptions &
 export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   if (!options.keypair) {
-    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
+    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
     spinner?.start("Resolving API key...");
@@ -171,7 +171,7 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
 export async function stakeWithdrawCommand(stakeAccount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   if (!options.keypair) {
-    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, options.json);
+    exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
     spinner?.start("Resolving API key...");

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -36,10 +36,10 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     // Validate plan, period, and email upfront
     const planKey = options.plan.toLowerCase();
     const planErr = validateUpgradePlan(options.plan);
-    if (planErr) exitWithError("INVALID_INPUT", planErr, undefined, options.json);
+    if (planErr) exitWithError("INVALID_INPUT", planErr, undefined, !!options.json);
 
     const periodErr = validatePeriod(options.period);
-    if (periodErr) exitWithError("INVALID_INPUT", periodErr, undefined, options.json);
+    if (periodErr) exitWithError("INVALID_INPUT", periodErr, undefined, !!options.json);
 
     // All-or-none customer info validation
     const hasAnyCustomerInfo = options.email || options.firstName || options.lastName;
@@ -49,17 +49,17 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
         !options.firstName && "firstName",
         !options.lastName && "lastName",
       ].filter(Boolean);
-      exitWithError("INVALID_INPUT", `Partial customer info. If any of --email/--first-name/--last-name is given, all three are required. Missing: ${missing.join(", ")}`, undefined, options.json);
+      exitWithError("INVALID_INPUT", `Partial customer info. If any of --email/--first-name/--last-name is given, all three are required. Missing: ${missing.join(", ")}`, undefined, !!options.json);
     }
 
     if (options.email) {
       const emailErr = validateEmail(options.email);
-      if (emailErr) exitWithError("INVALID_INPUT", emailErr, undefined, options.json);
+      if (emailErr) exitWithError("INVALID_INPUT", emailErr, undefined, !!options.json);
     }
 
     // Check keypair exists
     if (!keypairExists(options.keypair)) {
-      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, options.json);
+      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, !!options.json);
     }
 
     // 1. Load keypair and authenticate
@@ -78,7 +78,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     spinner?.start("Fetching project...");
     const projects = await listProjects(authResult.token);
     if (projects.length === 0) {
-      exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
+      exitWithError("NO_PROJECTS", "No projects found", undefined, !!options.json);
     }
     const project = projects[0];
     const projectDetails = await getProject(authResult.token, project.id);

--- a/helius-cli/src/commands/usage.ts
+++ b/helius-cli/src/commands/usage.ts
@@ -9,7 +9,7 @@ export async function usageCommand(projectId?: string, options: OutputOptions = 
   try {
     const jwt = getJwt();
     if (!jwt) {
-      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, options.json);
+      exitWithError("NOT_LOGGED_IN", "Not logged in", undefined, !!options.json);
     }
 
     // If no project ID provided, try to get the only project
@@ -20,14 +20,14 @@ export async function usageCommand(projectId?: string, options: OutputOptions = 
       spinner?.stop();
 
       if (projects.length === 0) {
-        exitWithError("NO_PROJECTS", "No projects found", undefined, options.json);
+        exitWithError("NO_PROJECTS", "No projects found", undefined, !!options.json);
       }
 
       if (projects.length > 1) {
         if (options.json) {
           exitWithError("MULTIPLE_PROJECTS", "Multiple projects found, specify project ID", {
             projects: projects.map(p => ({ id: p.id, name: p.name })),
-          }, options.json);
+          }, !!options.json);
         }
         console.log(
           chalk.yellow(

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -79,7 +79,7 @@ export async function webhookCreateCommand(options: WebhookOptions & {
 
     // Validate addresses before sending to API
     const addrErr = validateSolanaAddresses(options.accounts);
-    if (addrErr) exitWithError("INVALID_INPUT", addrErr, undefined, options.json);
+    if (addrErr) exitWithError("INVALID_INPUT", addrErr, undefined, !!options.json);
 
     const accountAddresses = options.accounts.split(",").map((s: string) => s.trim()).filter(Boolean);
     const transactionTypes = options.types.split(",").map((s: string) => s.trim()).filter(Boolean);
@@ -118,7 +118,7 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
     // Validate addresses if provided
     if (options.accounts) {
       const addrErr = validateSolanaAddresses(options.accounts);
-      if (addrErr) exitWithError("INVALID_INPUT", addrErr, undefined, options.json);
+      if (addrErr) exitWithError("INVALID_INPUT", addrErr, undefined, !!options.json);
     }
     if (options.url) params.webhookURL = options.url;
     if (options.accounts) params.accountAddresses = options.accounts.split(",").map((s: string) => s.trim()).filter(Boolean);


### PR DESCRIPTION
This PR fixes an issue where `exitWithError()` outputs JSON when `--json` was not passed. The 4th param defaults to `true`, but `options.json` is `undefined` (i.e., not `false`) when omitted, so it falls through to the default. We fix it with `!!options.json` across all 36 call sites in 13 files. We also fix the unreachable `process.exit()` after `exitWithError()` in `rpc.ts`'s multiple-projects branch