### PR TITLE
feat(cli): Add `--retry` Flag For Transient Error Recovery With Exponential Backoff

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -66,6 +66,7 @@ program
   .version(VERSION)
   .option("--api-key <key>", "Helius API key")
   .option("--network <net>", "Network: mainnet or devnet", "mainnet")
+  .option("--retry <n>", "Retry transient errors (429, 5xx, network) up to n times with exponential backoff", "0")
   .hook('preAction', (_thisCommand, actionCommand) => {
     setCurrentCommand(actionCommand.name());
     sendCommandEvent(actionCommand.name());

--- a/helius-cli/src/commands/account.ts
+++ b/helius-cli/src/commands/account.ts
@@ -14,7 +14,7 @@ export async function accountCommand(address: string, options: AccountOptions = 
     const helius = getClient(apiKey, network);
 
     spinner?.start("Fetching account info...");
-    const result: any = await withRetry(() => helius.raw.getAccountInfo(address, { encoding: "jsonParsed" }), options, spinner);
+    const result = await withRetry(() => helius.raw.getAccountInfo(address, { encoding: "jsonParsed" }), options, spinner) as any;
     spinner?.stop();
 
     if (options.json) {

--- a/helius-cli/src/commands/account.ts
+++ b/helius-cli/src/commands/account.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface AccountOptions extends OutputOptions, ResolveOptions {}
+interface AccountOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function accountCommand(address: string, options: AccountOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -14,7 +14,7 @@ export async function accountCommand(address: string, options: AccountOptions = 
     const helius = getClient(apiKey, network);
 
     spinner?.start("Fetching account info...");
-    const result = await helius.raw.getAccountInfo(address, { encoding: "jsonParsed" });
+    const result: any = await withRetry(() => helius.raw.getAccountInfo(address, { encoding: "jsonParsed" }), options, spinner);
     spinner?.stop();
 
     if (options.json) {

--- a/helius-cli/src/commands/asset.ts
+++ b/helius-cli/src/commands/asset.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface AssetOptions extends OutputOptions, ResolveOptions {}
+interface AssetOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 async function setup(spinner: any, options: AssetOptions, message: string) {
   spinner?.start("Resolving API key...");
@@ -54,7 +54,7 @@ export async function assetGetCommand(id: string, options: AssetOptions = {}): P
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching asset...");
-    const result = await helius.getAsset({ id });
+    const result: any = await withRetry(() => helius.getAsset({ id }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold("\nAsset Details:\n"));
@@ -68,7 +68,7 @@ export async function assetBatchCommand(ids: string[], options: AssetOptions = {
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching ${ids.length} asset(s)...`);
-    const result = await helius.getAssetBatch({ ids });
+    const result: any = await withRetry(() => helius.getAssetBatch({ ids }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const items = Array.isArray(result) ? result : [];
@@ -83,11 +83,11 @@ export async function assetOwnerCommand(address: string, options: AssetOptions &
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by owner...");
-    const result = await helius.getAssetsByOwner({
+    const result: any = await withRetry(() => helius.getAssetsByOwner({
       ownerAddress: address,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    });
+    }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAssets owned by ${chalk.cyan(address)}:\n`));
@@ -101,12 +101,12 @@ export async function assetCreatorCommand(address: string, options: AssetOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by creator...");
-    const result = await helius.getAssetsByCreator({
+    const result: any = await withRetry(() => helius.getAssetsByCreator({
       creatorAddress: address,
       onlyVerified: options.verified ?? false,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    });
+    }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAssets by creator ${chalk.cyan(address)}:\n`));
@@ -120,11 +120,11 @@ export async function assetAuthorityCommand(address: string, options: AssetOptio
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by authority...");
-    const result = await helius.getAssetsByAuthority({
+    const result: any = await withRetry(() => helius.getAssetsByAuthority({
       authorityAddress: address,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    });
+    }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAssets by authority ${chalk.cyan(address)}:\n`));
@@ -138,12 +138,12 @@ export async function assetCollectionCommand(address: string, options: AssetOpti
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching collection assets...");
-    const result = await helius.getAssetsByGroup({
+    const result: any = await withRetry(() => helius.getAssetsByGroup({
       groupKey: "collection",
       groupValue: address,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    });
+    }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAssets in collection ${chalk.cyan(address)}:\n`));
@@ -171,7 +171,7 @@ export async function assetSearchCommand(options: AssetOptions & {
     if (options.compressed != null) params.compressed = options.compressed;
     if (options.burnt != null) params.burnt = options.burnt;
     if (options.frozen != null) params.frozen = options.frozen;
-    const result = await helius.searchAssets(params);
+    const result: any = await withRetry(() => helius.searchAssets(params), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold("\nSearch Results:\n"));
@@ -185,7 +185,7 @@ export async function assetProofCommand(id: string, options: AssetOptions = {}):
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching asset proof...");
-    const result = await helius.getAssetProof({ id });
+    const result: any = await withRetry(() => helius.getAssetProof({ id }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAsset Proof for ${chalk.cyan(id)}:\n`));
@@ -206,7 +206,7 @@ export async function assetProofBatchCommand(ids: string[], options: AssetOption
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching proofs for ${ids.length} asset(s)...`);
-    const result = await helius.getAssetProofBatch({ ids });
+    const result: any = await withRetry(() => helius.getAssetProofBatch({ ids }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAsset Proofs (${ids.length}):\n`));
@@ -223,11 +223,11 @@ export async function assetEditionsCommand(mint: string, options: AssetOptions &
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching NFT editions...");
-    const result = await helius.getNftEditions({
+    const result: any = await withRetry(() => helius.getNftEditions({
       mint,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    });
+    }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const editions = (result as any)?.editions || [];
@@ -248,11 +248,11 @@ export async function assetSignaturesCommand(id: string, options: AssetOptions &
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching signatures for asset...");
-    const result = await helius.getSignaturesForAsset({
+    const result: any = await withRetry(() => helius.getSignaturesForAsset({
       id,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    });
+    }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const sigs = (result as any)?.items || [];
@@ -280,7 +280,7 @@ export async function assetTokenAccountsCommand(options: AssetOptions & { owner?
     };
     if (options.owner) params.owner = options.owner;
     if (options.mint) params.mint = options.mint;
-    const result = await helius.getTokenAccounts(params);
+    const result: any = await withRetry(() => helius.getTokenAccounts(params), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const accounts = (result as any)?.token_accounts || [];

--- a/helius-cli/src/commands/asset.ts
+++ b/helius-cli/src/commands/asset.ts
@@ -54,7 +54,7 @@ export async function assetGetCommand(id: string, options: AssetOptions = {}): P
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching asset...");
-    const result: any = await withRetry(() => helius.getAsset({ id }), options, spinner);
+    const result = await withRetry(() => helius.getAsset({ id }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold("\nAsset Details:\n"));
@@ -68,7 +68,7 @@ export async function assetBatchCommand(ids: string[], options: AssetOptions = {
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching ${ids.length} asset(s)...`);
-    const result: any = await withRetry(() => helius.getAssetBatch({ ids }), options, spinner);
+    const result = await withRetry(() => helius.getAssetBatch({ ids }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const items = Array.isArray(result) ? result : [];
@@ -83,11 +83,11 @@ export async function assetOwnerCommand(address: string, options: AssetOptions &
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by owner...");
-    const result: any = await withRetry(() => helius.getAssetsByOwner({
+    const result = await withRetry(() => helius.getAssetsByOwner({
       ownerAddress: address,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    }), options, spinner);
+    }), options, spinner) as any;
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAssets owned by ${chalk.cyan(address)}:\n`));
@@ -101,12 +101,12 @@ export async function assetCreatorCommand(address: string, options: AssetOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by creator...");
-    const result: any = await withRetry(() => helius.getAssetsByCreator({
+    const result = await withRetry(() => helius.getAssetsByCreator({
       creatorAddress: address,
       onlyVerified: options.verified ?? false,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    }), options, spinner);
+    }), options, spinner) as any;
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAssets by creator ${chalk.cyan(address)}:\n`));
@@ -120,11 +120,11 @@ export async function assetAuthorityCommand(address: string, options: AssetOptio
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching assets by authority...");
-    const result: any = await withRetry(() => helius.getAssetsByAuthority({
+    const result = await withRetry(() => helius.getAssetsByAuthority({
       authorityAddress: address,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    }), options, spinner);
+    }), options, spinner) as any;
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAssets by authority ${chalk.cyan(address)}:\n`));
@@ -138,12 +138,12 @@ export async function assetCollectionCommand(address: string, options: AssetOpti
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching collection assets...");
-    const result: any = await withRetry(() => helius.getAssetsByGroup({
+    const result = await withRetry(() => helius.getAssetsByGroup({
       groupKey: "collection",
       groupValue: address,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
-    }), options, spinner);
+    }), options, spinner) as any;
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAssets in collection ${chalk.cyan(address)}:\n`));
@@ -171,7 +171,7 @@ export async function assetSearchCommand(options: AssetOptions & {
     if (options.compressed != null) params.compressed = options.compressed;
     if (options.burnt != null) params.burnt = options.burnt;
     if (options.frozen != null) params.frozen = options.frozen;
-    const result: any = await withRetry(() => helius.searchAssets(params), options, spinner);
+    const result = await withRetry(() => helius.searchAssets(params), options, spinner) as any;
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold("\nSearch Results:\n"));
@@ -185,7 +185,7 @@ export async function assetProofCommand(id: string, options: AssetOptions = {}):
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching asset proof...");
-    const result: any = await withRetry(() => helius.getAssetProof({ id }), options, spinner);
+    const result = await withRetry(() => helius.getAssetProof({ id }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAsset Proof for ${chalk.cyan(id)}:\n`));
@@ -206,7 +206,7 @@ export async function assetProofBatchCommand(ids: string[], options: AssetOption
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching proofs for ${ids.length} asset(s)...`);
-    const result: any = await withRetry(() => helius.getAssetProofBatch({ ids }), options, spinner);
+    const result = await withRetry(() => helius.getAssetProofBatch({ ids }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nAsset Proofs (${ids.length}):\n`));
@@ -223,7 +223,7 @@ export async function assetEditionsCommand(mint: string, options: AssetOptions &
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching NFT editions...");
-    const result: any = await withRetry(() => helius.getNftEditions({
+    const result = await withRetry(() => helius.getNftEditions({
       mint,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
@@ -248,7 +248,7 @@ export async function assetSignaturesCommand(id: string, options: AssetOptions &
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching signatures for asset...");
-    const result: any = await withRetry(() => helius.getSignaturesForAsset({
+    const result = await withRetry(() => helius.getSignaturesForAsset({
       id,
       page: options.page ? parseInt(options.page, 10) : 1,
       limit: options.limit ? parseInt(options.limit, 10) : 20,
@@ -280,7 +280,7 @@ export async function assetTokenAccountsCommand(options: AssetOptions & { owner?
     };
     if (options.owner) params.owner = options.owner;
     if (options.mint) params.mint = options.mint;
-    const result: any = await withRetry(() => helius.getTokenAccounts(params), options, spinner);
+    const result = await withRetry(() => helius.getTokenAccounts(params), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const accounts = (result as any)?.token_accounts || [];

--- a/helius-cli/src/commands/balance.ts
+++ b/helius-cli/src/commands/balance.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatAddress, formatTokenAmount, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface BalanceOptions extends OutputOptions, ResolveOptions {}
+interface BalanceOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function balanceCommand(address: string, options: BalanceOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -14,7 +14,7 @@ export async function balanceCommand(address: string, options: BalanceOptions = 
     const helius = getClient(apiKey, network);
 
     spinner?.start("Fetching balance...");
-    const result = await helius.raw.getBalance(address);
+    const result: any = await withRetry(() => helius.raw.getBalance(address), options, spinner);
     spinner?.stop();
 
     const lamports = Number(result.value);
@@ -42,7 +42,7 @@ export async function tokensCommand(address: string, options: BalanceOptions & {
 
     spinner?.start("Fetching token balances...");
     const limit = options.limit ? parseInt(options.limit, 10) : 100;
-    const result = await helius.getAssetsByOwner({ ownerAddress: address, page: 1, limit, displayOptions: { showFungible: true } });
+    const result: any = await withRetry(() => helius.getAssetsByOwner({ ownerAddress: address, page: 1, limit, displayOptions: { showFungible: true } }), options, spinner);
     spinner?.stop();
 
     // Filter to fungible tokens
@@ -96,7 +96,7 @@ export async function tokenHoldersCommand(mint: string, options: BalanceOptions 
 
     spinner?.start("Fetching token holders...");
     const limit = options.limit ? parseInt(options.limit, 10) : 20;
-    const result = await helius.getTokenAccounts({ mint, page: 1, limit });
+    const result: any = await withRetry(() => helius.getTokenAccounts({ mint, page: 1, limit }), options, spinner);
     spinner?.stop();
 
     const accounts = result.token_accounts || [];

--- a/helius-cli/src/commands/balance.ts
+++ b/helius-cli/src/commands/balance.ts
@@ -14,7 +14,7 @@ export async function balanceCommand(address: string, options: BalanceOptions = 
     const helius = getClient(apiKey, network);
 
     spinner?.start("Fetching balance...");
-    const result: any = await withRetry(() => helius.raw.getBalance(address), options, spinner);
+    const result = await withRetry(() => helius.raw.getBalance(address), options, spinner) as any;
     spinner?.stop();
 
     const lamports = Number(result.value);
@@ -42,7 +42,7 @@ export async function tokensCommand(address: string, options: BalanceOptions & {
 
     spinner?.start("Fetching token balances...");
     const limit = options.limit ? parseInt(options.limit, 10) : 100;
-    const result: any = await withRetry(() => helius.getAssetsByOwner({ ownerAddress: address, page: 1, limit, displayOptions: { showFungible: true } }), options, spinner);
+    const result = await withRetry(() => helius.getAssetsByOwner({ ownerAddress: address, page: 1, limit, displayOptions: { showFungible: true } }), options, spinner) as any;
     spinner?.stop();
 
     // Filter to fungible tokens
@@ -96,7 +96,7 @@ export async function tokenHoldersCommand(mint: string, options: BalanceOptions 
 
     spinner?.start("Fetching token holders...");
     const limit = options.limit ? parseInt(options.limit, 10) : 20;
-    const result: any = await withRetry(() => helius.getTokenAccounts({ mint, page: 1, limit }), options, spinner);
+    const result = await withRetry(() => helius.getTokenAccounts({ mint, page: 1, limit }), options, spinner) as any;
     spinner?.stop();
 
     const accounts = result.token_accounts || [];

--- a/helius-cli/src/commands/block.ts
+++ b/helius-cli/src/commands/block.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatTimestamp } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface BlockOptions extends OutputOptions, ResolveOptions {}
+interface BlockOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function blockCommand(slot: string, options: BlockOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -15,10 +15,10 @@ export async function blockCommand(slot: string, options: BlockOptions = {}): Pr
 
     spinner?.start(`Fetching block at slot ${slot}...`);
     const slotNum = BigInt(slot);
-    const result = await helius.raw.getBlock(slotNum, {
+    const result: any = await withRetry(() => helius.raw.getBlock(slotNum, {
       maxSupportedTransactionVersion: 0,
       transactionDetails: "signatures",
-    });
+    }), options, spinner);
     spinner?.stop();
 
     if (options.json) {

--- a/helius-cli/src/commands/block.ts
+++ b/helius-cli/src/commands/block.ts
@@ -15,7 +15,7 @@ export async function blockCommand(slot: string, options: BlockOptions = {}): Pr
 
     spinner?.start(`Fetching block at slot ${slot}...`);
     const slotNum = BigInt(slot);
-    const result: any = await withRetry(() => helius.raw.getBlock(slotNum, {
+    const result = await withRetry(() => helius.raw.getBlock(slotNum, {
       maxSupportedTransactionVersion: 0,
       transactionDetails: "signatures",
     }), options, spinner);

--- a/helius-cli/src/commands/network-status.ts
+++ b/helius-cli/src/commands/network-status.ts
@@ -1,8 +1,8 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface NetworkOptions extends OutputOptions, ResolveOptions {}
+interface NetworkOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function networkStatusCommand(options: NetworkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -13,11 +13,11 @@ export async function networkStatusCommand(options: NetworkOptions = {}): Promis
     const helius = getClient(apiKey, network);
 
     spinner?.start("Fetching network status...");
-    const [epochInfo, version, blockHeight] = await Promise.all([
+    const [epochInfo, version, blockHeight]: any[] = await withRetry(() => Promise.all([
       helius.raw.getEpochInfo(),
       helius.raw.getVersion(),
       helius.raw.getBlockHeight(),
-    ]);
+    ]), options, spinner);
     spinner?.stop();
 
     if (options.json) {

--- a/helius-cli/src/commands/network-status.ts
+++ b/helius-cli/src/commands/network-status.ts
@@ -13,7 +13,7 @@ export async function networkStatusCommand(options: NetworkOptions = {}): Promis
     const helius = getClient(apiKey, network);
 
     spinner?.start("Fetching network status...");
-    const [epochInfo, version, blockHeight]: any[] = await withRetry(() => Promise.all([
+    const [epochInfo, version, blockHeight] = await withRetry(() => Promise.all([
       helius.raw.getEpochInfo(),
       helius.raw.getVersion(),
       helius.raw.getBlockHeight(),

--- a/helius-cli/src/commands/program.ts
+++ b/helius-cli/src/commands/program.ts
@@ -17,7 +17,7 @@ export async function programAccountsCommand(programId: string, options: Program
     const config: any = {};
     if (options.dataSize) config.filters = [{ dataSize: parseInt(options.dataSize, 10) }];
     if (options.limit) config.limit = parseInt(options.limit, 10);
-    const result: any = await withRetry(() => helius.getProgramAccountsV2([programId, config]), options, spinner);
+    const result = await withRetry(() => helius.getProgramAccountsV2([programId, config]), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -57,7 +57,7 @@ export async function programAccountsAllCommand(programId: string, options: Prog
     spinner?.start("Fetching all program accounts (auto-paginating)...");
     const config: any = {};
     if (options.dataSize) config.filters = [{ dataSize: parseInt(options.dataSize, 10) }];
-    const result: any = await withRetry(() => helius.getAllProgramAccounts([programId, config]), options, spinner);
+    const result = await withRetry(() => helius.getAllProgramAccounts([programId, config]), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -82,7 +82,7 @@ export async function programTokenAccountsCommand(owner: string, options: Progra
     const config: any = { encoding: "base64" };
     if (options.limit) config.limit = parseInt(options.limit, 10);
     const filter = { programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" };
-    const result: any = await withRetry(() => helius.getTokenAccountsByOwnerV2([owner, filter, config]), options, spinner);
+    const result = await withRetry(() => helius.getTokenAccountsByOwnerV2([owner, filter, config]), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }

--- a/helius-cli/src/commands/program.ts
+++ b/helius-cli/src/commands/program.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface ProgramOptions extends OutputOptions, ResolveOptions {}
+interface ProgramOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function programAccountsCommand(programId: string, options: ProgramOptions & { dataSize?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -17,7 +17,7 @@ export async function programAccountsCommand(programId: string, options: Program
     const config: any = {};
     if (options.dataSize) config.filters = [{ dataSize: parseInt(options.dataSize, 10) }];
     if (options.limit) config.limit = parseInt(options.limit, 10);
-    const result = await helius.getProgramAccountsV2([programId, config]);
+    const result: any = await withRetry(() => helius.getProgramAccountsV2([programId, config]), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -57,7 +57,7 @@ export async function programAccountsAllCommand(programId: string, options: Prog
     spinner?.start("Fetching all program accounts (auto-paginating)...");
     const config: any = {};
     if (options.dataSize) config.filters = [{ dataSize: parseInt(options.dataSize, 10) }];
-    const result = await helius.getAllProgramAccounts([programId, config]);
+    const result: any = await withRetry(() => helius.getAllProgramAccounts([programId, config]), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -82,7 +82,7 @@ export async function programTokenAccountsCommand(owner: string, options: Progra
     const config: any = { encoding: "base64" };
     if (options.limit) config.limit = parseInt(options.limit, 10);
     const filter = { programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" };
-    const result = await helius.getTokenAccountsByOwnerV2([owner, filter, config]);
+    const result: any = await withRetry(() => helius.getTokenAccountsByOwnerV2([owner, filter, config]), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -13,7 +13,7 @@ export async function sendBroadcastCommand(base64Tx: string, options: SendOption
     const helius = getClient(apiKey, network);
 
     spinner?.start("Broadcasting transaction...");
-    const signature: any = await withRetry(() => helius.tx.broadcastTransaction(base64Tx), options, spinner);
+    const signature = await withRetry(() => helius.tx.broadcastTransaction(base64Tx), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ signature }); return; }
@@ -33,7 +33,7 @@ export async function sendRawCommand(base64Tx: string, options: SendOptions = {}
     const helius = getClient(apiKey, network);
 
     spinner?.start("Sending transaction...");
-    const signature: any = await withRetry(() => helius.tx.sendTransaction({ base64: base64Tx }), options, spinner);
+    const signature = await withRetry(() => helius.tx.sendTransaction({ base64: base64Tx }), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ signature: String(signature) }); return; }
@@ -54,7 +54,7 @@ export async function sendSenderCommand(base64Tx: string, options: SendOptions &
 
     const region = (options.region || "Default") as any;
     spinner?.start(`Sending via Helius Sender (${region})...`);
-    const signature: any = await withRetry(() => helius.tx.sendTransaction({
+    const signature = await withRetry(() => helius.tx.sendTransaction({
       base64: base64Tx,
       sendOptions: { region },
     } as any), options, spinner);
@@ -77,7 +77,7 @@ export async function sendPollCommand(signature: string, options: SendOptions = 
     const helius = getClient(apiKey, network);
 
     spinner?.start("Polling for confirmation...");
-    const result: any = await withRetry(() => helius.tx.pollTransactionConfirmation(signature as any), options, spinner);
+    const result = await withRetry(() => helius.tx.pollTransactionConfirmation(signature as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ signature: String(result), confirmed: true }); return; }
@@ -97,7 +97,7 @@ export async function sendComputeUnitsCommand(base64Tx: string, options: SendOpt
     const helius = getClient(apiKey, network);
 
     spinner?.start("Simulating for compute units...");
-    const result: any = await withRetry(() => helius.tx.getComputeUnits(base64Tx as any), options, spinner);
+    const result = await withRetry(() => helius.tx.getComputeUnits(base64Tx as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ computeUnits: result }); return; }

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -1,8 +1,8 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface SendOptions extends OutputOptions, ResolveOptions {}
+interface SendOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function sendBroadcastCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -13,7 +13,7 @@ export async function sendBroadcastCommand(base64Tx: string, options: SendOption
     const helius = getClient(apiKey, network);
 
     spinner?.start("Broadcasting transaction...");
-    const signature = await helius.tx.broadcastTransaction(base64Tx);
+    const signature: any = await withRetry(() => helius.tx.broadcastTransaction(base64Tx), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ signature }); return; }
@@ -33,7 +33,7 @@ export async function sendRawCommand(base64Tx: string, options: SendOptions = {}
     const helius = getClient(apiKey, network);
 
     spinner?.start("Sending transaction...");
-    const signature = await helius.tx.sendTransaction({ base64: base64Tx });
+    const signature: any = await withRetry(() => helius.tx.sendTransaction({ base64: base64Tx }), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ signature: String(signature) }); return; }
@@ -54,10 +54,10 @@ export async function sendSenderCommand(base64Tx: string, options: SendOptions &
 
     const region = (options.region || "Default") as any;
     spinner?.start(`Sending via Helius Sender (${region})...`);
-    const signature = await helius.tx.sendTransaction({
+    const signature: any = await withRetry(() => helius.tx.sendTransaction({
       base64: base64Tx,
       sendOptions: { region },
-    } as any);
+    } as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ signature }); return; }
@@ -77,7 +77,7 @@ export async function sendPollCommand(signature: string, options: SendOptions = 
     const helius = getClient(apiKey, network);
 
     spinner?.start("Polling for confirmation...");
-    const result = await helius.tx.pollTransactionConfirmation(signature as any);
+    const result: any = await withRetry(() => helius.tx.pollTransactionConfirmation(signature as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ signature: String(result), confirmed: true }); return; }
@@ -97,7 +97,7 @@ export async function sendComputeUnitsCommand(base64Tx: string, options: SendOpt
     const helius = getClient(apiKey, network);
 
     spinner?.start("Simulating for compute units...");
-    const result = await helius.tx.getComputeUnits(base64Tx as any);
+    const result: any = await withRetry(() => helius.tx.getComputeUnits(base64Tx as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ computeUnits: result }); return; }

--- a/helius-cli/src/commands/simd.ts
+++ b/helius-cli/src/commands/simd.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { CLI_USER_AGENT } from "../http.js";
-import { outputJson, handleCommandError, exitWithError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, exitWithError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
 // ---------------------------------------------------------------------------
 // GitHub constants
@@ -74,13 +74,13 @@ function extractFrontMatter(markdown: string): { title: string; status: string; 
 // Commands
 // ---------------------------------------------------------------------------
 
-interface SimdListOptions extends OutputOptions {}
+interface SimdListOptions extends OutputOptions, RetryOptions {}
 
 export async function simdListCommand(options: SimdListOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
     spinner?.start("Fetching SIMD index from GitHub...");
-    const index = await fetchSimdIndex();
+    const index = await withRetry(() => fetchSimdIndex(), options, spinner);
     spinner?.stop();
 
     if (options.json) {
@@ -101,7 +101,7 @@ export async function simdListCommand(options: SimdListOptions = {}): Promise<vo
   }
 }
 
-interface SimdGetOptions extends OutputOptions {}
+interface SimdGetOptions extends OutputOptions, RetryOptions {}
 
 export async function simdGetCommand(number: string, options: SimdGetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -115,7 +115,7 @@ export async function simdGetCommand(number: string, options: SimdGetOptions = {
     spinner?.start(`Fetching SIMD-${paddedNumber}...`);
 
     // Fetch index to find the filename
-    const index = await fetchSimdIndex();
+    const index = await withRetry(() => fetchSimdIndex(), options, spinner);
     const entry = index.find((e) => e.number === paddedNumber);
 
     if (!entry) {

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -14,7 +14,7 @@ export async function stakeAccountsCommand(wallet: string, options: StakeOptions
     const helius = getClient(apiKey, network);
 
     spinner?.start("Fetching Helius stake accounts...");
-    const result: any = await withRetry(() => helius.stake.getHeliusStakeAccounts(wallet as any), options, spinner);
+    const result = await withRetry(() => helius.stake.getHeliusStakeAccounts(wallet as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -42,7 +42,7 @@ export async function stakeWithdrawableCommand(stakeAccount: string, options: St
     const helius = getClient(apiKey, network);
 
     spinner?.start("Checking withdrawable amount...");
-    const result: any = await withRetry(() => helius.stake.getWithdrawableAmount(stakeAccount as any), options, spinner);
+    const result = await withRetry(() => helius.stake.getWithdrawableAmount(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ stakeAccount, withdrawable: result }); return; }
@@ -64,7 +64,7 @@ export async function stakeInstructionsCommand(amount: string, options: StakeOpt
 
     spinner?.start("Getting stake instructions...");
     const lamports = BigInt(Math.round(parseFloat(amount) * 1e9));
-    const result: any = await withRetry(() => helius.stake.getStakeInstructions(lamports), options, spinner);
+    const result = await withRetry(() => helius.stake.getStakeInstructions(lamports), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -85,7 +85,7 @@ export async function stakeUnstakeInstructionCommand(stakeAccount: string, optio
     const helius = getClient(apiKey, network);
 
     spinner?.start("Getting unstake instruction...");
-    const result: any = await withRetry(() => helius.stake.getUnstakeInstruction(stakeAccount as any), options, spinner);
+    const result = await withRetry(() => helius.stake.getUnstakeInstruction(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -106,7 +106,7 @@ export async function stakeWithdrawInstructionCommand(stakeAccount: string, opti
     const helius = getClient(apiKey, network);
 
     spinner?.start("Getting withdraw instruction...");
-    const result: any = await withRetry(() => helius.stake.getWithdrawInstruction(stakeAccount as any), options, spinner);
+    const result = await withRetry(() => helius.stake.getWithdrawInstruction(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -131,7 +131,7 @@ export async function stakeCreateCommand(amount: string, options: StakeOptions &
 
     spinner?.start("Creating stake transaction...");
     const lamports = BigInt(Math.round(parseFloat(amount) * 1e9));
-    const result: any = await withRetry(() => helius.stake.createStakeTransaction(lamports), options, spinner);
+    const result = await withRetry(() => helius.stake.createStakeTransaction(lamports), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -156,7 +156,7 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
     const helius = getClient(apiKey, network);
 
     spinner?.start("Creating unstake transaction...");
-    const result: any = await withRetry(() => helius.stake.createUnstakeTransaction(stakeAccount as any), options, spinner);
+    const result = await withRetry(() => helius.stake.createUnstakeTransaction(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -180,7 +180,7 @@ export async function stakeWithdrawCommand(stakeAccount: string, options: StakeO
     const helius = getClient(apiKey, network);
 
     spinner?.start("Creating withdraw transaction...");
-    const result: any = await withRetry(() => helius.stake.createWithdrawTransaction(stakeAccount as any), options, spinner);
+    const result = await withRetry(() => helius.stake.createWithdrawTransaction(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface StakeOptions extends OutputOptions, ResolveOptions {}
+interface StakeOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function stakeAccountsCommand(wallet: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -14,7 +14,7 @@ export async function stakeAccountsCommand(wallet: string, options: StakeOptions
     const helius = getClient(apiKey, network);
 
     spinner?.start("Fetching Helius stake accounts...");
-    const result = await helius.stake.getHeliusStakeAccounts(wallet as any);
+    const result: any = await withRetry(() => helius.stake.getHeliusStakeAccounts(wallet as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -42,7 +42,7 @@ export async function stakeWithdrawableCommand(stakeAccount: string, options: St
     const helius = getClient(apiKey, network);
 
     spinner?.start("Checking withdrawable amount...");
-    const result = await helius.stake.getWithdrawableAmount(stakeAccount as any);
+    const result: any = await withRetry(() => helius.stake.getWithdrawableAmount(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ stakeAccount, withdrawable: result }); return; }
@@ -64,7 +64,7 @@ export async function stakeInstructionsCommand(amount: string, options: StakeOpt
 
     spinner?.start("Getting stake instructions...");
     const lamports = BigInt(Math.round(parseFloat(amount) * 1e9));
-    const result = await helius.stake.getStakeInstructions(lamports);
+    const result: any = await withRetry(() => helius.stake.getStakeInstructions(lamports), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -85,7 +85,7 @@ export async function stakeUnstakeInstructionCommand(stakeAccount: string, optio
     const helius = getClient(apiKey, network);
 
     spinner?.start("Getting unstake instruction...");
-    const result = await helius.stake.getUnstakeInstruction(stakeAccount as any);
+    const result: any = await withRetry(() => helius.stake.getUnstakeInstruction(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -106,7 +106,7 @@ export async function stakeWithdrawInstructionCommand(stakeAccount: string, opti
     const helius = getClient(apiKey, network);
 
     spinner?.start("Getting withdraw instruction...");
-    const result = await helius.stake.getWithdrawInstruction(stakeAccount as any);
+    const result: any = await withRetry(() => helius.stake.getWithdrawInstruction(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -131,7 +131,7 @@ export async function stakeCreateCommand(amount: string, options: StakeOptions &
 
     spinner?.start("Creating stake transaction...");
     const lamports = BigInt(Math.round(parseFloat(amount) * 1e9));
-    const result = await helius.stake.createStakeTransaction(lamports);
+    const result: any = await withRetry(() => helius.stake.createStakeTransaction(lamports), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -156,7 +156,7 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
     const helius = getClient(apiKey, network);
 
     spinner?.start("Creating unstake transaction...");
-    const result = await helius.stake.createUnstakeTransaction(stakeAccount as any);
+    const result: any = await withRetry(() => helius.stake.createUnstakeTransaction(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -180,7 +180,7 @@ export async function stakeWithdrawCommand(stakeAccount: string, options: StakeO
     const helius = getClient(apiKey, network);
 
     spinner?.start("Creating withdraw transaction...");
-    const result = await helius.stake.createWithdrawTransaction(stakeAccount as any);
+    const result: any = await withRetry(() => helius.stake.createWithdrawTransaction(stakeAccount as any), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatTimestamp, formatAddress, formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface TxOptions extends OutputOptions, ResolveOptions {}
+interface TxOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function txParseCommand(signatures: string[], options: TxOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -14,7 +14,7 @@ export async function txParseCommand(signatures: string[], options: TxOptions = 
     const helius = getClient(apiKey, network);
 
     spinner?.start(`Parsing ${signatures.length} transaction(s)...`);
-    const result = await helius.enhanced.getTransactions({ transactions: signatures });
+    const result: any = await withRetry(() => helius.enhanced.getTransactions({ transactions: signatures }), options, spinner);
     spinner?.stop();
 
     if (options.json) {
@@ -70,7 +70,7 @@ export async function txHistoryCommand(address: string, options: TxOptions & { l
     if (options.limit) params.limit = parseInt(options.limit, 10);
     if (options.before) params.before = options.before;
     if (options.type) params.type = options.type;
-    const result = await helius.enhanced.getTransactionsByAddress(params);
+    const result: any = await withRetry(() => helius.enhanced.getTransactionsByAddress(params), options, spinner);
     spinner?.stop();
 
     if (options.json) {
@@ -114,7 +114,7 @@ export async function txFeesCommand(options: TxOptions & { accounts?: string } =
     if (options.accounts) {
       params.accountKeys = options.accounts.split(",").map((s: string) => s.trim());
     }
-    const result = await helius.getPriorityFeeEstimate(params);
+    const result: any = await withRetry(() => helius.getPriorityFeeEstimate(params), options, spinner);
     spinner?.stop();
 
     if (options.json) {

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -14,7 +14,7 @@ export async function txParseCommand(signatures: string[], options: TxOptions = 
     const helius = getClient(apiKey, network);
 
     spinner?.start(`Parsing ${signatures.length} transaction(s)...`);
-    const result: any = await withRetry(() => helius.enhanced.getTransactions({ transactions: signatures }), options, spinner);
+    const result = await withRetry(() => helius.enhanced.getTransactions({ transactions: signatures }), options, spinner);
     spinner?.stop();
 
     if (options.json) {
@@ -70,7 +70,7 @@ export async function txHistoryCommand(address: string, options: TxOptions & { l
     if (options.limit) params.limit = parseInt(options.limit, 10);
     if (options.before) params.before = options.before;
     if (options.type) params.type = options.type;
-    const result: any = await withRetry(() => helius.enhanced.getTransactionsByAddress(params), options, spinner);
+    const result = await withRetry(() => helius.enhanced.getTransactionsByAddress(params), options, spinner);
     spinner?.stop();
 
     if (options.json) {
@@ -114,7 +114,7 @@ export async function txFeesCommand(options: TxOptions & { accounts?: string } =
     if (options.accounts) {
       params.accountKeys = options.accounts.split(",").map((s: string) => s.trim());
     }
-    const result: any = await withRetry(() => helius.getPriorityFeeEstimate(params), options, spinner);
+    const result = await withRetry(() => helius.getPriorityFeeEstimate(params), options, spinner);
     spinner?.stop();
 
     if (options.json) {

--- a/helius-cli/src/commands/wallet.ts
+++ b/helius-cli/src/commands/wallet.ts
@@ -11,7 +11,7 @@ export async function walletIdentityCommand(address: string, options: WalletOpti
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start("Looking up wallet identity...");
-    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/identity`, apiKey), options, spinner);
+    const result = await withRetry(() => restRequest(`/v1/wallet/${address}/identity`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     if (!result || (!result.name && !result.type)) {
@@ -34,7 +34,7 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start(`Looking up ${addresses.length} wallet(s)...`);
-    const result: any = await withRetry(() => restRequest("/v1/wallet/batch-identity", apiKey, {
+    const result = await withRetry(() => restRequest("/v1/wallet/batch-identity", apiKey, {
       method: "POST",
       body: JSON.stringify({ addresses }),
     }), options, spinner);
@@ -65,7 +65,7 @@ export async function walletBalancesCommand(address: string, options: WalletOpti
     if (options.showNfts) params.set("showNfts", "true");
     const qs = params.toString();
     spinner?.start("Fetching wallet balances...");
-    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/balances${qs ? "?" + qs : ""}`, apiKey), options, spinner);
+    const result = await withRetry(() => restRequest(`/v1/wallet/${address}/balances${qs ? "?" + qs : ""}`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nBalances for ${chalk.cyan(address)}:\n`));
@@ -110,7 +110,7 @@ export async function walletHistoryCommand(address: string, options: WalletOptio
     if (options.before) params.set("before", options.before);
     const qs = params.toString();
     spinner?.start("Fetching wallet history...");
-    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/history${qs ? "?" + qs : ""}`, apiKey), options, spinner);
+    const result = await withRetry(() => restRequest(`/v1/wallet/${address}/history${qs ? "?" + qs : ""}`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const txs = result?.data || result?.transactions || result || [];
@@ -144,7 +144,7 @@ export async function walletTransfersCommand(address: string, options: WalletOpt
     if (options.cursor) params.set("cursor", options.cursor);
     const qs = params.toString();
     spinner?.start("Fetching wallet transfers...");
-    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/transfers${qs ? "?" + qs : ""}`, apiKey), options, spinner);
+    const result = await withRetry(() => restRequest(`/v1/wallet/${address}/transfers${qs ? "?" + qs : ""}`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const transfers = result?.data || result?.transfers || result || [];
@@ -173,7 +173,7 @@ export async function walletFundedByCommand(address: string, options: WalletOpti
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start("Finding funding source...");
-    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/funded-by`, apiKey), options, spinner);
+    const result = await withRetry(() => restRequest(`/v1/wallet/${address}/funded-by`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nFunding Source for ${chalk.cyan(address)}:\n`));

--- a/helius-cli/src/commands/wallet.ts
+++ b/helius-cli/src/commands/wallet.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import { resolveApiKey, restRequest, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, formatEnumLabel, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface WalletOptions extends OutputOptions, ResolveOptions {}
+interface WalletOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function walletIdentityCommand(address: string, options: WalletOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -11,7 +11,7 @@ export async function walletIdentityCommand(address: string, options: WalletOpti
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start("Looking up wallet identity...");
-    const result = await restRequest(`/v1/wallet/${address}/identity`, apiKey);
+    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/identity`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     if (!result || (!result.name && !result.type)) {
@@ -34,10 +34,10 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start(`Looking up ${addresses.length} wallet(s)...`);
-    const result = await restRequest("/v1/wallet/batch-identity", apiKey, {
+    const result: any = await withRetry(() => restRequest("/v1/wallet/batch-identity", apiKey, {
       method: "POST",
       body: JSON.stringify({ addresses }),
-    });
+    }), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const identities = Array.isArray(result) ? result : [];
@@ -65,7 +65,7 @@ export async function walletBalancesCommand(address: string, options: WalletOpti
     if (options.showNfts) params.set("showNfts", "true");
     const qs = params.toString();
     spinner?.start("Fetching wallet balances...");
-    const result = await restRequest(`/v1/wallet/${address}/balances${qs ? "?" + qs : ""}`, apiKey);
+    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/balances${qs ? "?" + qs : ""}`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nBalances for ${chalk.cyan(address)}:\n`));
@@ -110,7 +110,7 @@ export async function walletHistoryCommand(address: string, options: WalletOptio
     if (options.before) params.set("before", options.before);
     const qs = params.toString();
     spinner?.start("Fetching wallet history...");
-    const result = await restRequest(`/v1/wallet/${address}/history${qs ? "?" + qs : ""}`, apiKey);
+    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/history${qs ? "?" + qs : ""}`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const txs = result?.data || result?.transactions || result || [];
@@ -144,7 +144,7 @@ export async function walletTransfersCommand(address: string, options: WalletOpt
     if (options.cursor) params.set("cursor", options.cursor);
     const qs = params.toString();
     spinner?.start("Fetching wallet transfers...");
-    const result = await restRequest(`/v1/wallet/${address}/transfers${qs ? "?" + qs : ""}`, apiKey);
+    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/transfers${qs ? "?" + qs : ""}`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     const transfers = result?.data || result?.transfers || result || [];
@@ -173,7 +173,7 @@ export async function walletFundedByCommand(address: string, options: WalletOpti
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start("Finding funding source...");
-    const result = await restRequest(`/v1/wallet/${address}/funded-by`, apiKey);
+    const result: any = await withRetry(() => restRequest(`/v1/wallet/${address}/funded-by`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
     console.log(chalk.bold(`\nFunding Source for ${chalk.cyan(address)}:\n`));

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -1,10 +1,10 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 import { validateSolanaAddresses } from "../lib/validation.js";
 
-interface WebhookOptions extends OutputOptions, ResolveOptions {}
+interface WebhookOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function webhookListCommand(options: WebhookOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -14,7 +14,7 @@ export async function webhookListCommand(options: WebhookOptions = {}): Promise<
     const helius = getClient(apiKey, resolveNetwork(options));
 
     spinner?.start("Fetching webhooks...");
-    const result = await helius.webhooks.getAll();
+    const result: any = await withRetry(() => helius.webhooks.getAll(), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -47,7 +47,7 @@ export async function webhookGetCommand(webhookId: string, options: WebhookOptio
     const helius = getClient(apiKey, resolveNetwork(options));
 
     spinner?.start("Fetching webhook...");
-    const result = await helius.webhooks.get(webhookId);
+    const result: any = await withRetry(() => helius.webhooks.get(webhookId), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -86,12 +86,12 @@ export async function webhookCreateCommand(options: WebhookOptions & {
     const webhookType = (options.webhookType || "enhanced") as any;
 
     spinner?.start("Creating webhook...");
-    const result = await helius.webhooks.create({
+    const result: any = await withRetry(() => helius.webhooks.create({
       webhookURL: options.url,
       accountAddresses,
       transactionTypes: transactionTypes as any,
       webhookType,
-    });
+    }), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -125,7 +125,7 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
     if (options.types) params.transactionTypes = options.types.split(",").map((s: string) => s.trim()).filter(Boolean);
 
     spinner?.start("Updating webhook...");
-    const result = await helius.webhooks.update(webhookId, params);
+    const result: any = await withRetry(() => helius.webhooks.update(webhookId, params), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -144,7 +144,7 @@ export async function webhookDeleteCommand(webhookId: string, options: WebhookOp
     const helius = getClient(apiKey, resolveNetwork(options));
 
     spinner?.start("Deleting webhook...");
-    await helius.webhooks.delete(webhookId);
+    await withRetry(() => helius.webhooks.delete(webhookId), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson({ success: true, webhookID: webhookId }); return; }

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -14,7 +14,7 @@ export async function webhookListCommand(options: WebhookOptions = {}): Promise<
     const helius = getClient(apiKey, resolveNetwork(options));
 
     spinner?.start("Fetching webhooks...");
-    const result: any = await withRetry(() => helius.webhooks.getAll(), options, spinner);
+    const result = await withRetry(() => helius.webhooks.getAll(), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -47,7 +47,7 @@ export async function webhookGetCommand(webhookId: string, options: WebhookOptio
     const helius = getClient(apiKey, resolveNetwork(options));
 
     spinner?.start("Fetching webhook...");
-    const result: any = await withRetry(() => helius.webhooks.get(webhookId), options, spinner);
+    const result = await withRetry(() => helius.webhooks.get(webhookId), options, spinner) as any;
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -86,12 +86,12 @@ export async function webhookCreateCommand(options: WebhookOptions & {
     const webhookType = (options.webhookType || "enhanced") as any;
 
     spinner?.start("Creating webhook...");
-    const result: any = await withRetry(() => helius.webhooks.create({
+    const result = await withRetry(() => helius.webhooks.create({
       webhookURL: options.url,
       accountAddresses,
       transactionTypes: transactionTypes as any,
       webhookType,
-    }), options, spinner);
+    }), options, spinner) as any;
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
@@ -125,7 +125,7 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
     if (options.types) params.transactionTypes = options.types.split(",").map((s: string) => s.trim()).filter(Boolean);
 
     spinner?.start("Updating webhook...");
-    const result: any = await withRetry(() => helius.webhooks.update(webhookId, params), options, spinner);
+    const result = await withRetry(() => helius.webhooks.update(webhookId, params), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }

--- a/helius-cli/src/commands/zk.ts
+++ b/helius-cli/src/commands/zk.ts
@@ -24,7 +24,7 @@ export async function zkAccountCommand(addressOrHash: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed account...");
-    const result: any = await withRetry(() => helius.zk.getCompressedAccount({ address: addressOrHash }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedAccount({ address: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Account");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -35,7 +35,7 @@ export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed accounts by owner...");
-    const result: any = await withRetry(() => helius.zk.getCompressedAccountsByOwner({ owner }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedAccountsByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Accounts by Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -46,7 +46,7 @@ export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed balance...");
-    const result: any = await withRetry(() => helius.zk.getCompressedBalance({ address: addressOrHash }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedBalance({ address: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Balance");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -57,7 +57,7 @@ export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions 
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed balance by owner...");
-    const result: any = await withRetry(() => helius.zk.getCompressedBalanceByOwner({ owner }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedBalanceByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Balance by Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -68,7 +68,7 @@ export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token holders...");
-    const result: any = await withRetry(() => helius.zk.getCompressedMintTokenHolders({ mint }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedMintTokenHolders({ mint }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Holders");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -79,7 +79,7 @@ export async function zkTokenBalanceCommand(account: string, options: ZkOptions 
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token account balance...");
-    const result: any = await withRetry(() => helius.zk.getCompressedTokenAccountBalance({ address: account }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedTokenAccountBalance({ address: account }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Account Balance");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -90,7 +90,7 @@ export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOp
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token accounts by owner...");
-    const result: any = await withRetry(() => helius.zk.getCompressedTokenAccountsByOwner({ owner }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedTokenAccountsByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Accounts by Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -101,7 +101,7 @@ export async function zkTokenAccountsByDelegateCommand(delegate: string, options
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token accounts by delegate...");
-    const result: any = await withRetry(() => helius.zk.getCompressedTokenAccountsByDelegate({ delegate }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedTokenAccountsByDelegate({ delegate }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Accounts by Delegate");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -112,7 +112,7 @@ export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOp
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token balances by owner (V2)...");
-    const result: any = await withRetry(() => helius.zk.getCompressedTokenBalancesByOwnerV2({ owner }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedTokenBalancesByOwnerV2({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Balances by Owner (V2)");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -123,7 +123,7 @@ export async function zkProofCommand(addressOrHash: string, options: ZkOptions =
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed account proof...");
-    const result: any = await withRetry(() => helius.zk.getCompressedAccountProof({ hash: addressOrHash }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressedAccountProof({ hash: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Account Proof");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -134,7 +134,7 @@ export async function zkProofsCommand(addresses: string[], options: ZkOptions = 
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching proofs for ${addresses.length} account(s)...`);
-    const result: any = await withRetry(() => helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses }), options, spinner);
+    const result = await withRetry(() => helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses }), options, spinner);
     handleResult(spinner, result, options, "Multiple Compressed Account Proofs");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -145,7 +145,7 @@ export async function zkMultipleAccountsCommand(addresses: string[], options: Zk
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching ${addresses.length} compressed account(s)...`);
-    const result: any = await withRetry(() => helius.zk.getMultipleCompressedAccounts({ addresses }), options, spinner);
+    const result = await withRetry(() => helius.zk.getMultipleCompressedAccounts({ addresses }), options, spinner);
     handleResult(spinner, result, options, "Multiple Compressed Accounts");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -156,7 +156,7 @@ export async function zkAddressProofsCommand(addresses: string[], options: ZkOpt
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching address proofs (V2)...`);
-    const result: any = await withRetry(() => helius.zk.getMultipleNewAddressProofsV2(addresses), options, spinner);
+    const result = await withRetry(() => helius.zk.getMultipleNewAddressProofsV2(addresses), options, spinner);
     handleResult(spinner, result, options, "Multiple New Address Proofs (V2)");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -167,7 +167,7 @@ export async function zkSignaturesAccountCommand(account: string, options: ZkOpt
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for account...");
-    const result: any = await withRetry(() => helius.zk.getCompressionSignaturesForAccount({ hash: account }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressionSignaturesForAccount({ hash: account }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Account");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -178,7 +178,7 @@ export async function zkSignaturesAddressCommand(address: string, options: ZkOpt
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for address...");
-    const result: any = await withRetry(() => helius.zk.getCompressionSignaturesForAddress({ address }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressionSignaturesForAddress({ address }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Address");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -189,7 +189,7 @@ export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for owner...");
-    const result: any = await withRetry(() => helius.zk.getCompressionSignaturesForOwner({ owner }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressionSignaturesForOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -200,7 +200,7 @@ export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOp
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for token owner...");
-    const result: any = await withRetry(() => helius.zk.getCompressionSignaturesForTokenOwner({ owner }), options, spinner);
+    const result = await withRetry(() => helius.zk.getCompressionSignaturesForTokenOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Token Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -211,7 +211,7 @@ export async function zkLatestSignaturesCommand(options: ZkOptions = {}): Promis
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching latest compression signatures...");
-    const result: any = await withRetry(() => helius.zk.getLatestCompressionSignatures({}), options, spinner);
+    const result = await withRetry(() => helius.zk.getLatestCompressionSignatures({}), options, spinner);
     handleResult(spinner, result, options, "Latest Compression Signatures");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -222,7 +222,7 @@ export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching latest non-voting signatures...");
-    const result: any = await withRetry(() => helius.zk.getLatestNonVotingSignatures({}), options, spinner);
+    const result = await withRetry(() => helius.zk.getLatestNonVotingSignatures({}), options, spinner);
     handleResult(spinner, result, options, "Latest Non-Voting Signatures");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -233,7 +233,7 @@ export async function zkTxCommand(signature: string, options: ZkOptions = {}): P
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching transaction with compression info...");
-    const result: any = await withRetry(() => helius.zk.getTransactionWithCompressionInfo({ signature }), options, spinner);
+    const result = await withRetry(() => helius.zk.getTransactionWithCompressionInfo({ signature }), options, spinner);
     handleResult(spinner, result, options, "Transaction with Compression Info");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -247,7 +247,7 @@ export async function zkValidityProofCommand(options: ZkOptions & { hashes?: str
     const params: any = {};
     if (options.hashes) params.hashes = options.hashes.split(",").map((s: string) => s.trim());
     if (options.addresses) params.newAddressesWithTrees = options.addresses.split(",").map((s: string) => ({ address: s.trim(), tree: "" }));
-    const result: any = await withRetry(() => helius.zk.getValidityProof(params), options, spinner);
+    const result = await withRetry(() => helius.zk.getValidityProof(params), options, spinner);
     handleResult(spinner, result, options, "Validity Proof");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -258,7 +258,7 @@ export async function zkIndexerHealthCommand(options: ZkOptions = {}): Promise<v
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Checking indexer health...");
-    const result: any = await withRetry(() => helius.zk.getIndexerHealth(), options, spinner);
+    const result = await withRetry(() => helius.zk.getIndexerHealth(), options, spinner);
     handleResult(spinner, result, options, "Indexer Health");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -269,7 +269,7 @@ export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<voi
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching indexer slot...");
-    const result: any = await withRetry(() => helius.zk.getIndexerSlot(), options, spinner);
+    const result = await withRetry(() => helius.zk.getIndexerSlot(), options, spinner);
     handleResult(spinner, result, options, "Indexer Slot");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -280,7 +280,7 @@ export async function zkSignaturesForAssetCommand(id: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching signatures for asset...");
-    const result: any = await withRetry(() => helius.zk.getSignaturesForAsset({ id, page: 1 }), options, spinner);
+    const result = await withRetry(() => helius.zk.getSignaturesForAsset({ id, page: 1 }), options, spinner);
     handleResult(spinner, result, options, "Signatures for Asset");
   } catch (error) {
     handleCommandError(error, options, spinner);

--- a/helius-cli/src/commands/zk.ts
+++ b/helius-cli/src/commands/zk.ts
@@ -1,8 +1,8 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface ZkOptions extends OutputOptions, ResolveOptions {}
+interface ZkOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 async function setup(spinner: any, options: ZkOptions, message: string) {
   spinner?.start("Resolving API key...");
@@ -24,7 +24,7 @@ export async function zkAccountCommand(addressOrHash: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed account...");
-    const result = await helius.zk.getCompressedAccount({ address: addressOrHash });
+    const result: any = await withRetry(() => helius.zk.getCompressedAccount({ address: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Account");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -35,7 +35,7 @@ export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed accounts by owner...");
-    const result = await helius.zk.getCompressedAccountsByOwner({ owner });
+    const result: any = await withRetry(() => helius.zk.getCompressedAccountsByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Accounts by Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -46,7 +46,7 @@ export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed balance...");
-    const result = await helius.zk.getCompressedBalance({ address: addressOrHash });
+    const result: any = await withRetry(() => helius.zk.getCompressedBalance({ address: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Balance");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -57,7 +57,7 @@ export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions 
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed balance by owner...");
-    const result = await helius.zk.getCompressedBalanceByOwner({ owner });
+    const result: any = await withRetry(() => helius.zk.getCompressedBalanceByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Balance by Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -68,7 +68,7 @@ export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token holders...");
-    const result = await helius.zk.getCompressedMintTokenHolders({ mint });
+    const result: any = await withRetry(() => helius.zk.getCompressedMintTokenHolders({ mint }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Holders");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -79,7 +79,7 @@ export async function zkTokenBalanceCommand(account: string, options: ZkOptions 
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token account balance...");
-    const result = await helius.zk.getCompressedTokenAccountBalance({ address: account });
+    const result: any = await withRetry(() => helius.zk.getCompressedTokenAccountBalance({ address: account }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Account Balance");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -90,7 +90,7 @@ export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOp
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token accounts by owner...");
-    const result = await helius.zk.getCompressedTokenAccountsByOwner({ owner });
+    const result: any = await withRetry(() => helius.zk.getCompressedTokenAccountsByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Accounts by Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -101,7 +101,7 @@ export async function zkTokenAccountsByDelegateCommand(delegate: string, options
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token accounts by delegate...");
-    const result = await helius.zk.getCompressedTokenAccountsByDelegate({ delegate });
+    const result: any = await withRetry(() => helius.zk.getCompressedTokenAccountsByDelegate({ delegate }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Accounts by Delegate");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -112,7 +112,7 @@ export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOp
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed token balances by owner (V2)...");
-    const result = await helius.zk.getCompressedTokenBalancesByOwnerV2({ owner });
+    const result: any = await withRetry(() => helius.zk.getCompressedTokenBalancesByOwnerV2({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Balances by Owner (V2)");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -123,7 +123,7 @@ export async function zkProofCommand(addressOrHash: string, options: ZkOptions =
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compressed account proof...");
-    const result = await helius.zk.getCompressedAccountProof({ hash: addressOrHash });
+    const result: any = await withRetry(() => helius.zk.getCompressedAccountProof({ hash: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Account Proof");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -134,7 +134,7 @@ export async function zkProofsCommand(addresses: string[], options: ZkOptions = 
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching proofs for ${addresses.length} account(s)...`);
-    const result = await helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses });
+    const result: any = await withRetry(() => helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses }), options, spinner);
     handleResult(spinner, result, options, "Multiple Compressed Account Proofs");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -145,7 +145,7 @@ export async function zkMultipleAccountsCommand(addresses: string[], options: Zk
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching ${addresses.length} compressed account(s)...`);
-    const result = await helius.zk.getMultipleCompressedAccounts({ addresses });
+    const result: any = await withRetry(() => helius.zk.getMultipleCompressedAccounts({ addresses }), options, spinner);
     handleResult(spinner, result, options, "Multiple Compressed Accounts");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -156,7 +156,7 @@ export async function zkAddressProofsCommand(addresses: string[], options: ZkOpt
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, `Fetching address proofs (V2)...`);
-    const result = await helius.zk.getMultipleNewAddressProofsV2(addresses);
+    const result: any = await withRetry(() => helius.zk.getMultipleNewAddressProofsV2(addresses), options, spinner);
     handleResult(spinner, result, options, "Multiple New Address Proofs (V2)");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -167,7 +167,7 @@ export async function zkSignaturesAccountCommand(account: string, options: ZkOpt
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for account...");
-    const result = await helius.zk.getCompressionSignaturesForAccount({ hash: account });
+    const result: any = await withRetry(() => helius.zk.getCompressionSignaturesForAccount({ hash: account }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Account");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -178,7 +178,7 @@ export async function zkSignaturesAddressCommand(address: string, options: ZkOpt
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for address...");
-    const result = await helius.zk.getCompressionSignaturesForAddress({ address });
+    const result: any = await withRetry(() => helius.zk.getCompressionSignaturesForAddress({ address }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Address");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -189,7 +189,7 @@ export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for owner...");
-    const result = await helius.zk.getCompressionSignaturesForOwner({ owner });
+    const result: any = await withRetry(() => helius.zk.getCompressionSignaturesForOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -200,7 +200,7 @@ export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOp
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching compression signatures for token owner...");
-    const result = await helius.zk.getCompressionSignaturesForTokenOwner({ owner });
+    const result: any = await withRetry(() => helius.zk.getCompressionSignaturesForTokenOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Token Owner");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -211,7 +211,7 @@ export async function zkLatestSignaturesCommand(options: ZkOptions = {}): Promis
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching latest compression signatures...");
-    const result = await helius.zk.getLatestCompressionSignatures({});
+    const result: any = await withRetry(() => helius.zk.getLatestCompressionSignatures({}), options, spinner);
     handleResult(spinner, result, options, "Latest Compression Signatures");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -222,7 +222,7 @@ export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching latest non-voting signatures...");
-    const result = await helius.zk.getLatestNonVotingSignatures({});
+    const result: any = await withRetry(() => helius.zk.getLatestNonVotingSignatures({}), options, spinner);
     handleResult(spinner, result, options, "Latest Non-Voting Signatures");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -233,7 +233,7 @@ export async function zkTxCommand(signature: string, options: ZkOptions = {}): P
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching transaction with compression info...");
-    const result = await helius.zk.getTransactionWithCompressionInfo({ signature });
+    const result: any = await withRetry(() => helius.zk.getTransactionWithCompressionInfo({ signature }), options, spinner);
     handleResult(spinner, result, options, "Transaction with Compression Info");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -247,7 +247,7 @@ export async function zkValidityProofCommand(options: ZkOptions & { hashes?: str
     const params: any = {};
     if (options.hashes) params.hashes = options.hashes.split(",").map((s: string) => s.trim());
     if (options.addresses) params.newAddressesWithTrees = options.addresses.split(",").map((s: string) => ({ address: s.trim(), tree: "" }));
-    const result = await helius.zk.getValidityProof(params);
+    const result: any = await withRetry(() => helius.zk.getValidityProof(params), options, spinner);
     handleResult(spinner, result, options, "Validity Proof");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -258,7 +258,7 @@ export async function zkIndexerHealthCommand(options: ZkOptions = {}): Promise<v
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Checking indexer health...");
-    const result = await helius.zk.getIndexerHealth();
+    const result: any = await withRetry(() => helius.zk.getIndexerHealth(), options, spinner);
     handleResult(spinner, result, options, "Indexer Health");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -269,7 +269,7 @@ export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<voi
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching indexer slot...");
-    const result = await helius.zk.getIndexerSlot();
+    const result: any = await withRetry(() => helius.zk.getIndexerSlot(), options, spinner);
     handleResult(spinner, result, options, "Indexer Slot");
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -280,7 +280,7 @@ export async function zkSignaturesForAssetCommand(id: string, options: ZkOptions
   const spinner = createSpinner(options);
   try {
     const helius = await setup(spinner, options, "Fetching signatures for asset...");
-    const result = await helius.zk.getSignaturesForAsset({ id, page: 1 });
+    const result: any = await withRetry(() => helius.zk.getSignaturesForAsset({ id, page: 1 }), options, spinner);
     handleResult(spinner, result, options, "Signatures for Asset");
   } catch (error) {
     handleCommandError(error, options, spinner);

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -316,6 +316,42 @@ export function exitWithError(
   process.exit(exitCode);
 }
 
+export interface RetryOptions {
+  retry?: string | number;
+  json?: boolean;
+}
+
+/**
+ * Wrap an async function with exponential backoff retry on transient errors.
+ * Only retries errors classified as retryable (429, 5xx, network).
+ * Non-retryable errors are re-thrown immediately.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions,
+  spinner?: { start(text: string): void } | null,
+): Promise<T> {
+  const maxRetries = Math.max(0, parseInt(String(options.retry ?? 0), 10) || 0);
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await fn();
+    } catch (error) {
+      const { retryable } = classifyError(error);
+      if (!retryable || attempt >= maxRetries) {
+        throw error;
+      }
+
+      attempt++;
+      const delay = Math.min(1000 * 2 ** (attempt - 1), 30_000);
+      const message = error instanceof Error ? error.message : String(error);
+      spinner?.start(`${message} — retrying in ${delay / 1000}s (${attempt}/${maxRetries})...`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
 /** Prompt the user for yes/no confirmation. Returns true if they answer y/yes. */
 export function confirm(question: string): Promise<boolean> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -318,7 +318,6 @@ export function exitWithError(
 
 export interface RetryOptions {
   retry?: string | number;
-  json?: boolean;
 }
 
 /**


### PR DESCRIPTION
This PR adds a global `--retry <n>` flag (default: n = 0) for automatic retries on transient errors (e.g., 429, 5xx, network errors). We exclude auth/payment, streaming, and local-only commands, and do not retry non-retryable errors (e.g., 400, 401, 404). We also implement an exponential backoff that starts at 1s and caps at 30s