### PR TITLE
feat(cli): Add `--dry-run` Flag For Transaction and Webhook Commands

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -1061,11 +1061,7 @@ const sendCmd = program
 sendCmd
   .command("broadcast <base64-tx>")
   .description("Broadcast a signed transaction and poll for confirmation")
-<<<<<<< Updated upstream
-  .option("--dry-run", "Validate without submitting the transaction")
-=======
   .option("--dry-run", "Preview without submitting the transaction")
->>>>>>> Stashed changes
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1075,11 +1071,7 @@ Examples:
 sendCmd
   .command("raw <base64-tx>")
   .description("Send a raw transaction")
-<<<<<<< Updated upstream
-  .option("--dry-run", "Validate without submitting the transaction")
-=======
   .option("--dry-run", "Preview without submitting the transaction")
->>>>>>> Stashed changes
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1090,11 +1082,7 @@ sendCmd
   .command("sender <base64-tx>")
   .description("Send via Helius Sender for ultra-low latency")
   .option("--region <region>", "Sender region (Default, US_SLC, US_EAST, etc.)")
-<<<<<<< Updated upstream
-  .option("--dry-run", "Validate without submitting the transaction")
-=======
   .option("--dry-run", "Preview without submitting the transaction")
->>>>>>> Stashed changes
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -676,6 +676,7 @@ webhookCmd
   .requiredOption("--accounts <addrs>", "Comma-separated addresses to monitor")
   .requiredOption("--types <types>", "Comma-separated transaction types (or ANY)")
   .option("--webhook-type <type>", "Webhook type: enhanced, raw, or discord", "enhanced")
+  .option("--dry-run", "Preview webhook config without creating")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -689,6 +690,7 @@ webhookCmd
   .option("--url <url>", "New webhook URL")
   .option("--accounts <addrs>", "New comma-separated addresses")
   .option("--types <types>", "New comma-separated transaction types")
+  .option("--dry-run", "Preview changes without updating")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -699,6 +701,7 @@ Examples:
 webhookCmd
   .command("delete <id>")
   .description("Delete a webhook")
+  .option("--dry-run", "Preview which webhook would be deleted")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1058,6 +1061,7 @@ const sendCmd = program
 sendCmd
   .command("broadcast <base64-tx>")
   .description("Broadcast a signed transaction and poll for confirmation")
+  .option("--dry-run", "Validate without submitting the transaction")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1067,6 +1071,7 @@ Examples:
 sendCmd
   .command("raw <base64-tx>")
   .description("Send a raw transaction")
+  .option("--dry-run", "Validate without submitting the transaction")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1077,6 +1082,7 @@ sendCmd
   .command("sender <base64-tx>")
   .description("Send via Helius Sender for ultra-low latency")
   .option("--region <region>", "Sender region (Default, US_SLC, US_EAST, etc.)")
+  .option("--dry-run", "Validate without submitting the transaction")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -1061,7 +1061,11 @@ const sendCmd = program
 sendCmd
   .command("broadcast <base64-tx>")
   .description("Broadcast a signed transaction and poll for confirmation")
+<<<<<<< Updated upstream
   .option("--dry-run", "Validate without submitting the transaction")
+=======
+  .option("--dry-run", "Preview without submitting the transaction")
+>>>>>>> Stashed changes
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1071,7 +1075,11 @@ Examples:
 sendCmd
   .command("raw <base64-tx>")
   .description("Send a raw transaction")
+<<<<<<< Updated upstream
   .option("--dry-run", "Validate without submitting the transaction")
+=======
+  .option("--dry-run", "Preview without submitting the transaction")
+>>>>>>> Stashed changes
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1082,7 +1090,11 @@ sendCmd
   .command("sender <base64-tx>")
   .description("Send via Helius Sender for ultra-low latency")
   .option("--region <region>", "Sender region (Default, US_SLC, US_EAST, etc.)")
+<<<<<<< Updated upstream
   .option("--dry-run", "Validate without submitting the transaction")
