### PR TITLE
feat(cli): Add Reclaim Command

### DIFF
--- a/helius-cli/CLAUDE.md
+++ b/helius-cli/CLAUDE.md
@@ -20,6 +20,7 @@ src/
     stake.ts           # staking commands
     zk.ts              # 24 ZK compression subcommands
     send.ts            # tx helpers (broadcast, raw, sender, poll, compute-units)
+    reclaim.ts         # close empty SPL token accounts, reclaim rent (via Sender)
     ws.ts              # WebSocket streaming (account, logs, slot, signature, program)
     config-cmd.ts      # config show/set-api-key/set-network/set-project/clear
     signup.ts          # account signup (existing)

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -50,6 +50,7 @@ import {
   zkSignaturesForAssetCommand,
 } from "../src/commands/zk.js";
 import { sendBroadcastCommand, sendRawCommand, sendSenderCommand, sendPollCommand, sendComputeUnitsCommand } from "../src/commands/send.js";
+import { reclaimCommand } from "../src/commands/reclaim.js";
 import { wsAccountCommand, wsLogsCommand, wsSlotCommand, wsSignatureCommand, wsProgramCommand } from "../src/commands/ws.js";
 import { simdListCommand, simdGetCommand } from "../src/commands/simd.js";
 import { owsLinkCommand, owsUnlinkCommand, owsStatusCommand } from "../src/commands/ows.js";
