### PR TITLE
feat(cli): Add Debug Flag For HTTP Req and Res Troubleshooting

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -56,6 +56,7 @@ import { owsLinkCommand, owsUnlinkCommand, owsStatusCommand } from "../src/comma
 import { updateCommand } from "../src/commands/update.js";
 import { completionsCommand } from "../src/commands/completions.js";
 import { VERSION } from "../src/constants.js";
+import { setDebugEnabled } from "../src/lib/output.js";
 import { sendCommandEvent, sendCliFeedback, setCurrentCommand } from "../src/lib/feedback.js";
 
 const program = new Command();
@@ -67,7 +68,9 @@ program
   .option("--api-key <key>", "Helius API key")
   .option("--network <net>", "Network: mainnet or devnet", "mainnet")
   .option("--retry <n>", "Retry transient errors (429, 5xx, network) up to n times with exponential backoff", "0")
+  .option("--debug", "Log HTTP request/response details to stderr for troubleshooting")
   .hook('preAction', (_thisCommand, actionCommand) => {
+    if (program.opts().debug) setDebugEnabled(true);
     setCurrentCommand(actionCommand.name());
     sendCommandEvent(actionCommand.name());
   })

--- a/helius-cli/src/lib/helius.ts
+++ b/helius-cli/src/lib/helius.ts
@@ -1,7 +1,7 @@
 import { createHelius, type HeliusClient } from "helius-sdk";
 import { getApiKey as getConfigApiKey, getNetwork as getConfigNetwork, getJwt, getProjectId } from "./config.js";
 import { listProjects, getProject } from "./api.js";
-import { registerHttpErrorClass } from "./output.js";
+import { registerHttpErrorClass, debug, maskKey } from "./output.js";
 
 /**
  * Thrown by restRequest() on non-2xx responses
@@ -106,6 +106,7 @@ export async function setupClient(
   spinner?.start("Resolving API key...");
   const apiKey = await resolveApiKey(options);
   const network = resolveNetwork(options);
+  debug(`setupClient: api-key=${maskKey(apiKey)}, network=${network}`);
   const helius = getClient(apiKey, network);
   spinner?.start(message);
   return helius;
@@ -118,19 +119,26 @@ export async function setupClient(
 export async function restRequest(endpoint: string, apiKey: string, options: RequestInit = {}): Promise<any> {
   const separator = endpoint.includes("?") ? "&" : "?";
   const url = `https://api.helius.xyz${endpoint}${separator}api-key=${apiKey}`;
+  const method = (options.method || "GET").toUpperCase();
+  const debugUrl = `https://api.helius.xyz${endpoint}${separator}api-key=${maskKey(apiKey)}`;
 
   const headers: Record<string, string> = { ...(options.headers as Record<string, string>) };
   if (options.body) {
     headers["Content-Type"] ??= "application/json";
   }
 
+  const start = Date.now();
+  debug(`${method} ${debugUrl}`);
   const response = await fetch(url, { ...options, headers });
+  const elapsed = Date.now() - start;
 
   if (!response.ok) {
     const text = await response.text();
+    debug(`${method} ${debugUrl} → ${response.status} (${elapsed}ms)`);
     throw new HeliusHttpError(response.status, `HTTP ${response.status}: ${text}`);
   }
 
+  debug(`${method} ${debugUrl} → ${response.status} (${elapsed}ms)`);
   const text = await response.text();
   if (!text || text === "null") return null;
   return JSON.parse(text);

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -8,10 +8,6 @@ export interface OutputOptions {
   json?: boolean;
 }
 
-export interface DebugOptions {
-  debug?: boolean;
-}
-
 /** True when the caller is a non-human agent (NO_DNA convention). */
 export const isAgent = !!process.env.NO_DNA;
 

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -8,8 +8,31 @@ export interface OutputOptions {
   json?: boolean;
 }
 
+export interface DebugOptions {
+  debug?: boolean;
+}
+
 /** True when the caller is a non-human agent (NO_DNA convention). */
 export const isAgent = !!process.env.NO_DNA;
+
+/** Global debug flag — set by --debug CLI option. */
+let _debugEnabled = false;
+
+export function setDebugEnabled(enabled: boolean): void {
+  _debugEnabled = enabled;
+}
+
+/** Log a debug message to stderr (never pollutes --json stdout). */
+export function debug(msg: string): void {
+  if (_debugEnabled) {
+    console.error(chalk.gray(`[DEBUG] ${msg}`));
+  }
+}
+
+/** Mask an API key for debug output: show first 4 chars + dots. */
+export function maskKey(key: string): string {
+  return key.length > 4 ? key.slice(0, 4) + "••••" : "••••";
+}
 
 /** Create a spinner, suppressed when --json is set or NO_DNA is detected. */
 export function createSpinner(options: OutputOptions = {}): ReturnType<typeof ora> | null {
@@ -334,10 +357,15 @@ export async function withRetry<T>(
   let attempt = 0;
 
   while (true) {
+    const start = Date.now();
     try {
-      return await fn();
+      const result = await fn();
+      debug(`SDK call → OK (${Date.now() - start}ms)`);
+      return result;
     } catch (error) {
-      const { retryable } = classifyError(error);
+      const elapsed = Date.now() - start;
+      const { retryable, errorCode } = classifyError(error);
+      debug(`SDK call → ${errorCode} (${elapsed}ms)${retryable ? " [retryable]" : ""}`);
       if (!retryable || attempt >= maxRetries) {
         throw error;
       }
@@ -345,6 +373,7 @@ export async function withRetry<T>(
       attempt++;
       const delay = Math.min(1000 * 2 ** (attempt - 1), 30_000);
       const message = error instanceof Error ? error.message : String(error);
+      debug(`Retry ${attempt}/${maxRetries} in ${delay / 1000}s...`);
       spinner?.start(`${message} — retrying in ${delay / 1000}s (${attempt}/${maxRetries})...`);
       await new Promise((resolve) => setTimeout(resolve, delay));
     }


### PR DESCRIPTION
This PR adds a global `--debug` flag that logs HTTP request/response details to stderr. It logs the API key (masked), network, HTTP method, URL, status code, and timing. All debug output goes to stderr, so it never pollutes `--json` stdout