### PR TITLE
feat(cli): Add `--amount` and `--raw-amount` Flags for Stake Commands

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -753,15 +753,18 @@ const stakeCmd = program
   .description("Staking commands");
 
 stakeCmd
-  .command("create <amount>")
-  .description("Create a stake transaction (amount in SOL)")
+  .command("create [amount]")
+  .description("Create a stake transaction. Accepts positional SOL, --amount <sol>, or --raw-amount <lamports>.")
   .option("-k, --keypair <path>", "Path to Solana keypair file")
+  .option("--amount <sol>", "Amount in SOL (e.g. 1.5) — alternative to positional")
+  .option("--raw-amount <lamports>", "Amount in lamports (e.g. 1500000000) — exact, avoids float rounding")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
   $ helius stake create 1.5 -k ~/.helius/keypair.json
-  $ helius stake create 10 -k ~/.helius/keypair.json --json`)
-  .action(function(this: any, amount: string) { stakeCreateCommand(amount, opts(this)); });
+  $ helius stake create --amount 1.5 -k ~/.helius/keypair.json
+  $ helius stake create --raw-amount 1500000000 -k ~/.helius/keypair.json --json`)
+  .action(function(this: any, amount: string | undefined) { stakeCreateCommand(amount, opts(this)); });
 
 stakeCmd
   .command("unstake <stake-account>")
@@ -802,13 +805,17 @@ Examples:
   .action(function(this: any, stakeAccount: string) { stakeWithdrawableCommand(stakeAccount, opts(this)); });
 
 stakeCmd
-  .command("instructions <amount>")
-  .description("Get stake instructions (amount in SOL)")
+  .command("instructions [amount]")
+  .description("Get stake instructions. Accepts positional SOL, --amount <sol>, or --raw-amount <lamports>.")
+  .option("--amount <sol>", "Amount in SOL (e.g. 1.5) — alternative to positional")
+  .option("--raw-amount <lamports>", "Amount in lamports (e.g. 1500000000) — exact, avoids float rounding")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
-  $ helius stake instructions 5 --json`)
-  .action(function(this: any, amount: string) { stakeInstructionsCommand(amount, opts(this)); });
+  $ helius stake instructions 5
+  $ helius stake instructions --amount 5
+  $ helius stake instructions --raw-amount 5000000000 --json`)
+  .action(function(this: any, amount: string | undefined) { stakeInstructionsCommand(amount, opts(this)); });
 
 stakeCmd
   .command("unstake-instruction <stake-account>")

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -6,6 +6,87 @@ import { validateAddress } from "../lib/validation.js";
 
 interface StakeOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
+interface AmountOptions {
+  amount?: string;     // --amount <sol> (human-readable, e.g. "1.5")
+  rawAmount?: string;  // --raw-amount <lamports> (exact, e.g. "1500000000")
+}
+
+/**
+ * Resolve an amount to lamports from three possible sources:
+ *   - positional SOL (legacy, e.g. "1.5")
+ *   - --amount <sol> flag (same format, prevents ambiguity with other positionals)
+ *   - --raw-amount <lamports> flag (exact integer, avoids float rounding for programmatic callers)
+ *
+ * Exactly one source must be provided; otherwise we exit with INVALID_INPUT.
+ * The SOL paths share the same parse+round logic so their behavior is identical.
+ */
+function resolveLamports(
+  positional: string | undefined,
+  opts: AmountOptions,
+  json: boolean,
+): bigint {
+  const sources = [positional, opts.amount, opts.rawAmount].filter((v): v is string => !!v);
+  if (sources.length === 0) {
+    exitWithError(
+      "INVALID_INPUT",
+      "Provide an amount: positional SOL, --amount <sol>, or --raw-amount <lamports>.",
+      undefined,
+      json,
+    );
+  }
+  if (sources.length > 1) {
+    exitWithError(
+      "INVALID_INPUT",
+      "Conflicting amount inputs. Use exactly one of: positional, --amount, --raw-amount.",
+      undefined,
+      json,
+    );
+  }
+
+  if (opts.rawAmount !== undefined) {
+    if (!/^\d+$/.test(opts.rawAmount)) {
+      exitWithError(
+        "INVALID_INPUT",
+        `Invalid --raw-amount: ${opts.rawAmount}. Must be a positive integer (lamports).`,
+        undefined,
+        json,
+      );
+    }
+    const lamports = BigInt(opts.rawAmount);
+    if (lamports <= 0n) {
+      exitWithError("INVALID_INPUT", "Amount must be greater than 0 lamports.", undefined, json);
+    }
+    return lamports;
+  }
+
+  // Validate format before parseFloat to reject trailing garbage ("1.5abc" → 1.5),
+  // scientific notation ("1e9"), leading signs, and other oddities that parseFloat
+  // silently accepts or truncates.
+  const sol = opts.amount ?? positional!;
+  if (!/^\d+(\.\d+)?$/.test(sol)) {
+    exitWithError(
+      "INVALID_INPUT",
+      `Invalid SOL amount: ${sol}. Must be a positive decimal number (e.g. 1.5).`,
+      undefined,
+      json,
+    );
+  }
+  const parsed = parseFloat(sol);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    exitWithError(
+      "INVALID_INPUT",
+      `Invalid SOL amount: ${sol}. Must be a positive number.`,
+      undefined,
+      json,
+    );
+  }
+  const lamports = BigInt(Math.round(parsed * 1e9));
+  if (lamports <= 0n) {
+    exitWithError("INVALID_INPUT", "Amount must be greater than 0 lamports.", undefined, json);
+  }
+  return lamports;
+}
+
 export async function stakeAccountsCommand(wallet: string, options: StakeOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
@@ -49,17 +130,20 @@ export async function stakeWithdrawableCommand(stakeAccount: string, options: St
   }
 }
 
