### PR TITLE
feat(cli): Add `llms.txt` File

### DIFF
--- a/helius-cli/README.md
+++ b/helius-cli/README.md
@@ -82,6 +82,8 @@ helius config clear               # Reset config
 | `helius apikeys [project-id]` | List API keys |
 | `helius apikeys create [project-id]` | Create a new API key |
 | `helius usage [project-id]` | Show credits usage |
+| `helius status` | Show account status: plan, credits, billing cycle |
+| `helius plans` | List available Helius plans and pricing |
 | `helius rpc [project-id]` | Show RPC endpoints |
 
 ### Balances & Tokens

--- a/helius-cli/llms.txt
+++ b/helius-cli/llms.txt
@@ -18,7 +18,7 @@ Exit code ranges:
 - `20-29` balance/payment (insufficient SOL/USDC)
 - `30-39` project state
 - `40-49` API errors
-- `50-59` SDK/data errors (52 invalid address, 54 invalid API key, 55 not found, 56 rate limited, 57 server error, 58 network error)
+- `50-59` SDK/data errors (50 no API key, 52 invalid address, 53 invalid input, 54 invalid API key, 55 not found, 56 rate limited, 57 server error, 58 network error)
 
 ## Commands
 

--- a/helius-cli/llms.txt
+++ b/helius-cli/llms.txt
@@ -44,8 +44,10 @@ Exit code ranges:
 - `--retry <n>` — retry transient errors up to `n` times with exponential backoff (default `0`)
 - `-k, --keypair <path>` — keypair file path (for `signup`, `login`, `upgrade`, `pay`, `stake`)
 
-## Optional
+## Resources
 
