### PR TITLE
fix(cli): Recover Corrupted Config Instead of Silently Ignoring

### DIFF
--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -22,6 +22,28 @@ function ensureDir(): void {
   }
 }
 
+/** Try to extract known config fields from corrupted JSON via regex. */
+function recoverConfig(raw: string): Config {
+  const recovered: Config = {};
+
+  const patterns: { key: keyof Config; regex: RegExp }[] = [
+    { key: "jwt", regex: /"jwt"\s*:\s*"([^"]+)"/ },
+    { key: "apiKey", regex: /"apiKey"\s*:\s*"([^"]+)"/ },
+    { key: "network", regex: /"network"\s*:\s*"(mainnet|devnet)"/ },
+    { key: "projectId", regex: /"projectId"\s*:\s*"([^"]+)"/ },
+    { key: "owsWallet", regex: /"owsWallet"\s*:\s*"([^"]+)"/ },
+  ];
+
+  for (const { key, regex } of patterns) {
+    const match = raw.match(regex);
+    if (match) {
+      (recovered as any)[key] = match[1];
+    }
+  }
+
+  return recovered;
+}
+
 export function load(): Config {
   try {
     if (fs.existsSync(CONFIG_FILE)) {
@@ -29,7 +51,19 @@ export function load(): Config {
       return JSON.parse(data);
     }
   } catch {
-    // Return empty config on error
+    const raw = fs.readFileSync(CONFIG_FILE, "utf-8");
+    const recovered = recoverConfig(raw);
+    const recoveredKeys = Object.keys(recovered);
+
+    if (recoveredKeys.length > 0) {
+      console.error(`Warning: ${CONFIG_FILE} is corrupted. Recovered: ${recoveredKeys.join(", ")}.`);
+      save(recovered);
+      console.error(`Repaired config saved. Other fields may have been lost.`);
+      return recovered;
+    }
+
+    console.error(`Warning: ${CONFIG_FILE} is corrupted and could not be read.`);
+    console.error(`Run "helius config clear" to reset, or fix the file manually.`);
   }
   return {};
 }

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -53,6 +53,7 @@ export function load(): Config {
   try {
     raw = fs.readFileSync(CONFIG_FILE, "utf-8");
   } catch {
+    console.error(`Warning: ${CONFIG_FILE} exists but could not be read.`);
     return {};
   }
 

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -45,13 +45,20 @@ function recoverConfig(raw: string): Config {
 }
 
 export function load(): Config {
+  if (!fs.existsSync(CONFIG_FILE)) {
+    return {};
+  }
+
+  let raw: string;
   try {
-    if (fs.existsSync(CONFIG_FILE)) {
-      const data = fs.readFileSync(CONFIG_FILE, "utf-8");
-      return JSON.parse(data);
-    }
+    raw = fs.readFileSync(CONFIG_FILE, "utf-8");
   } catch {
-    const raw = fs.readFileSync(CONFIG_FILE, "utf-8");
+    return {};
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
     const recovered = recoverConfig(raw);
     const recoveredKeys = Object.keys(recovered);
 
@@ -64,8 +71,8 @@ export function load(): Config {
 
     console.error(`Warning: ${CONFIG_FILE} is corrupted and could not be read.`);
     console.error(`Run "helius config clear" to reset, or fix the file manually.`);
+    return {};
   }
-  return {};
 }
 
 export function save(data: Config): void {


### PR DESCRIPTION
This PR fixes the issue where corruption of the config file (i.e., `~/.helius/config.json`) was silently swallowed, returning an empty config with no warning. We now attempt to recover known fields via regex extraction and save a repaired config, warning the user if applicable. If we cannot recover anything, we will warn the user and provide remediation steps. Note that warnings go to `stderr` so they don't break `--json` output on `stdout`