### PR TITLE
feat(cli): Add Error Category to JSON Output

### DIFF
--- a/helius-cli/CLAUDE.md
+++ b/helius-cli/CLAUDE.md
@@ -88,9 +88,11 @@ WebSocket commands (`ws.ts`) use a variant that preserves the AbortError early-r
 
 The `retryable` field in `--json` error output reflects this directly.
 
+JSON error output also includes a `category` field (`"auth" | "balance" | "project" | "api" | "input" | "network" | "general"`), derived per-errorCode via `getCategory()` in `src/lib/output.ts`. Categories don't map cleanly to exit code ranges — the 50-59 range spans `auth` (INVALID_API_KEY, NO_API_KEY), `input` (INVALID_ADDRESS, INVALID_INPUT), and `network` (NETWORK_ERROR). Both `handleCommandError()` and `exitWithError()` emit it.
+
 ## Error Classification
 
-`classifyError(error)` in `src/lib/output.ts` returns `{ exitCode, errorCode, retryable }` using three tiers:
+`classifyError(error)` in `src/lib/output.ts` returns `{ exitCode, errorCode, retryable }` using three tiers (the `category` string is derived separately via `getCategory(errorCode)` at output time):
 
 1. **`HeliusHttpError`** (from `restRequest()` — wallet.ts REST path): exact `status` property → precise code
 2. **Status in message** (enhanced TX: `"Helius HTTP 429: ..."`, webhooks: `"HTTP error! status: 429 - ..."`): regex extracts status → same mapping

--- a/helius-cli/src/commands/ws.ts
+++ b/helius-cli/src/commands/ws.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { resolveApiKey, resolveNetwork, getClient, type ResolveOptions } from "../lib/helius.js";
-import { jsonReplacer, classifyError, exitWithError, CLI_GUIDANCE, type OutputOptions } from "../lib/output.js";
+import { jsonReplacer, classifyError, exitWithError, getCategory, CLI_GUIDANCE, type OutputOptions } from "../lib/output.js";
 import { sendCommandEvent, getCurrentCommand } from "../lib/feedback.js";
 import { validateAddress, validateSignature } from "../lib/validation.js";
 