-export async function stakeInstructionsCommand(amount: string, options: StakeOptions = {}): Promise<void> {
+export async function stakeInstructionsCommand(
+  amount: string | undefined,
+  options: StakeOptions & AmountOptions = {},
+): Promise<void> {
   const spinner = createSpinner(options);
   try {
+    const lamports = resolveLamports(amount, options, !!options.json);
     const helius = await setupClient(spinner, options, "Getting stake instructions...");
-    const lamports = BigInt(Math.round(parseFloat(amount) * 1e9));
     const result = await withRetry(() => helius.stake.getStakeInstructions(lamports), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
 
-    console.log(chalk.bold(`\nStake Instructions for ${amount} SOL:\n`));
+    console.log(chalk.bold(`\nStake Instructions for ${formatSol(lamports)}:\n`));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {
     handleCommandError(error, options, spinner);
@@ -102,20 +186,23 @@ export async function stakeWithdrawInstructionCommand(stakeAccount: string, opti
   }
 }
 
-export async function stakeCreateCommand(amount: string, options: StakeOptions & { keypair?: string } = {}): Promise<void> {
+export async function stakeCreateCommand(
+  amount: string | undefined,
+  options: StakeOptions & AmountOptions & { keypair?: string } = {},
+): Promise<void> {
   const spinner = createSpinner(options);
   if (!options.keypair) {
     exitWithError("KEYPAIR_NOT_FOUND", "Missing --keypair flag", undefined, !!options.json);
   }
   try {
+    const lamports = resolveLamports(amount, options, !!options.json);
     const helius = await setupClient(spinner, options, "Creating stake transaction...");
-    const lamports = BigInt(Math.round(parseFloat(amount) * 1e9));
     const result = await withRetry(() => helius.stake.createStakeTransaction(lamports), options, spinner);
     spinner?.stop();
 
     if (options.json) { outputJson(result); return; }
 
-    console.log(chalk.bold("\nStake Transaction Created:\n"));
+    console.log(chalk.bold(`\nStake Transaction Created (${formatSol(lamports)}):\n`));
     console.log(chalk.gray("Transaction needs to be signed and sent with your keypair."));
     console.log(chalk.gray(JSON.stringify(result, null, 2)));
   } catch (error) {


### PR DESCRIPTION
This PR adds `--amount <sol>` and `--raw-amount <lamports>` flags to `stake create` and `stake instructions`. The positional SOL argument is now optional and kept for backward compatibility. Note that exactly one source must be provided. We also introduce a shared `resolveLamports()` helper in `stake.ts` that validates input format (regex guards reject `"1.5abc"`, `"1e9"`, `"+1.5"`, etc. that `parseFloat` would silently accept), rejects zero/negative, and converts to a lamports `bigint`