+=======
+  .option("--dry-run", "Preview without submitting the transaction")
+>>>>>>> Stashed changes
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -2,11 +2,20 @@ import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 
-interface SendOptions extends OutputOptions, ResolveOptions, RetryOptions {}
+interface SendOptions extends OutputOptions, ResolveOptions, RetryOptions {
+  dryRun?: boolean;
+}
 
 export async function sendBroadcastCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    if (options.dryRun) {
+      spinner?.succeed("Dry run — transaction not submitted");
+      if (options.json) { outputJson({ dryRun: true, transaction: base64Tx }); return; }
+      console.log(chalk.yellow("\n  Dry run — transaction would be broadcast but was not submitted."));
+      return;
+    }
+
     const helius = await setupClient(spinner, options, "Broadcasting transaction...");
     const signature = await withRetry(() => helius.tx.broadcastTransaction(base64Tx), options, spinner);
     spinner?.stop();
@@ -22,6 +31,13 @@ export async function sendBroadcastCommand(base64Tx: string, options: SendOption
 export async function sendRawCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    if (options.dryRun) {
+      spinner?.succeed("Dry run — transaction not submitted");
+      if (options.json) { outputJson({ dryRun: true, transaction: base64Tx }); return; }
+      console.log(chalk.yellow("\n  Dry run — transaction would be sent but was not submitted."));
+      return;
+    }
+
     const helius = await setupClient(spinner, options, "Sending transaction...");
     const signature = await withRetry(() => helius.tx.sendTransaction({ base64: base64Tx }), options, spinner);
     spinner?.stop();
@@ -37,6 +53,14 @@ export async function sendRawCommand(base64Tx: string, options: SendOptions = {}
 export async function sendSenderCommand(base64Tx: string, options: SendOptions & { region?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    if (options.dryRun) {
+      const region = options.region || "Default";
+      spinner?.succeed("Dry run — transaction not submitted");
+      if (options.json) { outputJson({ dryRun: true, transaction: base64Tx, region }); return; }
+      console.log(chalk.yellow(`\n  Dry run — transaction would be sent via Helius Sender (${region}) but was not submitted.`));
+      return;
+    }
+
     const helius = await setupClient(spinner, options, "Resolving API key...");
 
     const region = (options.region || "Default") as any;

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -4,7 +4,9 @@ import { formatEnumLabel } from "../lib/formatters.js";
 import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
 import { validateSolanaAddresses } from "../lib/validation.js";
 
-interface WebhookOptions extends OutputOptions, ResolveOptions, RetryOptions {}
+interface WebhookOptions extends OutputOptions, ResolveOptions, RetryOptions {
+  dryRun?: boolean;
+}
 
 export async function webhookListCommand(options: WebhookOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
@@ -75,6 +77,24 @@ export async function webhookCreateCommand(options: WebhookOptions & {
     const transactionTypes = options.types.split(",").map((s: string) => s.trim()).filter(Boolean);
     const webhookType = (options.webhookType || "enhanced") as any;
 
+    const preview = {
+      webhookURL: options.url,
+      accountAddresses,
+      transactionTypes,
+      webhookType: options.webhookType || "enhanced",
+    };
+
+    if (options.dryRun) {
+      spinner?.succeed("Dry run — webhook not created");
+      if (options.json) { outputJson({ dryRun: true, ...preview }); return; }
+      console.log(chalk.yellow("\n  Dry run — webhook would be created with:"));
+      console.log(`    ${chalk.gray("URL:")}      ${preview.webhookURL}`);
+      console.log(`    ${chalk.gray("Accounts:")} ${accountAddresses.length} address(es)`);
+      console.log(`    ${chalk.gray("Types:")}    ${transactionTypes.join(", ")}`);
+      console.log(`    ${chalk.gray("Type:")}     ${formatEnumLabel(preview.webhookType)}`);
+      return;
+    }
+
     spinner?.start("Creating webhook...");
     const result = await withRetry(() => helius.webhooks.create({
       webhookURL: options.url,
@@ -112,6 +132,16 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
     if (options.accounts) params.accountAddresses = options.accounts.split(",").map((s: string) => s.trim()).filter(Boolean);
     if (options.types) params.transactionTypes = options.types.split(",").map((s: string) => s.trim()).filter(Boolean);
 
+    if (options.dryRun) {
+      spinner?.succeed("Dry run — webhook not updated");
+      if (options.json) { outputJson({ dryRun: true, webhookID: webhookId, changes: params }); return; }
+      console.log(chalk.yellow(`\n  Dry run — webhook ${webhookId} would be updated with:`));
+      if (params.webhookURL) console.log(`    ${chalk.gray("URL:")}      ${params.webhookURL}`);
+      if (params.accountAddresses) console.log(`    ${chalk.gray("Accounts:")} ${params.accountAddresses.length} address(es)`);
+      if (params.transactionTypes) console.log(`    ${chalk.gray("Types:")}    ${params.transactionTypes.join(", ")}`);
+      return;
+    }
+
     spinner?.start("Updating webhook...");
     const result = await withRetry(() => helius.webhooks.update(webhookId, params), options, spinner);
     spinner?.stop();
@@ -127,6 +157,13 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
 export async function webhookDeleteCommand(webhookId: string, options: WebhookOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    if (options.dryRun) {
+      spinner?.succeed("Dry run — webhook not deleted");
+      if (options.json) { outputJson({ dryRun: true, webhookID: webhookId }); return; }
+      console.log(chalk.yellow(`\n  Dry run — webhook ${webhookId} would be deleted.`));
+      return;
+    }
+
     const helius = await setupClient(spinner, options, "Deleting webhook...");
     await withRetry(() => helius.webhooks.delete(webhookId), options, spinner);
     spinner?.stop();

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -67,8 +67,6 @@ export async function webhookCreateCommand(options: WebhookOptions & {
 }): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setupClient(spinner, options, "Resolving API key...");
-
     // Validate addresses before sending to API
     const addrErr = validateSolanaAddresses(options.accounts);
     if (addrErr) exitWithError("INVALID_INPUT", addrErr, undefined, !!options.json);
@@ -77,15 +75,9 @@ export async function webhookCreateCommand(options: WebhookOptions & {
     const transactionTypes = options.types.split(",").map((s: string) => s.trim()).filter(Boolean);
     const webhookType = (options.webhookType || "enhanced") as any;
 
-    const preview = {
-      webhookURL: options.url,
-      accountAddresses,
-      transactionTypes,
-      webhookType: options.webhookType || "enhanced",
-    };
-
     if (options.dryRun) {
       spinner?.succeed("Dry run — webhook not created");
+      const preview = { webhookURL: options.url, accountAddresses, transactionTypes, webhookType: options.webhookType || "enhanced" };
       if (options.json) { outputJson({ dryRun: true, ...preview }); return; }
       console.log(chalk.yellow("\n  Dry run — webhook would be created with:"));
       console.log(`    ${chalk.gray("URL:")}      ${preview.webhookURL}`);
@@ -95,7 +87,7 @@ export async function webhookCreateCommand(options: WebhookOptions & {
       return;
     }
 
-    spinner?.start("Creating webhook...");
+    const helius = await setupClient(spinner, options, "Creating webhook...");
     const result = await withRetry(() => helius.webhooks.create({
       webhookURL: options.url,
       accountAddresses,
@@ -120,8 +112,6 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
 }): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const helius = await setupClient(spinner, options, "Resolving API key...");
-
     const params: any = {};
     // Validate addresses if provided
     if (options.accounts) {
@@ -142,7 +132,7 @@ export async function webhookUpdateCommand(webhookId: string, options: WebhookOp
       return;
     }
 
-    spinner?.start("Updating webhook...");
+    const helius = await setupClient(spinner, options, "Updating webhook...");
     const result = await withRetry(() => helius.webhooks.update(webhookId, params), options, spinner);
     spinner?.stop();
 


### PR DESCRIPTION
This PR adds a `--dry-run` flag to `send broadcast`, `send raw`, and `send sender`, returning the transaction without submitting, as well as `webhook create`, `webhook update`, and `webhook delete` to preview the operation without executing

Note that the `stake` commands already return unsigned transactions without submitting, so adding a dry run check there doesn't make much sense