### PR TITLE
feat(cli): Add Pre-Input Validation For Addresses, Sigs, and Slots

### DIFF
--- a/helius-cli/src/commands/account.ts
+++ b/helius-cli/src/commands/account.ts
@@ -1,13 +1,16 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateAddress } from "../lib/validation.js";
 
 interface AccountOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function accountCommand(address: string, options: AccountOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching account info...");
     const result = await withRetry(() => helius.raw.getAccountInfo(address, { encoding: "jsonParsed" }), options, spinner) as any;
     spinner?.stop();

--- a/helius-cli/src/commands/asset.ts
+++ b/helius-cli/src/commands/asset.ts
@@ -1,7 +1,8 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateAddress, validateAddresses } from "../lib/validation.js";
 
 interface AssetOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
@@ -45,6 +46,8 @@ function printAssetList(items: any[], label: string): void {
 export async function assetGetCommand(id: string, options: AssetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(id);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching asset...");
     const result = await withRetry(() => helius.getAsset({ id }), options, spinner);
     spinner?.stop();
@@ -59,6 +62,8 @@ export async function assetGetCommand(id: string, options: AssetOptions = {}): P
 export async function assetBatchCommand(ids: string[], options: AssetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddresses(ids);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, `Fetching ${ids.length} asset(s)...`);
     const result = await withRetry(() => helius.getAssetBatch({ ids }), options, spinner);
     spinner?.stop();
@@ -74,6 +79,8 @@ export async function assetBatchCommand(ids: string[], options: AssetOptions = {
 export async function assetOwnerCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching assets by owner...");
     const result = await withRetry(() => helius.getAssetsByOwner({
       ownerAddress: address,
@@ -92,6 +99,8 @@ export async function assetOwnerCommand(address: string, options: AssetOptions &
 export async function assetCreatorCommand(address: string, options: AssetOptions & { page?: string; limit?: string; verified?: boolean } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching assets by creator...");
     const result = await withRetry(() => helius.getAssetsByCreator({
       creatorAddress: address,
@@ -111,6 +120,8 @@ export async function assetCreatorCommand(address: string, options: AssetOptions
 export async function assetAuthorityCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching assets by authority...");
     const result = await withRetry(() => helius.getAssetsByAuthority({
       authorityAddress: address,
@@ -129,6 +140,8 @@ export async function assetAuthorityCommand(address: string, options: AssetOptio
 export async function assetCollectionCommand(address: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching collection assets...");
     const result = await withRetry(() => helius.getAssetsByGroup({
       groupKey: "collection",
@@ -176,6 +189,8 @@ export async function assetSearchCommand(options: AssetOptions & {
 export async function assetProofCommand(id: string, options: AssetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(id);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching asset proof...");
     const result = await withRetry(() => helius.getAssetProof({ id }), options, spinner);
     spinner?.stop();
@@ -197,6 +212,8 @@ export async function assetProofCommand(id: string, options: AssetOptions = {}):
 export async function assetProofBatchCommand(ids: string[], options: AssetOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddresses(ids);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, `Fetching proofs for ${ids.length} asset(s)...`);
     const result = await withRetry(() => helius.getAssetProofBatch({ ids }), options, spinner);
     spinner?.stop();
@@ -214,6 +231,8 @@ export async function assetProofBatchCommand(ids: string[], options: AssetOption
 export async function assetEditionsCommand(mint: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(mint);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching NFT editions...");
     const result = await withRetry(() => helius.getNftEditions({
       mint,
@@ -239,6 +258,8 @@ export async function assetEditionsCommand(mint: string, options: AssetOptions &
 export async function assetSignaturesCommand(id: string, options: AssetOptions & { page?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(id);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching signatures for asset...");
     const result = await withRetry(() => helius.getSignaturesForAsset({
       id,

--- a/helius-cli/src/commands/balance.ts
+++ b/helius-cli/src/commands/balance.ts
@@ -1,13 +1,16 @@
 import chalk from "chalk";
 import { setupClient, resolveNetwork, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatAddress, formatTokenAmount, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateAddress } from "../lib/validation.js";
 
 interface BalanceOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function balanceCommand(address: string, options: BalanceOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching balance...");
     const result = await withRetry(() => helius.raw.getBalance(address), options, spinner) as any;
     spinner?.stop();
@@ -30,6 +33,8 @@ export async function balanceCommand(address: string, options: BalanceOptions = 
 export async function tokensCommand(address: string, options: BalanceOptions & { limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching token balances...");
     const limit = options.limit ? parseInt(options.limit, 10) : 100;
     const result = await withRetry(() => helius.getAssetsByOwner({ ownerAddress: address, page: 1, limit, displayOptions: { showFungible: true } }), options, spinner) as any;
@@ -79,6 +84,8 @@ export async function tokensCommand(address: string, options: BalanceOptions & {
 export async function tokenHoldersCommand(mint: string, options: BalanceOptions & { limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(mint);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching token holders...");
     const limit = options.limit ? parseInt(options.limit, 10) : 20;
     const result = await withRetry(() => helius.getTokenAccounts({ mint, page: 1, limit }), options, spinner) as any;

--- a/helius-cli/src/commands/block.ts
+++ b/helius-cli/src/commands/block.ts
@@ -1,13 +1,16 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatTimestamp } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateSlot } from "../lib/validation.js";
 
 interface BlockOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function blockCommand(slot: string, options: BlockOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const slotErr = validateSlot(slot);
+    if (slotErr) exitWithError("INVALID_INPUT", slotErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, `Fetching block at slot ${slot}...`);
     const slotNum = BigInt(slot);
     const result = await withRetry(() => helius.raw.getBlock(slotNum, {

--- a/helius-cli/src/commands/program.ts
+++ b/helius-cli/src/commands/program.ts
@@ -1,13 +1,16 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateAddress } from "../lib/validation.js";
 
 interface ProgramOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function programAccountsCommand(programId: string, options: ProgramOptions & { dataSize?: string; limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(programId);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching program accounts...");
     const config: any = {};
     if (options.dataSize) config.filters = [{ dataSize: parseInt(options.dataSize, 10) }];
@@ -44,6 +47,8 @@ export async function programAccountsCommand(programId: string, options: Program
 export async function programAccountsAllCommand(programId: string, options: ProgramOptions & { dataSize?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(programId);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching all program accounts (auto-paginating)...");
     const config: any = {};
     if (options.dataSize) config.filters = [{ dataSize: parseInt(options.dataSize, 10) }];
@@ -63,6 +68,8 @@ export async function programAccountsAllCommand(programId: string, options: Prog
 export async function programTokenAccountsCommand(owner: string, options: ProgramOptions & { limit?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(owner);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching token accounts by owner...");
     const config: any = { encoding: "base64" };
     if (options.limit) config.limit = parseInt(options.limit, 10);

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateSignature } from "../lib/validation.js";
 
 interface SendOptions extends OutputOptions, ResolveOptions, RetryOptions {
   dryRun?: boolean;
@@ -82,6 +83,8 @@ export async function sendSenderCommand(base64Tx: string, options: SendOptions &
 export async function sendPollCommand(signature: string, options: SendOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const sigErr = validateSignature(signature);
+    if (sigErr) exitWithError("INVALID_INPUT", sigErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Polling for confirmation...");
     const result = await withRetry(() => helius.tx.pollTransactionConfirmation(signature as any), options, spinner);
     spinner?.stop();

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -2,12 +2,15 @@ import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
 import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateAddress } from "../lib/validation.js";
 
 interface StakeOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function stakeAccountsCommand(wallet: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(wallet);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching Helius stake accounts...");
     const result = await withRetry(() => helius.stake.getHeliusStakeAccounts(wallet as any), options, spinner);
     spinner?.stop();
@@ -31,6 +34,8 @@ export async function stakeAccountsCommand(wallet: string, options: StakeOptions
 export async function stakeWithdrawableCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(stakeAccount);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Checking withdrawable amount...");
     const result = await withRetry(() => helius.stake.getWithdrawableAmount(stakeAccount as any), options, spinner);
     spinner?.stop();
@@ -64,6 +69,8 @@ export async function stakeInstructionsCommand(amount: string, options: StakeOpt
 export async function stakeUnstakeInstructionCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(stakeAccount);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Getting unstake instruction...");
     const result = await withRetry(() => helius.stake.getUnstakeInstruction(stakeAccount as any), options, spinner);
     spinner?.stop();
@@ -80,6 +87,8 @@ export async function stakeUnstakeInstructionCommand(stakeAccount: string, optio
 export async function stakeWithdrawInstructionCommand(stakeAccount: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(stakeAccount);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Getting withdraw instruction...");
     const result = await withRetry(() => helius.stake.getWithdrawInstruction(stakeAccount as any), options, spinner);
     spinner?.stop();
@@ -120,6 +129,8 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
+    const addrErr = validateAddress(stakeAccount);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Creating unstake transaction...");
     const result = await withRetry(() => helius.stake.createUnstakeTransaction(stakeAccount as any), options, spinner);
     spinner?.stop();
@@ -139,6 +150,8 @@ export async function stakeWithdrawCommand(stakeAccount: string, options: StakeO
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
+    const addrErr = validateAddress(stakeAccount);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Creating withdraw transaction...");
     const result = await withRetry(() => helius.stake.createWithdrawTransaction(stakeAccount as any), options, spinner);
     spinner?.stop();

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -1,13 +1,18 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol, formatTimestamp, formatAddress, formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateAddress, validateSignature } from "../lib/validation.js";
 
 interface TxOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function txParseCommand(signatures: string[], options: TxOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    for (const sig of signatures) {
+      const sigErr = validateSignature(sig);
+      if (sigErr) exitWithError("INVALID_INPUT", sigErr, undefined, !!options.json);
+    }
     const helius = await setupClient(spinner, options, `Parsing ${signatures.length} transaction(s)...`);
     const result = await withRetry(() => helius.enhanced.getTransactions({ transactions: signatures }), options, spinner);
     spinner?.stop();
@@ -55,6 +60,8 @@ export async function txParseCommand(signatures: string[], options: TxOptions = 
 export async function txHistoryCommand(address: string, options: TxOptions & { limit?: string; before?: string; type?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching transaction history...");
     const params: any = { address };
     if (options.limit) params.limit = parseInt(options.limit, 10);

--- a/helius-cli/src/commands/wallet.ts
+++ b/helius-cli/src/commands/wallet.ts
@@ -1,13 +1,16 @@
 import chalk from "chalk";
 import { resolveApiKey, restRequest, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, formatEnumLabel, type TableColumn } from "../lib/formatters.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateAddress, validateAddresses } from "../lib/validation.js";
 
 interface WalletOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function walletIdentityCommand(address: string, options: WalletOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start("Looking up wallet identity...");
@@ -31,6 +34,8 @@ export async function walletIdentityCommand(address: string, options: WalletOpti
 export async function walletIdentityBatchCommand(addresses: string[], options: WalletOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddresses(addresses);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start(`Looking up ${addresses.length} wallet(s)...`);
@@ -59,6 +64,8 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
 export async function walletBalancesCommand(address: string, options: WalletOptions & { showNfts?: boolean } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     const params = new URLSearchParams();
@@ -102,6 +109,8 @@ export async function walletBalancesCommand(address: string, options: WalletOpti
 export async function walletHistoryCommand(address: string, options: WalletOptions & { limit?: string; type?: string; before?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     const params = new URLSearchParams();
@@ -137,6 +146,8 @@ export async function walletHistoryCommand(address: string, options: WalletOptio
 export async function walletTransfersCommand(address: string, options: WalletOptions & { limit?: string; cursor?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     const params = new URLSearchParams();
@@ -170,6 +181,8 @@ export async function walletTransfersCommand(address: string, options: WalletOpt
 export async function walletFundedByCommand(address: string, options: WalletOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
     spinner?.start("Finding funding source...");

--- a/helius-cli/src/commands/ws.ts
+++ b/helius-cli/src/commands/ws.ts
@@ -1,7 +1,8 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { jsonReplacer, classifyError, CLI_GUIDANCE, type OutputOptions } from "../lib/output.js";
+import { jsonReplacer, classifyError, exitWithError, CLI_GUIDANCE, type OutputOptions } from "../lib/output.js";
 import { sendCommandEvent, getCurrentCommand } from "../lib/feedback.js";
+import { validateAddress, validateSignature } from "../lib/validation.js";
 
 interface WsOptions extends OutputOptions, ResolveOptions {}
 
@@ -72,6 +73,8 @@ function setupShutdown(helius: { ws: { close(): void } }, abortController: Abort
 }
 
 export async function wsAccountCommand(address: string, options: WsOptions = {}): Promise<void> {
+  const addrErr = validateAddress(address);
+  if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
   try {
     const apiKey = await resolveApiKey(options);
     const network = resolveNetwork(options);
@@ -129,6 +132,8 @@ export async function wsSlotCommand(options: WsOptions = {}): Promise<void> {
 }
 
 export async function wsSignatureCommand(signature: string, options: WsOptions = {}): Promise<void> {
+  const sigErr = validateSignature(signature);
+  if (sigErr) exitWithError("INVALID_INPUT", sigErr, undefined, !!options.json);
   try {
     const apiKey = await resolveApiKey(options);
     const network = resolveNetwork(options);
@@ -144,6 +149,8 @@ export async function wsSignatureCommand(signature: string, options: WsOptions =
 }
 
 export async function wsProgramCommand(programId: string, options: WsOptions = {}): Promise<void> {
+  const addrErr = validateAddress(programId);
+  if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
   try {
     const apiKey = await resolveApiKey(options);
     const network = resolveNetwork(options);

--- a/helius-cli/src/commands/ws.ts
+++ b/helius-cli/src/commands/ws.ts
@@ -73,9 +73,9 @@ function setupShutdown(helius: { ws: { close(): void } }, abortController: Abort
 }
 
 export async function wsAccountCommand(address: string, options: WsOptions = {}): Promise<void> {
-  const addrErr = validateAddress(address);
-  if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const apiKey = await resolveApiKey(options);
     const network = resolveNetwork(options);
     const helius = getClient(apiKey, network);
@@ -132,9 +132,9 @@ export async function wsSlotCommand(options: WsOptions = {}): Promise<void> {
 }
 
 export async function wsSignatureCommand(signature: string, options: WsOptions = {}): Promise<void> {
-  const sigErr = validateSignature(signature);
-  if (sigErr) exitWithError("INVALID_INPUT", sigErr, undefined, !!options.json);
   try {
+    const sigErr = validateSignature(signature);
+    if (sigErr) exitWithError("INVALID_INPUT", sigErr, undefined, !!options.json);
     const apiKey = await resolveApiKey(options);
     const network = resolveNetwork(options);
     const helius = getClient(apiKey, network);
@@ -149,9 +149,9 @@ export async function wsSignatureCommand(signature: string, options: WsOptions =
 }
 
 export async function wsProgramCommand(programId: string, options: WsOptions = {}): Promise<void> {
-  const addrErr = validateAddress(programId);
-  if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
   try {
+    const addrErr = validateAddress(programId);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const apiKey = await resolveApiKey(options);
     const network = resolveNetwork(options);
     const helius = getClient(apiKey, network);

--- a/helius-cli/src/commands/zk.ts
+++ b/helius-cli/src/commands/zk.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { validateAddress, validateAddresses, validateSignature } from "../lib/validation.js";
 
 interface ZkOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
@@ -14,6 +15,8 @@ function handleResult(spinner: any, result: any, options: ZkOptions, label: stri
 export async function zkAccountCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(addressOrHash);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed account...");
     const result = await withRetry(() => helius.zk.getCompressedAccount({ address: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Account");
@@ -25,6 +28,8 @@ export async function zkAccountCommand(addressOrHash: string, options: ZkOptions
 export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(owner);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed accounts by owner...");
     const result = await withRetry(() => helius.zk.getCompressedAccountsByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Accounts by Owner");
@@ -36,6 +41,8 @@ export async function zkAccountsByOwnerCommand(owner: string, options: ZkOptions
 export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(addressOrHash);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed balance...");
     const result = await withRetry(() => helius.zk.getCompressedBalance({ address: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Balance");
@@ -47,6 +54,8 @@ export async function zkBalanceCommand(addressOrHash: string, options: ZkOptions
 export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(owner);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed balance by owner...");
     const result = await withRetry(() => helius.zk.getCompressedBalanceByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Balance by Owner");
@@ -58,6 +67,8 @@ export async function zkBalanceByOwnerCommand(owner: string, options: ZkOptions 
 export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(mint);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed token holders...");
     const result = await withRetry(() => helius.zk.getCompressedMintTokenHolders({ mint }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Holders");
@@ -69,6 +80,8 @@ export async function zkTokenHoldersCommand(mint: string, options: ZkOptions = {
 export async function zkTokenBalanceCommand(account: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(account);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed token account balance...");
     const result = await withRetry(() => helius.zk.getCompressedTokenAccountBalance({ address: account }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Account Balance");
@@ -80,6 +93,8 @@ export async function zkTokenBalanceCommand(account: string, options: ZkOptions 
 export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(owner);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed token accounts by owner...");
     const result = await withRetry(() => helius.zk.getCompressedTokenAccountsByOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Accounts by Owner");
@@ -91,6 +106,8 @@ export async function zkTokenAccountsByOwnerCommand(owner: string, options: ZkOp
 export async function zkTokenAccountsByDelegateCommand(delegate: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(delegate);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed token accounts by delegate...");
     const result = await withRetry(() => helius.zk.getCompressedTokenAccountsByDelegate({ delegate }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Accounts by Delegate");
@@ -102,6 +119,8 @@ export async function zkTokenAccountsByDelegateCommand(delegate: string, options
 export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(owner);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed token balances by owner (V2)...");
     const result = await withRetry(() => helius.zk.getCompressedTokenBalancesByOwnerV2({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compressed Token Balances by Owner (V2)");
@@ -113,6 +132,8 @@ export async function zkTokenBalancesByOwnerCommand(owner: string, options: ZkOp
 export async function zkProofCommand(addressOrHash: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(addressOrHash);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compressed account proof...");
     const result = await withRetry(() => helius.zk.getCompressedAccountProof({ hash: addressOrHash }), options, spinner);
     handleResult(spinner, result, options, "Compressed Account Proof");
@@ -124,6 +145,8 @@ export async function zkProofCommand(addressOrHash: string, options: ZkOptions =
 export async function zkProofsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddresses(addresses);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, `Fetching proofs for ${addresses.length} account(s)...`);
     const result = await withRetry(() => helius.zk.getMultipleCompressedAccountProofs({ hashes: addresses }), options, spinner);
     handleResult(spinner, result, options, "Multiple Compressed Account Proofs");
@@ -135,6 +158,8 @@ export async function zkProofsCommand(addresses: string[], options: ZkOptions = 
 export async function zkMultipleAccountsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddresses(addresses);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, `Fetching ${addresses.length} compressed account(s)...`);
     const result = await withRetry(() => helius.zk.getMultipleCompressedAccounts({ addresses }), options, spinner);
     handleResult(spinner, result, options, "Multiple Compressed Accounts");
@@ -146,6 +171,8 @@ export async function zkMultipleAccountsCommand(addresses: string[], options: Zk
 export async function zkAddressProofsCommand(addresses: string[], options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddresses(addresses);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, `Fetching address proofs (V2)...`);
     const result = await withRetry(() => helius.zk.getMultipleNewAddressProofsV2(addresses), options, spinner);
     handleResult(spinner, result, options, "Multiple New Address Proofs (V2)");
@@ -157,6 +184,8 @@ export async function zkAddressProofsCommand(addresses: string[], options: ZkOpt
 export async function zkSignaturesAccountCommand(account: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(account);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compression signatures for account...");
     const result = await withRetry(() => helius.zk.getCompressionSignaturesForAccount({ hash: account }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Account");
@@ -168,6 +197,8 @@ export async function zkSignaturesAccountCommand(account: string, options: ZkOpt
 export async function zkSignaturesAddressCommand(address: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compression signatures for address...");
     const result = await withRetry(() => helius.zk.getCompressionSignaturesForAddress({ address }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Address");
@@ -179,6 +210,8 @@ export async function zkSignaturesAddressCommand(address: string, options: ZkOpt
 export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(owner);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compression signatures for owner...");
     const result = await withRetry(() => helius.zk.getCompressionSignaturesForOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Owner");
@@ -190,6 +223,8 @@ export async function zkSignaturesOwnerCommand(owner: string, options: ZkOptions
 export async function zkSignaturesTokenOwnerCommand(owner: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(owner);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching compression signatures for token owner...");
     const result = await withRetry(() => helius.zk.getCompressionSignaturesForTokenOwner({ owner }), options, spinner);
     handleResult(spinner, result, options, "Compression Signatures for Token Owner");
@@ -223,6 +258,8 @@ export async function zkLatestNonVotingCommand(options: ZkOptions = {}): Promise
 export async function zkTxCommand(signature: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const sigErr = validateSignature(signature);
+    if (sigErr) exitWithError("INVALID_INPUT", sigErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching transaction with compression info...");
     const result = await withRetry(() => helius.zk.getTransactionWithCompressionInfo({ signature }), options, spinner);
     handleResult(spinner, result, options, "Transaction with Compression Info");
@@ -270,6 +307,8 @@ export async function zkIndexerSlotCommand(options: ZkOptions = {}): Promise<voi
 export async function zkSignaturesForAssetCommand(id: string, options: ZkOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const addrErr = validateAddress(id);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     const helius = await setupClient(spinner, options, "Fetching signatures for asset...");
     const result = await withRetry(() => helius.zk.getSignaturesForAsset({ id, page: 1 }), options, spinner);
     handleResult(spinner, result, options, "Signatures for Asset");

--- a/helius-cli/src/lib/validation.ts
+++ b/helius-cli/src/lib/validation.ts
@@ -53,8 +53,8 @@ export function validateAddresses(addrs: string[]): string | null {
   return null;
 }
 
-// Transaction signatures are base58, 87-88 characters
-const SIGNATURE_RE = /^[1-9A-HJ-NP-Za-km-z]{87,88}$/;
+// Transaction signatures are 64 bytes base58-encoded, producing 86-88 characters
+const SIGNATURE_RE = /^[1-9A-HJ-NP-Za-km-z]{86,88}$/;
 
 export function validateSignature(sig: string): string | null {
   if (!SIGNATURE_RE.test(sig)) {

--- a/helius-cli/src/lib/validation.ts
+++ b/helius-cli/src/lib/validation.ts
@@ -38,6 +38,38 @@ export function validateEmail(email: string): string | null {
   return null;
 }
 
+export function validateAddress(addr: string): string | null {
+  if (!BASE58_RE.test(addr)) {
+    return `Invalid Solana address: ${addr}`;
+  }
+  return null;
+}
+
+export function validateAddresses(addrs: string[]): string | null {
+  for (const addr of addrs) {
+    const err = validateAddress(addr);
+    if (err) return err;
+  }
+  return null;
+}
+
+// Transaction signatures are base58, 87-88 characters
+const SIGNATURE_RE = /^[1-9A-HJ-NP-Za-km-z]{87,88}$/;
+
+export function validateSignature(sig: string): string | null {
+  if (!SIGNATURE_RE.test(sig)) {
+    return `Invalid transaction signature: ${sig}`;
+  }
+  return null;
+}
+
+export function validateSlot(slot: string): string | null {
+  if (!/^\d+$/.test(slot)) {
+    return `Invalid slot number: ${slot}. Must be a positive integer.`;
+  }
+  return null;
+}
+
 export function validateSolanaAddresses(raw: string): string | null {
   const addresses = raw.split(",").map(s => s.trim()).filter(Boolean);
   if (addresses.length === 0) {


### PR DESCRIPTION
This PR adds `validateAddress()`, `validateAddresses()`, `validateSignature()`, and `validateSlot()` to `lib/validation.ts` and wires the new pre-input validation into 55 command handlers across 11 files, so that errors are caught instantly before any API calls are made 