-- [Full README](README.md): complete command reference, configuration, and development setup
-- [Helius docs](https://www.helius.dev/docs): platform API documentation (RPC, DAS, Sender, webhooks, Laserstream)
-- [Helius dashboard](https://dashboard.helius.dev): manage API keys, billing, and webhooks in the browser
+- [Full README](README.md): Complete command reference, configuration, and development setup for the Helius CLI
+- [Helius Agents Documentation](https://www.helius.dev/docs/agents/llms.txt): Machine-readable index of all agent-focused documentation for the Helius Solana platform
+- [Helius for Agents](https://www.helius.dev/docs/agents/overview.md): Everything AI agents need to build on Solana with Helius
+- [Helius Docs](https://www.helius.dev/docs): Platform API documentation (RPC, DAS, Sender, webhooks, Laserstream)
+- [Helius Dashboard](https://dashboard.helius.dev): Manage API keys, billing, and webhooks in the browser

--- a/helius-cli/llms.txt
+++ b/helius-cli/llms.txt
@@ -1,8 +1,8 @@
 # Helius CLI (`helius`)
 
-> Official command-line interface for the Helius Solana platform. Built for developers and LLM agents.
+> Official command-line interface for the Helius, Solana's leading developer platform. Built for developers and LLM agents.
 
-`helius` covers account management, Solana data queries (balances, transactions, assets, accounts, blocks), Digital Asset Standard (DAS), ZK compression, webhooks, priority fees, transaction sending, staking, and real-time WebSocket streaming.
+`helius` covers account management, Solana data queries (balances, transactions, assets, accounts, blocks), Digital Asset Standard (DAS), ZK compression, webhooks, priority fees, transaction sending, staking, and WebSocket streaming.
 
 Install: `npm install -g helius-cli`
 
@@ -47,5 +47,5 @@ Exit code ranges:
 ## Optional
 
 - [Full README](README.md): complete command reference, configuration, and development setup
-- [Helius platform docs](https://docs.helius.dev): platform API documentation (RPC, DAS, Sender, webhooks, Laserstream)
+- [Helius platform docs](https://www.helius.dev/docs): platform API documentation (RPC, DAS, Sender, webhooks, Laserstream)
 - [Helius dashboard](https://dashboard.helius.dev): manage API keys, billing, and webhooks in the browser

--- a/helius-cli/llms.txt
+++ b/helius-cli/llms.txt
@@ -47,5 +47,5 @@ Exit code ranges:
 ## Optional
 
 - [Full README](README.md): complete command reference, configuration, and development setup
-- [Helius platform docs](https://www.helius.dev/docs): platform API documentation (RPC, DAS, Sender, webhooks, Laserstream)
+- [Helius docs](https://www.helius.dev/docs): platform API documentation (RPC, DAS, Sender, webhooks, Laserstream)
 - [Helius dashboard](https://dashboard.helius.dev): manage API keys, billing, and webhooks in the browser

--- a/helius-cli/llms.txt
+++ b/helius-cli/llms.txt
@@ -1,0 +1,51 @@
+# Helius CLI (`helius`)
+
+> Official command-line interface for the Helius Solana platform. Built for developers and LLM agents.
+
+`helius` covers account management, Solana data queries (balances, transactions, assets, accounts, blocks), Digital Asset Standard (DAS), ZK compression, webhooks, priority fees, transaction sending, staking, and real-time WebSocket streaming.
+
+Install: `npm install -g helius-cli`
+
+Agents: set `NO_DNA=1` to suppress spinners and unblock non-interactive flows. All data commands support `--json` for machine-readable output. `--retry <n>` enables exponential-backoff retry on transient errors.
+
+## Error handling
+
+Commands exit with distinct codes per error class. When `--json` is set, errors are output as `{ error, message, retryable, guidance? }` on stdout; the `retryable` field indicates whether the error is transient (429, 5xx, network) vs. permanent (400, 401, 404, invalid input).
+
+Exit code ranges:
+- `0` success, `1` general error
+- `10-19` authentication (not logged in, keypair missing)
+- `20-29` balance/payment (insufficient SOL/USDC)
+- `30-39` project state
+- `40-49` API errors
+- `50-59` SDK/data errors (52 invalid address, 54 invalid API key, 55 not found, 56 rate limited, 57 server error, 58 network error)
+
+## Commands
+
+- [Account management](README.md#account-management): `keygen`, `signup`, `login`, `upgrade`, `pay`, `projects`, `project`, `apikeys`, `usage`, `rpc`, `status`, `plans`, `config`
+- [Balances & tokens](README.md#balances--tokens): `balance`, `tokens`, `token-holders`
+- [Transactions](README.md#transactions): `tx parse`, `tx history`, `tx fees`
+- [Digital assets (DAS)](README.md#digital-assets-das-api): `asset get`, `asset batch`, `asset owner`, `asset creator`, `asset authority`, `asset collection`, `asset search`, `asset proof`, `asset proof-batch`, `asset editions`, `asset signatures`, `asset token-accounts`
+- [Account & network](README.md#account--network): `account`, `network-status`, `block`
+- [Wallet API](README.md#wallet-api): `wallet identity`, `wallet identity-batch`, `wallet balances`, `wallet history`, `wallet transfers`, `wallet funded-by`
+- [Webhooks](README.md#webhooks): `webhook list`, `webhook get`, `webhook create`, `webhook update`, `webhook delete`
+- [Program accounts](README.md#program-accounts): `program accounts`, `program accounts-all`, `program token-accounts`
+- [Staking](README.md#staking): `stake create`, `stake unstake`, `stake withdraw`, `stake accounts`, `stake withdrawable`, `stake instructions`
+- [ZK compression](README.md#zk-compression): `zk account`, `zk balance`, `zk token-holders`, `zk proof`, `zk validity-proof`, `zk tx`, `zk indexer-health`, and more
+- [Transaction sending](README.md#transaction-sending): `send broadcast`, `send raw`, `send sender`, `send poll`, `send compute-units`
+- [WebSocket streaming](README.md#websocket-streaming): `ws account`, `ws logs`, `ws slot`, `ws signature`, `ws program`
+- [SIMDs](README.md#simds): `simd list`, `simd get`
+
+## Global options
+
+- `--api-key <key>` — override the configured API key
+- `--network <net>` — `mainnet` (default) or `devnet`
+- `--json` — machine-readable JSON output
+- `--retry <n>` — retry transient errors up to `n` times with exponential backoff (default `0`)
+- `-k, --keypair <path>` — keypair file path (for `signup`, `login`, `upgrade`, `pay`, `stake`)
+
+## Optional
+
+- [Full README](README.md): complete command reference, configuration, and development setup
+- [Helius platform docs](https://docs.helius.dev): platform API documentation (RPC, DAS, Sender, webhooks, Laserstream)
+- [Helius dashboard](https://dashboard.helius.dev): manage API keys, billing, and webhooks in the browser

--- a/helius-cli/package.json
+++ b/helius-cli/package.json
@@ -7,7 +7,9 @@
     "helius": "./dist/bin/helius.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "llms.txt",
+    "README.md"
   ],
   "scripts": {
     "prebuild": "node -p \"'export const version = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",


### PR DESCRIPTION
This PR adds a `llms.txt` file at the CLI package root, indexing all command groups, and documents error handling conventions, global options, and agent-relevant flags (e.g., `NO_DNA`, `--json`, `--retry`)