### PR TITLE
feat(cli): Extract Duplicated Setup Helper to Shared `setupClient`

### DIFF
--- a/helius-cli/src/commands/account.ts
+++ b/helius-cli/src/commands/account.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
@@ -8,12 +8,7 @@ interface AccountOptions extends OutputOptions, ResolveOptions {}
 export async function accountCommand(address: string, options: AccountOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching account info...");
+    const helius = await setupClient(spinner, options, "Fetching account info...");
     const result = await helius.raw.getAccountInfo(address, { encoding: "jsonParsed" });
     spinner?.stop();
 

--- a/helius-cli/src/commands/asset.ts
+++ b/helius-cli/src/commands/asset.ts
@@ -1,18 +1,10 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface AssetOptions extends OutputOptions, ResolveOptions {}
 
-async function setup(spinner: any, options: AssetOptions, message: string) {
-  spinner?.start("Resolving API key...");
-  const apiKey = await resolveApiKey(options);
-  const network = resolveNetwork(options);
-  const helius = getClient(apiKey, network);
-  spinner?.start(message);
-  return helius;
-}
 
 function printAssetSummary(asset: any): void {
   console.log(`  ${chalk.gray("ID:")}           ${chalk.cyan(asset.id)}`);
@@ -53,7 +45,7 @@ function printAssetList(items: any[], label: string): void {
 export async function assetGetCommand(id: string, options: AssetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching asset...");
+    const helius = await setupClient(spinner, options, "Fetching asset...");
     const result = await helius.getAsset({ id });
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
@@ -67,7 +59,7 @@ export async function assetGetCommand(id: string, options: AssetOptions = {}): P
 export async function assetBatchCommand(ids: string[], options: AssetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, `Fetching ${ids.length} asset(s)...`);
+    const helius = await setupClient(spinner, options, `Fetching ${ids.length} asset(s)...`);
     const result = await helius.getAssetBatch({ ids });
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
@@ -82,7 +74,7 @@ export async function assetBatchCommand(ids: string[], options: AssetOptions = {
 export async function assetOwnerCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching assets by owner...");
+    const helius = await setupClient(spinner, options, "Fetching assets by owner...");
     const result = await helius.getAssetsByOwner({
       ownerAddress: address,
       page: options.page ? parseInt(options.page, 10) : 1,
@@ -100,7 +92,7 @@ export async function assetOwnerCommand(address: string, options: AssetOptions &
 export async function assetCreatorCommand(address: string, options: AssetOptions & { page?: string; limit?: string; verified?: boolean } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching assets by creator...");
+    const helius = await setupClient(spinner, options, "Fetching assets by creator...");
     const result = await helius.getAssetsByCreator({
       creatorAddress: address,
       onlyVerified: options.verified ?? false,
@@ -119,7 +111,7 @@ export async function assetCreatorCommand(address: string, options: AssetOptions
 export async function assetAuthorityCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching assets by authority...");
+    const helius = await setupClient(spinner, options, "Fetching assets by authority...");
     const result = await helius.getAssetsByAuthority({
       authorityAddress: address,
       page: options.page ? parseInt(options.page, 10) : 1,
@@ -137,7 +129,7 @@ export async function assetAuthorityCommand(address: string, options: AssetOptio
 export async function assetCollectionCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching collection assets...");
+    const helius = await setupClient(spinner, options, "Fetching collection assets...");
     const result = await helius.getAssetsByGroup({
       groupKey: "collection",
       groupValue: address,
@@ -160,7 +152,7 @@ export async function assetSearchCommand(options: AssetOptions & {
 } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Searching assets...");
+    const helius = await setupClient(spinner, options, "Searching assets...");
     const params: any = {
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
@@ -184,7 +176,7 @@ export async function assetSearchCommand(options: AssetOptions & {
 export async function assetProofCommand(id: string, options: AssetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching asset proof...");
+    const helius = await setupClient(spinner, options, "Fetching asset proof...");
     const result = await helius.getAssetProof({ id });
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
@@ -205,7 +197,7 @@ export async function assetProofCommand(id: string, options: AssetOptions = {}):
 export async function assetProofBatchCommand(ids: string[], options: AssetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, `Fetching proofs for ${ids.length} asset(s)...`);
+    const helius = await setupClient(spinner, options, `Fetching proofs for ${ids.length} asset(s)...`);
     const result = await helius.getAssetProofBatch({ ids });
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
@@ -222,7 +214,7 @@ export async function assetProofBatchCommand(ids: string[], options: AssetOption
 export async function assetEditionsCommand(mint: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching NFT editions...");
+    const helius = await setupClient(spinner, options, "Fetching NFT editions...");
     const result = await helius.getNftEditions({
       mint,
       page: options.page ? parseInt(options.page, 10) : 1,
@@ -247,7 +239,7 @@ export async function assetEditionsCommand(mint: string, options: AssetOptions &
 export async function assetSignaturesCommand(id: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching signatures for asset...");
+    const helius = await setupClient(spinner, options, "Fetching signatures for asset...");
     const result = await helius.getSignaturesForAsset({
       id,
       page: options.page ? parseInt(options.page, 10) : 1,
@@ -273,7 +265,7 @@ export async function assetSignaturesCommand(id: string, options: AssetOptions &
 export async function assetTokenAccountsCommand(options: AssetOptions & { owner?: string; mint?: string; page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching token accounts...");
+    const helius = await setupClient(spinner, options, "Fetching token accounts...");
     const params: any = {
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,

--- a/helius-cli/src/commands/balance.ts
+++ b/helius-cli/src/commands/balance.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { setupClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, resolveNetwork, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatAddress, formatTokenAmount, formatTable, type TableColumn } from "../lib/formatters.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
@@ -14,14 +14,14 @@ export async function balanceCommand(address: string, options: BalanceOptions = 
 
     const lamports = Number(result.value);
     if (options.json) {
-      outputJson({ address, lamports, sol: lamports / 1e9, network: options.network || "mainnet" });
+      outputJson({ address, lamports, sol: lamports / 1e9, network: resolveNetwork(options) });
       return;
     }
 
     console.log(chalk.bold(`\nBalance for ${chalk.cyan(address)}:\n`));
     console.log(`  ${chalk.green(formatSol(lamports))}`);
     console.log(`  ${chalk.gray(`(${lamports.toLocaleString()} lamports)`)}`);
-    console.log(`  ${chalk.gray(`Network: ${options.network || "mainnet"}`)}`);
+    console.log(`  ${chalk.gray(`Network: ${resolveNetwork(options)}`)}`);
   } catch (error) {
     handleCommandError(error, options, spinner);
   }

--- a/helius-cli/src/commands/balance.ts
+++ b/helius-cli/src/commands/balance.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatAddress, formatTokenAmount, formatTable, type TableColumn } from "../lib/formatters.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
@@ -8,25 +8,20 @@ interface BalanceOptions extends OutputOptions, ResolveOptions {}
 export async function balanceCommand(address: string, options: BalanceOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching balance...");
+    const helius = await setupClient(spinner, options, "Fetching balance...");
     const result = await helius.raw.getBalance(address);
     spinner?.stop();
 
     const lamports = Number(result.value);
     if (options.json) {
-      outputJson({ address, lamports, sol: lamports / 1e9, network });
+      outputJson({ address, lamports, sol: lamports / 1e9, network: options.network || "mainnet" });
       return;
     }
 
     console.log(chalk.bold(`\nBalance for ${chalk.cyan(address)}:\n`));
     console.log(`  ${chalk.green(formatSol(lamports))}`);
     console.log(`  ${chalk.gray(`(${lamports.toLocaleString()} lamports)`)}`);
-    console.log(`  ${chalk.gray(`Network: ${network}`)}`);
+    console.log(`  ${chalk.gray(`Network: ${options.network || "mainnet"}`)}`);
   } catch (error) {
     handleCommandError(error, options, spinner);
   }
@@ -35,12 +30,7 @@ export async function balanceCommand(address: string, options: BalanceOptions = 
 export async function tokensCommand(address: string, options: BalanceOptions & { limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching token balances...");
+    const helius = await setupClient(spinner, options, "Fetching token balances...");
     const limit = options.limit ? parseInt(options.limit, 10) : 100;
     const result = await helius.getAssetsByOwner({ ownerAddress: address, page: 1, limit, displayOptions: { showFungible: true } });
     spinner?.stop();
@@ -89,12 +79,7 @@ export async function tokensCommand(address: string, options: BalanceOptions & {
 export async function tokenHoldersCommand(mint: string, options: BalanceOptions & { limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching token holders...");
+    const helius = await setupClient(spinner, options, "Fetching token holders...");
     const limit = options.limit ? parseInt(options.limit, 10) : 20;
     const result = await helius.getTokenAccounts({ mint, page: 1, limit });
     spinner?.stop();

--- a/helius-cli/src/commands/block.ts
+++ b/helius-cli/src/commands/block.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatTimestamp } from "../lib/formatters.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
@@ -8,12 +8,7 @@ interface BlockOptions extends OutputOptions, ResolveOptions {}
 export async function blockCommand(slot: string, options: BlockOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start(`Fetching block at slot ${slot}...`);
+    const helius = await setupClient(spinner, options, `Fetching block at slot ${slot}...`);
     const slotNum = BigInt(slot);
     const result = await helius.raw.getBlock(slotNum, {
       maxSupportedTransactionVersion: 0,

--- a/helius-cli/src/commands/network-status.ts
+++ b/helius-cli/src/commands/network-status.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { setupClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, resolveNetwork, type ResolveOptions } from "../lib/helius.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface NetworkOptions extends OutputOptions, ResolveOptions {}
@@ -16,11 +16,11 @@ export async function networkStatusCommand(options: NetworkOptions = {}): Promis
     spinner?.stop();
 
     if (options.json) {
-      outputJson({ network: options.network || "mainnet", epochInfo, version, blockHeight });
+      outputJson({ network: resolveNetwork(options), epochInfo, version, blockHeight });
       return;
     }
 
-    console.log(chalk.bold(`\nSolana Network Status (${chalk.cyan(options.network || "mainnet")}):\n`));
+    console.log(chalk.bold(`\nSolana Network Status (${chalk.cyan(resolveNetwork(options))}):\n`));
     console.log(`  ${chalk.gray("Cluster version:")} ${(version as any)["solana-core"] || JSON.stringify(version)}`);
     console.log(`  ${chalk.gray("Block height:")}    ${Number(blockHeight).toLocaleString()}`);
     console.log(`  ${chalk.gray("Current epoch:")}   ${epochInfo.epoch}`);

--- a/helius-cli/src/commands/network-status.ts
+++ b/helius-cli/src/commands/network-status.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface NetworkOptions extends OutputOptions, ResolveOptions {}
@@ -7,12 +7,7 @@ interface NetworkOptions extends OutputOptions, ResolveOptions {}
 export async function networkStatusCommand(options: NetworkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching network status...");
+    const helius = await setupClient(spinner, options, "Fetching network status...");
     const [epochInfo, version, blockHeight] = await Promise.all([
       helius.raw.getEpochInfo(),
       helius.raw.getVersion(),
@@ -21,11 +16,11 @@ export async function networkStatusCommand(options: NetworkOptions = {}): Promis
     spinner?.stop();
 
     if (options.json) {
-      outputJson({ network, epochInfo, version, blockHeight });
+      outputJson({ network: options.network || "mainnet", epochInfo, version, blockHeight });
       return;
     }
 
-    console.log(chalk.bold(`\nSolana Network Status (${chalk.cyan(network)}):\n`));
+    console.log(chalk.bold(`\nSolana Network Status (${chalk.cyan(options.network || "mainnet")}):\n`));
     console.log(`  ${chalk.gray("Cluster version:")} ${(version as any)["solana-core"] || JSON.stringify(version)}`);
     console.log(`  ${chalk.gray("Block height:")}    ${Number(blockHeight).toLocaleString()}`);
     console.log(`  ${chalk.gray("Current epoch:")}   ${epochInfo.epoch}`);

--- a/helius-cli/src/commands/program.ts
+++ b/helius-cli/src/commands/program.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
@@ -8,12 +8,7 @@ interface ProgramOptions extends OutputOptions, ResolveOptions {}
 export async function programAccountsCommand(programId: string, options: ProgramOptions & { dataSize?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching program accounts...");
+    const helius = await setupClient(spinner, options, "Fetching program accounts...");
     const config: any = {};
     if (options.dataSize) config.filters = [{ dataSize: parseInt(options.dataSize, 10) }];
     if (options.limit) config.limit = parseInt(options.limit, 10);
@@ -49,12 +44,7 @@ export async function programAccountsCommand(programId: string, options: Program
 export async function programAccountsAllCommand(programId: string, options: ProgramOptions & { dataSize?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching all program accounts (auto-paginating)...");
+    const helius = await setupClient(spinner, options, "Fetching all program accounts (auto-paginating)...");
     const config: any = {};
     if (options.dataSize) config.filters = [{ dataSize: parseInt(options.dataSize, 10) }];
     const result = await helius.getAllProgramAccounts([programId, config]);
@@ -73,12 +63,7 @@ export async function programAccountsAllCommand(programId: string, options: Prog
 export async function programTokenAccountsCommand(owner: string, options: ProgramOptions & { limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching token accounts by owner...");
+    const helius = await setupClient(spinner, options, "Fetching token accounts by owner...");
     const config: any = { encoding: "base64" };
     if (options.limit) config.limit = parseInt(options.limit, 10);
     const filter = { programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" };

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface SendOptions extends OutputOptions, ResolveOptions {}
@@ -7,12 +7,7 @@ interface SendOptions extends OutputOptions, ResolveOptions {}
 export async function sendBroadcastCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Broadcasting transaction...");
+    const helius = await setupClient(spinner, options, "Broadcasting transaction...");
     const signature = await helius.tx.broadcastTransaction(base64Tx);
     spinner?.stop();
 
@@ -27,12 +22,7 @@ export async function sendBroadcastCommand(base64Tx: string, options: SendOption
 export async function sendRawCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Sending transaction...");
+    const helius = await setupClient(spinner, options, "Sending transaction...");
     const signature = await helius.tx.sendTransaction({ base64: base64Tx });
     spinner?.stop();
 
@@ -47,10 +37,7 @@ export async function sendRawCommand(base64Tx: string, options: SendOptions = {}
 export async function sendSenderCommand(base64Tx: string, options: SendOptions & { region?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
+    const helius = await setupClient(spinner, options, "Resolving API key...");
 
     const region = (options.region || "Default") as any;
     spinner?.start(`Sending via Helius Sender (${region})...`);
@@ -71,12 +58,7 @@ export async function sendSenderCommand(base64Tx: string, options: SendOptions &
 export async function sendPollCommand(signature: string, options: SendOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Polling for confirmation...");
+    const helius = await setupClient(spinner, options, "Polling for confirmation...");
     const result = await helius.tx.pollTransactionConfirmation(signature as any);
     spinner?.stop();
 
@@ -91,12 +73,7 @@ export async function sendPollCommand(signature: string, options: SendOptions = 
 export async function sendComputeUnitsCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Simulating for compute units...");
+    const helius = await setupClient(spinner, options, "Simulating for compute units...");
     const result = await helius.tx.getComputeUnits(base64Tx as any);
     spinner?.stop();
 

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
 import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
@@ -8,12 +8,7 @@ interface StakeOptions extends OutputOptions, ResolveOptions {}
 export async function stakeAccountsCommand(wallet: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching Helius stake accounts...");
+    const helius = await setupClient(spinner, options, "Fetching Helius stake accounts...");
     const result = await helius.stake.getHeliusStakeAccounts(wallet as any);
     spinner?.stop();
 
@@ -36,12 +31,7 @@ export async function stakeAccountsCommand(wallet: string, options: StakeOptions
 export async function stakeWithdrawableCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Checking withdrawable amount...");
+    const helius = await setupClient(spinner, options, "Checking withdrawable amount...");
     const result = await helius.stake.getWithdrawableAmount(stakeAccount as any);
     spinner?.stop();
 
@@ -57,12 +47,7 @@ export async function stakeWithdrawableCommand(stakeAccount: string, options: St
 export async function stakeInstructionsCommand(amount: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Getting stake instructions...");
+    const helius = await setupClient(spinner, options, "Getting stake instructions...");
     const lamports = BigInt(Math.round(parseFloat(amount) * 1e9));
     const result = await helius.stake.getStakeInstructions(lamports);
     spinner?.stop();
@@ -79,12 +64,7 @@ export async function stakeInstructionsCommand(amount: string, options: StakeOpt
 export async function stakeUnstakeInstructionCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Getting unstake instruction...");
+    const helius = await setupClient(spinner, options, "Getting unstake instruction...");
     const result = await helius.stake.getUnstakeInstruction(stakeAccount as any);
     spinner?.stop();
 
@@ -100,12 +80,7 @@ export async function stakeUnstakeInstructionCommand(stakeAccount: string, optio
 export async function stakeWithdrawInstructionCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Getting withdraw instruction...");
+    const helius = await setupClient(spinner, options, "Getting withdraw instruction...");
     const result = await helius.stake.getWithdrawInstruction(stakeAccount as any);
     spinner?.stop();
 
@@ -124,12 +99,7 @@ export async function stakeCreateCommand(amount: string, options: StakeOptions &
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Creating stake transaction...");
+    const helius = await setupClient(spinner, options, "Creating stake transaction...");
     const lamports = BigInt(Math.round(parseFloat(amount) * 1e9));
     const result = await helius.stake.createStakeTransaction(lamports);
     spinner?.stop();
@@ -150,12 +120,7 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Creating unstake transaction...");
+    const helius = await setupClient(spinner, options, "Creating unstake transaction...");
     const result = await helius.stake.createUnstakeTransaction(stakeAccount as any);
     spinner?.stop();
 
@@ -174,12 +139,7 @@ export async function stakeWithdrawCommand(stakeAccount: string, options: StakeO
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Creating withdraw transaction...");
+    const helius = await setupClient(spinner, options, "Creating withdraw transaction...");
     const result = await helius.stake.createWithdrawTransaction(stakeAccount as any);
     spinner?.stop();
 

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatTimestamp, formatAddress, formatEnumLabel } from "../lib/formatters.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
@@ -8,12 +8,7 @@ interface TxOptions extends OutputOptions, ResolveOptions {}
 export async function txParseCommand(signatures: string[], options: TxOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start(`Parsing ${signatures.length} transaction(s)...`);
+    const helius = await setupClient(spinner, options, `Parsing ${signatures.length} transaction(s)...`);
     const result = await helius.enhanced.getTransactions({ transactions: signatures });
     spinner?.stop();
 
@@ -60,12 +55,7 @@ export async function txParseCommand(signatures: string[], options: TxOptions = 
 export async function txHistoryCommand(address: string, options: TxOptions & { limit?: string; before?: string; type?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching transaction history...");
+    const helius = await setupClient(spinner, options, "Fetching transaction history...");
     const params: any = { address };
     if (options.limit) params.limit = parseInt(options.limit, 10);
     if (options.before) params.before = options.before;
@@ -104,12 +94,7 @@ export async function txHistoryCommand(address: string, options: TxOptions & { l
 export async function txFeesCommand(options: TxOptions & { accounts?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const network = resolveNetwork(options);
-    const helius = getClient(apiKey, network);
-
-    spinner?.start("Fetching priority fee estimate...");
+    const helius = await setupClient(spinner, options, "Fetching priority fee estimate...");
     const params: any = { options: { includeAllPriorityFeeLevels: true } };
     if (options.accounts) {
       params.accountKeys = options.accounts.split(",").map((s: string) => s.trim());

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatEnumLabel } from "../lib/formatters.js";
 import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 import { validateSolanaAddresses } from "../lib/validation.js";
@@ -9,11 +9,7 @@ interface WebhookOptions extends OutputOptions, ResolveOptions {}
 export async function webhookListCommand(options: WebhookOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const helius = getClient(apiKey, resolveNetwork(options));
-
-    spinner?.start("Fetching webhooks...");
+    const helius = await setupClient(spinner, options, "Fetching webhooks...");
     const result = await helius.webhooks.getAll();
     spinner?.stop();
 
@@ -42,11 +38,7 @@ export async function webhookListCommand(options: WebhookOptions = {}): Promise<
 export async function webhookGetCommand(webhookId: string, options: WebhookOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const helius = getClient(apiKey, resolveNetwork(options));
-
-    spinner?.start("Fetching webhook...");
+    const helius = await setupClient(spinner, options, "Fetching webhook...");
     const result = await helius.webhooks.get(webhookId);
     spinner?.stop();
 
@@ -73,9 +65,7 @@ export async function webhookCreateCommand(options: WebhookOptions & {
 }): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const helius = getClient(apiKey, resolveNetwork(options));
+    const helius = await setupClient(spinner, options, "Resolving API key...");
 
     // Validate addresses before sending to API
     const addrErr = validateSolanaAddresses(options.accounts);
@@ -110,9 +100,7 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
 }): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const helius = getClient(apiKey, resolveNetwork(options));
+    const helius = await setupClient(spinner, options, "Resolving API key...");
 
     const params: any = {};
     // Validate addresses if provided
@@ -139,11 +127,7 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
 export async function webhookDeleteCommand(webhookId: string, options: WebhookOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    spinner?.start("Resolving API key...");
-    const apiKey = await resolveApiKey(options);
-    const helius = getClient(apiKey, resolveNetwork(options));
-
-    spinner?.start("Deleting webhook...");
+    const helius = await setupClient(spinner, options, "Deleting webhook...");
     await helius.webhooks.delete(webhookId);
     spinner?.stop();
 

--- a/helius-cli/src/commands/zk.ts
+++ b/helius-cli/src/commands/zk.ts
@@ -1,17 +1,8 @@
 import chalk from "chalk";
-import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
 
 interface ZkOptions extends OutputOptions, ResolveOptions {}
-
-async function setup(spinner: any, options: ZkOptions, message: string) {
-  spinner?.start("Resolving API key...");
-  const apiKey = await resolveApiKey(options);
-  const network = resolveNetwork(options);
-  const helius = getClient(apiKey, network);
-  spinner?.start(message);
-  return helius;
-}
 
 function handleResult(spinner: any, result: any, options: ZkOptions, label: string): void {
   spinner?.stop();
@@ -23,7 +14,7 @@ function handleResult(spinner: any, result: any, options: ZkOptions, label: stri
 export async function zkAccountCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed account...");
+    const helius = await setupClient(spinner, options, "Fetching compressed account...");
     const result = await helius.zk.getCompressedAccount({ address: addressOrHash });
     handleResult(spinner, result, options, "Compressed Account");
   } catch (error) {
@@ -34,7 +25,7 @@ export async function zkAccountCommand(addressOrHash: string, options: ZkOptions
 export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed accounts by owner...");
+    const helius = await setupClient(spinner, options, "Fetching compressed accounts by owner...");
     const result = await helius.zk.getCompressedAccountsByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Accounts by Owner");
   } catch (error) {
@@ -45,7 +36,7 @@ export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions
 export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed balance...");
+    const helius = await setupClient(spinner, options, "Fetching compressed balance...");
     const result = await helius.zk.getCompressedBalance({ address: addressOrHash });
     handleResult(spinner, result, options, "Compressed Balance");
   } catch (error) {
@@ -56,7 +47,7 @@ export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions
 export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed balance by owner...");
+    const helius = await setupClient(spinner, options, "Fetching compressed balance by owner...");
     const result = await helius.zk.getCompressedBalanceByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Balance by Owner");
   } catch (error) {
@@ -67,7 +58,7 @@ export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions 
 export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed token holders...");
+    const helius = await setupClient(spinner, options, "Fetching compressed token holders...");
     const result = await helius.zk.getCompressedMintTokenHolders({ mint });
     handleResult(spinner, result, options, "Compressed Token Holders");
   } catch (error) {
@@ -78,7 +69,7 @@ export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {
 export async function zkTokenBalanceCommand(account: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed token account balance...");
+    const helius = await setupClient(spinner, options, "Fetching compressed token account balance...");
     const result = await helius.zk.getCompressedTokenAccountBalance({ address: account });
     handleResult(spinner, result, options, "Compressed Token Account Balance");
   } catch (error) {
@@ -89,7 +80,7 @@ export async function zkTokenBalanceCommand(account: string, options: ZkOptions 
 export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed token accounts by owner...");
+    const helius = await setupClient(spinner, options, "Fetching compressed token accounts by owner...");
     const result = await helius.zk.getCompressedTokenAccountsByOwner({ owner });
     handleResult(spinner, result, options, "Compressed Token Accounts by Owner");
   } catch (error) {
@@ -100,7 +91,7 @@ export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOp
 export async function zkTokenAccountsByDelegateCommand(delegate: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed token accounts by delegate...");
+    const helius = await setupClient(spinner, options, "Fetching compressed token accounts by delegate...");
     const result = await helius.zk.getCompressedTokenAccountsByDelegate({ delegate });
     handleResult(spinner, result, options, "Compressed Token Accounts by Delegate");
   } catch (error) {
@@ -111,7 +102,7 @@ export async function zkTokenAccountsByDelegateCommand(delegate: string, options
 export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed token balances by owner (V2)...");
+    const helius = await setupClient(spinner, options, "Fetching compressed token balances by owner (V2)...");
     const result = await helius.zk.getCompressedTokenBalancesByOwnerV2({ owner });
     handleResult(spinner, result, options, "Compressed Token Balances by Owner (V2)");
   } catch (error) {
@@ -122,7 +113,7 @@ export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOp
 export async function zkProofCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compressed account proof...");
+    const helius = await setupClient(spinner, options, "Fetching compressed account proof...");
     const result = await helius.zk.getCompressedAccountProof({ hash: addressOrHash });
     handleResult(spinner, result, options, "Compressed Account Proof");
   } catch (error) {
@@ -133,7 +124,7 @@ export async function zkProofCommand(addressOrHash: string, options: ZkOptions =
 export async function zkProofsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, `Fetching proofs for ${addresses.length} account(s)...`);
+    const helius = await setupClient(spinner, options, `Fetching proofs for ${addresses.length} account(s)...`);
     const result = await helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses });
     handleResult(spinner, result, options, "Multiple Compressed Account Proofs");
   } catch (error) {
@@ -144,7 +135,7 @@ export async function zkProofsCommand(addresses: string[], options: ZkOptions = 
 export async function zkMultipleAccountsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, `Fetching ${addresses.length} compressed account(s)...`);
+    const helius = await setupClient(spinner, options, `Fetching ${addresses.length} compressed account(s)...`);
     const result = await helius.zk.getMultipleCompressedAccounts({ addresses });
     handleResult(spinner, result, options, "Multiple Compressed Accounts");
   } catch (error) {
@@ -155,7 +146,7 @@ export async function zkMultipleAccountsCommand(addresses: string[], options: Zk
 export async function zkAddressProofsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, `Fetching address proofs (V2)...`);
+    const helius = await setupClient(spinner, options, `Fetching address proofs (V2)...`);
     const result = await helius.zk.getMultipleNewAddressProofsV2(addresses);
     handleResult(spinner, result, options, "Multiple New Address Proofs (V2)");
   } catch (error) {
@@ -166,7 +157,7 @@ export async function zkAddressProofsCommand(addresses: string[], options: ZkOpt
 export async function zkSignaturesAccountCommand(account: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compression signatures for account...");
+    const helius = await setupClient(spinner, options, "Fetching compression signatures for account...");
     const result = await helius.zk.getCompressionSignaturesForAccount({ hash: account });
     handleResult(spinner, result, options, "Compression Signatures for Account");
   } catch (error) {
@@ -177,7 +168,7 @@ export async function zkSignaturesAccountCommand(account: string, options: ZkOpt
 export async function zkSignaturesAddressCommand(address: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compression signatures for address...");
+    const helius = await setupClient(spinner, options, "Fetching compression signatures for address...");
     const result = await helius.zk.getCompressionSignaturesForAddress({ address });
     handleResult(spinner, result, options, "Compression Signatures for Address");
   } catch (error) {
@@ -188,7 +179,7 @@ export async function zkSignaturesAddressCommand(address: string, options: ZkOpt
 export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compression signatures for owner...");
+    const helius = await setupClient(spinner, options, "Fetching compression signatures for owner...");
     const result = await helius.zk.getCompressionSignaturesForOwner({ owner });
     handleResult(spinner, result, options, "Compression Signatures for Owner");
   } catch (error) {
@@ -199,7 +190,7 @@ export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions
 export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching compression signatures for token owner...");
+    const helius = await setupClient(spinner, options, "Fetching compression signatures for token owner...");
     const result = await helius.zk.getCompressionSignaturesForTokenOwner({ owner });
     handleResult(spinner, result, options, "Compression Signatures for Token Owner");
   } catch (error) {
@@ -210,7 +201,7 @@ export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOp
 export async function zkLatestSignaturesCommand(options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching latest compression signatures...");
+    const helius = await setupClient(spinner, options, "Fetching latest compression signatures...");
     const result = await helius.zk.getLatestCompressionSignatures({});
     handleResult(spinner, result, options, "Latest Compression Signatures");
   } catch (error) {
@@ -221,7 +212,7 @@ export async function zkLatestSignaturesCommand(options: ZkOptions = {}): Promis
 export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching latest non-voting signatures...");
+    const helius = await setupClient(spinner, options, "Fetching latest non-voting signatures...");
     const result = await helius.zk.getLatestNonVotingSignatures({});
     handleResult(spinner, result, options, "Latest Non-Voting Signatures");
   } catch (error) {
@@ -232,7 +223,7 @@ export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise
 export async function zkTxCommand(signature: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching transaction with compression info...");
+    const helius = await setupClient(spinner, options, "Fetching transaction with compression info...");
     const result = await helius.zk.getTransactionWithCompressionInfo({ signature });
     handleResult(spinner, result, options, "Transaction with Compression Info");
   } catch (error) {
@@ -243,7 +234,7 @@ export async function zkTxCommand(signature: string, options: ZkOptions = {}): P
 export async function zkValidityProofCommand(options: ZkOptions & { hashes?: string; addresses?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching validity proof...");
+    const helius = await setupClient(spinner, options, "Fetching validity proof...");
     const params: any = {};
     if (options.hashes) params.hashes = options.hashes.split(",").map((s: string) => s.trim());
     if (options.addresses) params.newAddressesWithTrees = options.addresses.split(",").map((s: string) => ({ address: s.trim(), tree: "" }));
@@ -257,7 +248,7 @@ export async function zkValidityProofCommand(options: ZkOptions & { hashes?: str
 export async function zkIndexerHealthCommand(options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Checking indexer health...");
+    const helius = await setupClient(spinner, options, "Checking indexer health...");
     const result = await helius.zk.getIndexerHealth();
     handleResult(spinner, result, options, "Indexer Health");
   } catch (error) {
@@ -268,7 +259,7 @@ export async function zkIndexerHealthCommand(options: ZkOptions = {}): Promise<v
 export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching indexer slot...");
+    const helius = await setupClient(spinner, options, "Fetching indexer slot...");
     const result = await helius.zk.getIndexerSlot();
     handleResult(spinner, result, options, "Indexer Slot");
   } catch (error) {
@@ -279,7 +270,7 @@ export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<voi
 export async function zkSignaturesForAssetCommand(id: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setup(spinner, options, "Fetching signatures for asset...");
+    const helius = await setupClient(spinner, options, "Fetching signatures for asset...");
     const result = await helius.zk.getSignaturesForAsset({ id, page: 1 });
     handleResult(spinner, result, options, "Signatures for Asset");
   } catch (error) {

--- a/helius-cli/src/lib/helius.ts
+++ b/helius-cli/src/lib/helius.ts
@@ -95,6 +95,23 @@ export function getClient(apiKey: string, network?: string): HeliusClient {
 }
 
 /**
+ * Resolve API key, get SDK client, and update the spinner.
+ * Shared setup for commands that follow the standard resolve → client → fetch pattern.
+ */
+export async function setupClient(
+  spinner: { start(text: string): void } | null | undefined,
+  options: ResolveOptions,
+  message: string,
+): Promise<HeliusClient> {
+  spinner?.start("Resolving API key...");
+  const apiKey = await resolveApiKey(options);
+  const network = resolveNetwork(options);
+  const helius = getClient(apiKey, network);
+  spinner?.start(message);
+  return helius;
+}
+
+/**
  * REST request helper for Wallet API endpoints (not in SDK).
  * Throws HeliusHttpError on non-2xx so classifyError() gets an exact status code.
  */


### PR DESCRIPTION
This PR extracts the resolve API key -> get client -> update spinner pattern into a shared `setupClient()` util to remove duplicate code across `zk.ts` and `asset.ts`