@@ -41,7 +41,7 @@ function handleWsError(error: unknown, options: WsOptions): void {
   sendCommandEvent(cmdName, { exitCode, success: false });
 
   if (options.json) {
-    emitEvent("error", { error: errorCode, message, retryable, ...(guidance ? { guidance } : {}) });
+    emitEvent("error", { error: errorCode, message, category: getCategory(errorCode), retryable, ...(guidance ? { guidance } : {}) });
   } else {
     const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
     console.error(chalk.red(`Error: ${message}${hint}`));

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -88,8 +88,33 @@ const RETRYABLE_CODES = new Set<ExitCodeType>([
   ExitCode.NETWORK_ERROR,
 ]);
 
+// Known error code strings. Used as the key type for errorToExitCode and
+// categoryForErrorCode so the compiler enforces matching coverage in both.
+export type ErrorCode =
+  | "NOT_LOGGED_IN"
+  | "KEYPAIR_NOT_FOUND"
+  | "AUTH_FAILED"
+  | "INSUFFICIENT_SOL"
+  | "INSUFFICIENT_USDC"
+  | "PAYMENT_FAILED"
+  | "NO_PROJECTS"
+  | "PROJECT_NOT_FOUND"
+  | "MULTIPLE_PROJECTS"
+  | "PROJECT_EXISTS"
+  | "API_ERROR"
+  | "NO_API_KEYS"
+  | "NO_API_KEY"
+  | "SDK_ERROR"
+  | "INVALID_ADDRESS"
+  | "INVALID_INPUT"
+  | "INVALID_API_KEY"
+  | "NOT_FOUND"
+  | "RATE_LIMITED"
+  | "SERVER_ERROR"
+  | "NETWORK_ERROR";
+
 // Map error code strings to exit codes
-const errorToExitCode: Record<string, ExitCodeType> = {
+const errorToExitCode: Record<ErrorCode, ExitCodeType> = {
   NOT_LOGGED_IN: ExitCode.NOT_LOGGED_IN,
   KEYPAIR_NOT_FOUND: ExitCode.KEYPAIR_NOT_FOUND,
   AUTH_FAILED: ExitCode.AUTH_FAILED,
@@ -114,7 +139,9 @@ const errorToExitCode: Record<string, ExitCodeType> = {
 };
 
 export function getExitCode(errorCode: string): ExitCodeType {
-  return errorToExitCode[errorCode] || ExitCode.GENERAL_ERROR;
+  // Cast to ErrorCode to index the tightly-typed map; runtime misses fall
+  // through to GENERAL_ERROR via `||`.
+  return errorToExitCode[errorCode as ErrorCode] || ExitCode.GENERAL_ERROR;
 }
 
 // Error categories for JSON output. Agents can branch on `category` without
@@ -132,7 +159,7 @@ export type ErrorCategory =
   | "network"
   | "general";
 
-const categoryForErrorCode: Record<string, ErrorCategory> = {
+const categoryForErrorCode: Record<ErrorCode, ErrorCategory> = {
   NOT_LOGGED_IN: "auth",
   KEYPAIR_NOT_FOUND: "auth",
   AUTH_FAILED: "auth",
@@ -157,7 +184,8 @@ const categoryForErrorCode: Record<string, ErrorCategory> = {
 };
 
 export function getCategory(errorCode: string): ErrorCategory {
-  return categoryForErrorCode[errorCode] || "general";
+  // Cast mirrors getExitCode; runtime misses fall through to "general".
+  return categoryForErrorCode[errorCode as ErrorCode] || "general";
 }
 
 // Classification result returned by classifyError()
@@ -368,7 +396,9 @@ export function exitWithError(
   if (json) {
     const retryable = RETRYABLE_CODES.has(exitCode);
     const category = getCategory(errorCode);
-    outputJson({ error: errorCode, message, category, retryable, ...details });
+    // Spread details first so canonical fields (error, message, category,
+    // retryable) can't be accidentally overridden by a caller.
+    outputJson({ ...details, error: errorCode, message, category, retryable });
   } else {
     console.error(chalk.red(message));
     const guidance = CLI_GUIDANCE[errorCode];

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -117,6 +117,49 @@ export function getExitCode(errorCode: string): ExitCodeType {
   return errorToExitCode[errorCode] || ExitCode.GENERAL_ERROR;
 }
 
+// Error categories for JSON output. Agents can branch on `category` without
+// needing to memorize the exit code range for a given errorCode.
+//
+// Note: the 50-59 range (SDK/data errors) spans multiple categories — e.g.
+// INVALID_API_KEY is "auth", INVALID_ADDRESS is "input", NETWORK_ERROR is
+// "network" — so category is derived per-errorCode, not per exit-code-range.
+export type ErrorCategory =
+  | "auth"
+  | "balance"
+  | "project"
+  | "api"
+  | "input"
+  | "network"
+  | "general";
+
+const categoryForErrorCode: Record<string, ErrorCategory> = {
+  NOT_LOGGED_IN: "auth",
+  KEYPAIR_NOT_FOUND: "auth",
+  AUTH_FAILED: "auth",
+  NO_API_KEY: "auth",
+  INVALID_API_KEY: "auth",
+  INSUFFICIENT_SOL: "balance",
+  INSUFFICIENT_USDC: "balance",
+  PAYMENT_FAILED: "balance",
+  NO_PROJECTS: "project",
+  PROJECT_NOT_FOUND: "project",
+  MULTIPLE_PROJECTS: "project",
+  PROJECT_EXISTS: "project",
+  API_ERROR: "api",
+  NO_API_KEYS: "api",
+  SDK_ERROR: "api",
+  NOT_FOUND: "api",
+  RATE_LIMITED: "api",
+  SERVER_ERROR: "api",
+  INVALID_ADDRESS: "input",
+  INVALID_INPUT: "input",
+  NETWORK_ERROR: "network",
+};
+
+export function getCategory(errorCode: string): ErrorCategory {
+  return categoryForErrorCode[errorCode] || "general";
+}
+
 // Classification result returned by classifyError()
 export interface ErrorClassification {
   exitCode: ExitCodeType;
@@ -275,7 +318,8 @@ export function handleCommandError(
   sendCommandEvent(cmdName, { exitCode, success: false });
 
   if (options.json) {
-    outputJson({ error: errorCode, message, retryable, ...(guidance ? { guidance } : {}) });
+    const category = getCategory(errorCode);
+    outputJson({ error: errorCode, message, category, retryable, ...(guidance ? { guidance } : {}) });
   } else {
     const hint = retryable ? chalk.gray(" (transient — safe to retry)") : "";
     spinner?.fail(`${message}${hint}`);
@@ -323,7 +367,8 @@ export function exitWithError(
 
   if (json) {
     const retryable = RETRYABLE_CODES.has(exitCode);
-    outputJson({ error: errorCode, message, retryable, ...details });
+    const category = getCategory(errorCode);
+    outputJson({ error: errorCode, message, category, retryable, ...details });
   } else {
     console.error(chalk.red(message));
     const guidance = CLI_GUIDANCE[errorCode];


### PR DESCRIPTION
This PR adds a `category` field to JSON error output (`"auth" | "balance" | "project" | "api" | "input" | "network" | "general"`) so agents can branch on error domain without needing to create their own lookup table. We introduce `ErrorCode`, a literal union, and retype `errorToExitCode` + `categoryForErrorCode` as `Record<ErrorCode, ...>` so the compiler enforces matching coverage in both maps. Now, we emit `category` from both `handleCommandError()` and `exitWithError()`