### PR TITLE
fix(cli): Extract Duplicate Confirm Prompt to Shared Output Util

### DIFF
--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -5,22 +5,11 @@ import { getPaymentIntent, executeRenewal } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, type OutputOptions } from "../lib/output.js";
-import readline from "readline";
+import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, confirm, type OutputOptions } from "../lib/output.js";
 
 interface PayOptions extends OutputOptions {
   keypair: string;
   yes?: boolean;
-}
-
-function confirm(question: string): Promise<boolean> {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
-    });
-  });
 }
 
 export async function payCommand(paymentIntentId: string, options: PayOptions): Promise<void> {

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -4,8 +4,7 @@ import { signup, listProjects, getProject } from "../lib/api.js";
 import { getCheckoutPreview, executeCheckout, PLAN_CATALOG } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
-import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, type OutputOptions } from "../lib/output.js";
-import readline from "readline";
+import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, confirm, type OutputOptions } from "../lib/output.js";
 import { validateUpgradePlan, validatePeriod, validateEmail } from "../lib/validation.js";
 
 interface UpgradeOptions extends OutputOptions {
@@ -17,16 +16,6 @@ interface UpgradeOptions extends OutputOptions {
   firstName?: string;
   lastName?: string;
   yes?: boolean;
-}
-
-function confirm(question: string): Promise<boolean> {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
-    });
-  });
 }
 
 export async function upgradeCommand(options: UpgradeOptions): Promise<void> {

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -1,6 +1,7 @@
 // Output utilities for JSON mode
 import chalk from "chalk";
 import ora from "ora";
+import readline from "readline";
 import { sendCommandEvent, getCurrentCommand } from "./feedback.js";
 
 export interface OutputOptions {
@@ -313,4 +314,15 @@ export function exitWithError(
   }
 
   process.exit(exitCode);
+}
+
+/** Prompt the user for yes/no confirmation. Returns true if they answer y/yes. */
+export function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
 }


### PR DESCRIPTION
This PR extracts the identical `confirm()` function from `pay.ts` and `upgrade.ts` into `lib/output.ts`. We also remove the duplicated `import readline` from both command files