@@ -1106,6 +1107,34 @@ sendCmd
 Examples:
   $ helius send compute-units <base64-tx> --json`)
   .action(function(this: any, tx: string) { sendComputeUnitsCommand(tx, opts(this)); });
+
+// ── Reclaim rent from empty token accounts ──
+
+program
+  .command("reclaim [owner]")
+  .description("Close empty SPL token accounts and reclaim rent via Helius Sender")
+  .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
+  .option("--destination <addr>", "Address to receive reclaimed lamports (default: signer)")
+  .option("--region <region>", "Sender region (Default, US_SLC, US_EAST, etc.)", "Default")
+  .option("--swqos-only", "Route only through SWQoS (cheaper tip)")
+  .option("--tip-amount <lamports>", "Override auto-tip for Sender")
+  .option("--batch-size <n>", "Number of accounts closed per transaction", "20")
+  .option("--limit <n>", "Cap total accounts closed across all batches")
+  .option("--dry-run", "List closable accounts without sending")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("--json", "Output in JSON format")
+  .addHelpText('after', `
+Examples:
+  $ helius reclaim --dry-run
+  $ helius reclaim --dry-run 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY
+  $ helius reclaim -y
+  $ helius reclaim --limit 50 --batch-size 15 --region US_EAST --swqos-only --yes --json
+
+Token-2022 accounts are not scanned in v1. Only empty, initialized (non-frozen)
+SPL Token accounts where closeAuthority is unset or matches the keypair will be
+closed. Each batch is sent independently via Helius Sender; a failed batch does
+not abort later batches.`)
+  .action(function(this: any, owner?: string) { reclaimCommand(owner, opts(this)); });
 
 // ── WebSocket subscriptions ──
 

--- a/helius-cli/package.json
+++ b/helius-cli/package.json
@@ -18,6 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@solana-program/token": "^0.9.0",
     "@solana/kit": "^5.5.1",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",

--- a/helius-cli/pnpm-lock.yaml
+++ b/helius-cli/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@solana-program/token':
+        specifier: ^0.9.0
+        version: 0.9.0(@solana/kit@5.5.1(typescript@5.9.3))
       '@solana/kit':
         specifier: ^5.5.1
         version: 5.5.1(typescript@5.9.3)

--- a/helius-cli/src/commands/reclaim.ts
+++ b/helius-cli/src/commands/reclaim.ts
@@ -117,11 +117,12 @@ export async function reclaimCommand(
         nonEmptySkipped++;
         continue;
       }
-      // If closeAuthority is set, it must equal the signer to be closable by us.
-      // (We still count the skip in dry-run-without-signer mode, where signerAddress
-      // is null; those are informational-only.)
+      // If closeAuthority is set, only that address can close the ATA. Compare
+      // against owner (the wallet being audited) rather than signerAddress, so
+      // dry-runs of another wallet don't flag their own legitimate close-authority
+      // accounts as mismatched. For real runs we later enforce signerAddress === owner.
       const closeAuth: string | null | undefined = info.closeAuthority;
-      if (closeAuth && signerAddress && closeAuth !== signerAddress) {
+      if (closeAuth && closeAuth !== owner) {
         authoritySkipped++;
         continue;
       }
@@ -132,10 +133,22 @@ export async function reclaimCommand(
       });
     }
 
-    // Apply --limit cap.
-    const limit = options.limit ? parseInt(options.limit, 10) : undefined;
-    const toClose =
-      limit && limit > 0 ? closable.slice(0, limit) : closable;
+    // Apply --limit cap. Reject <= 0 and NaN explicitly — `--limit 0` expecting
+    // "close nothing" would otherwise fall through to closing every account.
+    let limit: number | undefined;
+    if (options.limit !== undefined) {
+      const parsed = parseInt(options.limit, 10);
+      if (Number.isNaN(parsed) || parsed <= 0) {
+        exitWithError(
+          "INVALID_INPUT",
+          `Invalid --limit: ${options.limit}. Must be a positive integer.`,
+          undefined,
+          !!options.json,
+        );
+      }
+      limit = parsed;
+    }
+    const toClose = limit ? closable.slice(0, limit) : closable;
     const totalReclaimable = toClose.reduce((sum, a) => sum + a.lamports, 0);
 
     // Build batches.
@@ -199,7 +212,7 @@ export async function reclaimCommand(
       if (authoritySkipped) {
         console.log(
           chalk.yellow(
-            `  Skipped ${authoritySkipped} account(s) (closeAuthority does not match keypair)`,
+            `  Skipped ${authoritySkipped} account(s) (closeAuthority does not match owner)`,
           ),
         );
       }
@@ -287,7 +300,16 @@ export async function reclaimCommand(
     const senderOpts: Record<string, unknown> = { region };
     if (options.swqosOnly) senderOpts.swqosOnly = true;
     if (options.tipAmount) {
-      senderOpts.tipAmount = parseInt(options.tipAmount, 10);
+      const tip = parseInt(options.tipAmount, 10);
+      if (Number.isNaN(tip) || tip < 0) {
+        exitWithError(
+          "INVALID_INPUT",
+          `Invalid --tip-amount: ${options.tipAmount}. Must be a non-negative integer (lamports).`,
+          undefined,
+          !!options.json,
+        );
+      }
+      senderOpts.tipAmount = tip;
     }
 
     type BatchResult =

--- a/helius-cli/src/commands/reclaim.ts
+++ b/helius-cli/src/commands/reclaim.ts
@@ -155,8 +155,19 @@ export async function reclaimCommand(
     const totalReclaimable = toClose.reduce((sum, a) => sum + a.lamports, 0);
 
     // Build batches.
-    const parsedBatch = options.batchSize ? parseInt(options.batchSize, 10) : DEFAULT_BATCH_SIZE;
-    const batchSize = Number.isNaN(parsedBatch) || parsedBatch < 1 ? DEFAULT_BATCH_SIZE : parsedBatch;
+    let batchSize = DEFAULT_BATCH_SIZE;
+    if (options.batchSize !== undefined) {
+      const parsed = parseInt(options.batchSize, 10);
+      if (Number.isNaN(parsed) || parsed < 1) {
+        exitWithError(
+          "INVALID_INPUT",
+          `Invalid --batch-size: ${options.batchSize}. Must be a positive integer.`,
+          undefined,
+          !!options.json,
+        );
+      }
+      batchSize = parsed;
+    }
     const batches: ClosableAta[][] = [];
     for (let i = 0; i < toClose.length; i += batchSize) {
       batches.push(toClose.slice(i, i + batchSize));

--- a/helius-cli/src/commands/reclaim.ts
+++ b/helius-cli/src/commands/reclaim.ts
@@ -15,6 +15,7 @@ import {
   type OutputOptions,
   type RetryOptions,
 } from "../lib/output.js";
+import { validateAddress } from "../lib/validation.js";
 
 const TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 
@@ -78,6 +79,8 @@ export async function reclaimCommand(
         !!options.json,
       );
     }
+    const ownerErr = validateAddress(owner);
+    if (ownerErr) exitWithError("INVALID_ADDRESS", ownerErr, undefined, !!options.json);
 
     // Fetch token accounts (legacy SPL Token program only for v1).
     const helius = await setupClient(
@@ -136,10 +139,8 @@ export async function reclaimCommand(
     const totalReclaimable = toClose.reduce((sum, a) => sum + a.lamports, 0);
 
     // Build batches.
-    const batchSize = Math.max(
-      1,
-      options.batchSize ? parseInt(options.batchSize, 10) : DEFAULT_BATCH_SIZE,
-    );
+    const parsedBatch = options.batchSize ? parseInt(options.batchSize, 10) : DEFAULT_BATCH_SIZE;
+    const batchSize = Number.isNaN(parsedBatch) || parsedBatch < 1 ? DEFAULT_BATCH_SIZE : parsedBatch;
     const batches: ClosableAta[][] = [];
     for (let i = 0; i < toClose.length; i += batchSize) {
       batches.push(toClose.slice(i, i + batchSize));
@@ -278,7 +279,10 @@ export async function reclaimCommand(
       }
     }
 
-    const destination = address(options.destination || signerAddress);
+    const destinationAddr = options.destination || signerAddress;
+    const destErr = validateAddress(destinationAddr);
+    if (destErr) exitWithError("INVALID_ADDRESS", destErr, undefined, !!options.json);
+    const destination = address(destinationAddr);
     const region = (options.region || "Default") as any;
     const senderOpts: Record<string, unknown> = { region };
     if (options.swqosOnly) senderOpts.swqosOnly = true;

--- a/helius-cli/src/commands/reclaim.ts
+++ b/helius-cli/src/commands/reclaim.ts
@@ -1,8 +1,10 @@
 import chalk from "chalk";
-import { address } from "@solana/kit";
+import { address, createKeyPairSignerFromBytes, type KeyPairSigner } from "@solana/kit";
 import { getCloseAccountInstruction } from "@solana-program/token";
+import type { GtaV2Account } from "helius-sdk/types/types";
+import type { SenderRegion, SendViaSenderOptions } from "helius-sdk/transactions/types";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
-import { loadKeypairFromFile, getAddress } from "../lib/wallet.js";
+import { loadKeypairFromFile } from "../lib/wallet.js";
 import { formatSol } from "../lib/formatters.js";
 import {
   outputJson,
@@ -50,13 +52,14 @@ export async function reclaimCommand(
   try {
     // Load signer. Always required for a real run; optional in dry-run if
     // an explicit owner address is provided (useful for auditing a wallet).
-    let signer: any = null;
+    let signer: KeyPairSigner | null = null;
     let signerAddress: string | null = null;
 
     if (options.keypair) {
       try {
-        signer = await loadKeypairFromFile(options.keypair);
-        signerAddress = await getAddress(signer);
+        const keypair = await loadKeypairFromFile(options.keypair);
+        signer = await createKeyPairSignerFromBytes(keypair.secretKey);
+        signerAddress = signer.address;
       } catch (e) {
         const needSigner = !options.dryRun || !ownerArg;
         if (needSigner) {
@@ -88,16 +91,16 @@ export async function reclaimCommand(
       options,
       `Scanning token accounts for ${owner}...`,
     );
-    const accounts: any[] = await withRetry(
+    const accounts: ReadonlyArray<GtaV2Account> = await withRetry(
       () =>
         helius.getAllTokenAccountsByOwner(
-          owner as any,
+          owner,
           { programId: TOKEN_PROGRAM_ID },
-          { encoding: "jsonParsed" as any },
+          { encoding: "jsonParsed" },
         ),
       options,
       spinner,
-    ) as any;
+    );
 
     // Filter closable accounts.
     const closable: ClosableAta[] = [];
@@ -296,8 +299,8 @@ export async function reclaimCommand(
     const destErr = validateAddress(destinationAddr);
     if (destErr) exitWithError("INVALID_ADDRESS", destErr, undefined, !!options.json);
     const destination = address(destinationAddr);
-    const region = (options.region || "Default") as any;
-    const senderOpts: Record<string, unknown> = { region };
+    const region = (options.region || "Default") as SenderRegion;
+    const senderOpts: Partial<SendViaSenderOptions> = { region };
     if (options.swqosOnly) senderOpts.swqosOnly = true;
     if (options.tipAmount) {
       const tip = parseInt(options.tipAmount, 10);
@@ -338,7 +341,7 @@ export async function reclaimCommand(
           account: address(a.address),
           destination,
           owner: signer,
-        } as any),
+        }),
       );
 
       spinner?.start(
@@ -347,14 +350,14 @@ export async function reclaimCommand(
       try {
         const signature: string = await withRetry(
           () =>
-            (helius as any).tx.sendTransactionWithSender({
+            helius.tx.sendTransactionWithSender({
               signers: [signer],
               instructions,
               ...senderOpts,
             }),
           options,
           spinner,
-        ) as any;
+        );
         results.push({
           ok: true,
           batchIndex: i + 1,

--- a/helius-cli/src/commands/reclaim.ts
+++ b/helius-cli/src/commands/reclaim.ts
@@ -1,0 +1,406 @@
+import chalk from "chalk";
+import { address } from "@solana/kit";
+import { getCloseAccountInstruction } from "@solana-program/token";
+import { setupClient, type ResolveOptions } from "../lib/helius.js";
+import { loadKeypairFromFile, getAddress } from "../lib/wallet.js";
+import { formatSol } from "../lib/formatters.js";
+import {
+  outputJson,
+  exitWithError,
+  handleCommandError,
+  createSpinner,
+  withRetry,
+  confirm,
+  isAgent,
+  type OutputOptions,
+  type RetryOptions,
+} from "../lib/output.js";
+
+const TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+// Conservative default: stays well under the 1232-byte tx size cap for v0 txs
+// even after compute-budget ixs, priority fee, and the Sender tip transfer are
+// prepended. Users can override with --batch-size.
+const DEFAULT_BATCH_SIZE = 20;
+
+interface ReclaimOptions extends OutputOptions, ResolveOptions, RetryOptions {
+  keypair?: string;
+  destination?: string;
+  region?: string;
+  swqosOnly?: boolean;
+  tipAmount?: string;
+  batchSize?: string;
+  limit?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+interface ClosableAta {
+  address: string;
+  mint: string;
+  lamports: number;
+}
+
+export async function reclaimCommand(
+  ownerArg: string | undefined,
+  options: ReclaimOptions = {},
+): Promise<void> {
+  const spinner = createSpinner(options);
+  try {
+    // Load signer. Always required for a real run; optional in dry-run if
+    // an explicit owner address is provided (useful for auditing a wallet).
+    let signer: any = null;
+    let signerAddress: string | null = null;
+
+    if (options.keypair) {
+      try {
+        signer = await loadKeypairFromFile(options.keypair);
+        signerAddress = await getAddress(signer);
+      } catch (e) {
+        const needSigner = !options.dryRun || !ownerArg;
+        if (needSigner) {
+          exitWithError(
+            "KEYPAIR_NOT_FOUND",
+            (e as Error).message,
+            undefined,
+            !!options.json,
+          );
+        }
+      }
+    }
+
+    const owner = ownerArg ?? signerAddress;
+    if (!owner) {
+      exitWithError(
+        "KEYPAIR_NOT_FOUND",
+        "Provide an owner address as an argument or a keypair with -k.",
+        undefined,
+        !!options.json,
+      );
+    }
+
+    // Fetch token accounts (legacy SPL Token program only for v1).
+    const helius = await setupClient(
+      spinner,
+      options,
+      `Scanning token accounts for ${owner}...`,
+    );
+    const accounts: any[] = await withRetry(
+      () =>
+        helius.getAllTokenAccountsByOwner(
+          owner as any,
+          { programId: TOKEN_PROGRAM_ID },
+          { encoding: "jsonParsed" as any },
+        ),
+      options,
+      spinner,
+    ) as any;
+
+    // Filter closable accounts.
+    const closable: ClosableAta[] = [];
+    let frozenSkipped = 0;
+    let nonEmptySkipped = 0;
+    let authoritySkipped = 0;
+
+    for (const a of accounts) {
+      const info = (a.account?.data as any)?.parsed?.info;
+      if (!info) continue;
+      if (info.state === "frozen") {
+        frozenSkipped++;
+        continue;
+      }
+      const amount = info.tokenAmount?.amount ?? "0";
+      if (amount !== "0") {
+        nonEmptySkipped++;
+        continue;
+      }
+      // If closeAuthority is set, it must equal the signer to be closable by us.
+      // (We still count the skip in dry-run-without-signer mode, where signerAddress
+      // is null; those are informational-only.)
+      const closeAuth: string | null | undefined = info.closeAuthority;
+      if (closeAuth && signerAddress && closeAuth !== signerAddress) {
+        authoritySkipped++;
+        continue;
+      }
+      closable.push({
+        address: a.pubkey,
+        mint: info.mint,
+        lamports: a.account.lamports,
+      });
+    }
+
+    // Apply --limit cap.
+    const limit = options.limit ? parseInt(options.limit, 10) : undefined;
+    const toClose =
+      limit && limit > 0 ? closable.slice(0, limit) : closable;
+    const totalReclaimable = toClose.reduce((sum, a) => sum + a.lamports, 0);
+
+    // Build batches.
+    const batchSize = Math.max(
+      1,
+      options.batchSize ? parseInt(options.batchSize, 10) : DEFAULT_BATCH_SIZE,
+    );
+    const batches: ClosableAta[][] = [];
+    for (let i = 0; i < toClose.length; i += batchSize) {
+      batches.push(toClose.slice(i, i + batchSize));
+    }
+
+    spinner?.stop();
+
+    // Dry-run path — no signer required, no broadcast.
+    if (options.dryRun) {
+      if (options.json) {
+        outputJson({
+          dryRun: true,
+          owner,
+          closable: toClose.length,
+          totalReclaimableLamports: totalReclaimable,
+          totalReclaimableSol: totalReclaimable / 1_000_000_000,
+          batches: batches.length,
+          batchSize,
+          region: options.region || "Default",
+          swqosOnly: !!options.swqosOnly,
+          note: "Token-2022 accounts are not scanned in v1.",
+          skipped: {
+            frozen: frozenSkipped,
+            nonEmpty: nonEmptySkipped,
+            closeAuthorityMismatch: authoritySkipped,
+          },
+          accounts: toClose,
+        });
+        return;
+      }
+
+      console.log(
+        chalk.bold(`\nReclaim (dry-run) for ${chalk.cyan(owner)}:\n`),
+      );
+      console.log(
+        `  ${chalk.gray("Closable ATAs:")} ${chalk.green(toClose.length)}`,
+      );
+      console.log(
+        `  ${chalk.gray("Total reclaimable:")} ${chalk.green(formatSol(totalReclaimable))}`,
+      );
+      console.log(
+        `  ${chalk.gray("Transactions:")} ${chalk.green(batches.length)} (batch size ${batchSize}, Sender region ${options.region || "Default"})`,
+      );
+      if (frozenSkipped) {
+        console.log(
+          chalk.yellow(`  Skipped ${frozenSkipped} frozen account(s)`),
+        );
+      }
+      if (nonEmptySkipped) {
+        console.log(
+          chalk.gray(
+            `  Ignored ${nonEmptySkipped} non-empty account(s) (have balances)`,
+          ),
+        );
+      }
+      if (authoritySkipped) {
+        console.log(
+          chalk.yellow(
+            `  Skipped ${authoritySkipped} account(s) (closeAuthority does not match keypair)`,
+          ),
+        );
+      }
+      console.log(
+        chalk.gray("  Token-2022 accounts are not scanned in v1."),
+      );
+      if (toClose.length) {
+        console.log("");
+        const preview = toClose.slice(0, 10);
+        for (const ata of preview) {
+          console.log(
+            `  ${chalk.cyan(ata.address)}  mint=${chalk.gray(ata.mint)}  rent=${formatSol(ata.lamports)}`,
+          );
+        }
+        if (toClose.length > preview.length) {
+          console.log(
+            chalk.gray(`  ... and ${toClose.length - preview.length} more`),
+          );
+        }
+      }
+      return;
+    }
+
+    // Real run — require signer and owner match.
+    if (!signer || !signerAddress) {
+      exitWithError(
+        "KEYPAIR_NOT_FOUND",
+        "Reclaim requires a keypair. Use -k <path> or run `helius keygen`.",
+        undefined,
+        !!options.json,
+      );
+    }
+    if (signerAddress !== owner) {
+      exitWithError(
+        "INVALID_INPUT",
+        `Keypair address (${signerAddress}) does not match owner (${owner}). Only the owner can close their token accounts.`,
+        undefined,
+        !!options.json,
+      );
+    }
+
+    if (toClose.length === 0) {
+      if (options.json) {
+        outputJson({
+          closed: 0,
+          reclaimedLamports: 0,
+          message: "No empty ATAs found",
+        });
+        return;
+      }
+      console.log(
+        chalk.yellow(`\nNo empty token accounts to close for ${owner}.`),
+      );
+      return;
+    }
+
+    // Confirmation prompt — TTY only.
+    if (!options.yes && !options.json && !isAgent) {
+      console.log(
+        chalk.bold(
+          `\nAbout to close ${toClose.length} empty token account(s):`,
+        ),
+      );
+      console.log(
+        `  ${chalk.gray("Reclaim:")} ~${formatSol(totalReclaimable)}`,
+      );
+      console.log(
+        `  ${chalk.gray("Transactions:")} ${batches.length} (batch size ${batchSize}, Sender region ${options.region || "Default"})`,
+      );
+      console.log(
+        `  ${chalk.gray("Destination:")} ${options.destination || signerAddress}`,
+      );
+      const ok = await confirm(chalk.yellow("\n  Proceed? (y/N) "));
+      if (!ok) {
+        console.log(chalk.gray("  Cancelled."));
+        return;
+      }
+    }
+
+    const destination = address(options.destination || signerAddress);
+    const region = (options.region || "Default") as any;
+    const senderOpts: Record<string, unknown> = { region };
+    if (options.swqosOnly) senderOpts.swqosOnly = true;
+    if (options.tipAmount) {
+      senderOpts.tipAmount = parseInt(options.tipAmount, 10);
+    }
+
+    type BatchResult =
+      | {
+          ok: true;
+          batchIndex: number;
+          signature: string;
+          closed: number;
+          reclaimedLamports: number;
+        }
+      | {
+          ok: false;
+          batchIndex: number;
+          attempted: number;
+          error: string;
+        };
+
+    const results: BatchResult[] = [];
+
+    // Send batches. Continue-on-error: a failed batch does not abort later ones.
+    for (let i = 0; i < batches.length; i++) {
+      const batch = batches[i];
+      const batchReclaimed = batch.reduce((sum, a) => sum + a.lamports, 0);
+      const instructions = batch.map((a) =>
+        getCloseAccountInstruction({
+          account: address(a.address),
+          destination,
+          owner: signer,
+        } as any),
+      );
+
+      spinner?.start(
+        `Closing batch ${i + 1}/${batches.length} (${batch.length} account${batch.length === 1 ? "" : "s"}) via Sender...`,
+      );
+      try {
+        const signature: string = await withRetry(
+          () =>
+            (helius as any).tx.sendTransactionWithSender({
+              signers: [signer],
+              instructions,
+              ...senderOpts,
+            }),
+          options,
+          spinner,
+        ) as any;
+        results.push({
+          ok: true,
+          batchIndex: i + 1,
+          signature,
+          closed: batch.length,
+          reclaimedLamports: batchReclaimed,
+        });
+        spinner?.succeed(
+          `Batch ${i + 1}/${batches.length} landed: ${chalk.cyan(signature)}`,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        results.push({
+          ok: false,
+          batchIndex: i + 1,
+          attempted: batch.length,
+          error: msg,
+        });
+        spinner?.fail(`Batch ${i + 1}/${batches.length} failed: ${msg}`);
+      }
+    }
+
+    // Summarize.
+    const successes = results.filter((r): r is Extract<BatchResult, { ok: true }> => r.ok);
+    const failures = results.filter((r): r is Extract<BatchResult, { ok: false }> => !r.ok);
+    const closedCount = successes.reduce((sum, r) => sum + r.closed, 0);
+    const reclaimedLamports = successes.reduce(
+      (sum, r) => sum + r.reclaimedLamports,
+      0,
+    );
+
+    if (options.json) {
+      outputJson({
+        owner,
+        destination: String(destination),
+        region: options.region || "Default",
+        swqosOnly: !!options.swqosOnly,
+        batchSize,
+        totalBatches: batches.length,
+        closed: closedCount,
+        reclaimedLamports,
+        reclaimedSol: reclaimedLamports / 1_000_000_000,
+        successes,
+        failures,
+      });
+      return;
+    }
+
+    console.log(chalk.bold("\nReclaim complete:\n"));
+    console.log(
+      `  ${chalk.gray("Closed:")} ${chalk.green(closedCount)} / ${toClose.length} account(s)`,
+    );
+    console.log(
+      `  ${chalk.gray("Reclaimed:")} ${chalk.green(formatSol(reclaimedLamports))}`,
+    );
+    console.log(
+      `  ${chalk.gray("Batches:")} ${successes.length} succeeded, ${failures.length} failed`,
+    );
+    if (failures.length) {
+      console.log(chalk.yellow("\n  Failed batches:"));
+      for (const f of failures) {
+        console.log(
+          `    ${chalk.red(`Batch ${f.batchIndex}`)} (${f.attempted} account${f.attempted === 1 ? "" : "s"}): ${f.error}`,
+        );
+      }
+      console.log(
+        chalk.gray(
+          "\n  Re-run the command to retry. Successful batches are already on-chain.",
+        ),
+      );
+    }
+  } catch (error) {
+    handleCommandError(error, options, spinner);
+  }
+}


### PR DESCRIPTION
This PR adds a `helius reclaim {owner}` command that scans for empty SPL token accounts (i.e., zero balance, initialized, non-frozen), batches `CloseAccount` instructions, and sends them via Sender to recover rent lamports

It supports the `--dry-run` command to preview closable accounts without actually sending any transactions, `-y` to skip confirmation, and `--json` for machine-readable output

The command also continues on error, so failed batches don't abort later ones, and a summary of all failures is surfaced at the end