### PR TITLE
feat(cli,mcp): Add SNS/ANS domain resolution to wallet identity

### DIFF
--- a/.agents/skills/helius-dflow/SKILL.md
+++ b/.agents/skills/helius-dflow/SKILL.md
@@ -2,7 +2,7 @@
 
 ---
 name: helius-dflow
-version: "1.1.0"
+version: "1.1.1"
 description: >
   Build Solana trading applications combining DFlow trading APIs with Helius
   infrastructure. Use this skill when: building swap UIs or trading terminals,

--- a/.agents/skills/helius-dflow/prompts/claude.system.md
+++ b/.agents/skills/helius-dflow/prompts/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-dflow/prompts/full.md
+++ b/.agents/skills/helius-dflow/prompts/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 
 # Helius x DFlow — Build Trading Apps on Solana
@@ -2963,8 +2963,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -2995,11 +2995,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/.agents/skills/helius-dflow/prompts/openai.developer.md
+++ b/.agents/skills/helius-dflow/prompts/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-dflow/references/helius-wallet-api.md
+++ b/.agents/skills/helius-dflow/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/.agents/skills/helius-jupiter/SKILL.md
+++ b/.agents/skills/helius-jupiter/SKILL.md
@@ -2,7 +2,7 @@
 
 ---
 name: helius-jupiter
-version: "1.0.0"
+version: "1.0.1"
 description: >
   Build Solana DeFi applications combining Jupiter APIs with Helius
   infrastructure. Use this skill when: building token swap UIs or trading terminals,

--- a/.agents/skills/helius-jupiter/prompts/claude.system.md
+++ b/.agents/skills/helius-jupiter/prompts/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-jupiter/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-jupiter/prompts/full.md
+++ b/.agents/skills/helius-jupiter/prompts/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius-jupiter/SKILL.md — do not edit -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 
 # Helius x Jupiter — Build DeFi Apps on Solana
@@ -1869,8 +1869,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -1901,11 +1901,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/.agents/skills/helius-jupiter/prompts/openai.developer.md
+++ b/.agents/skills/helius-jupiter/prompts/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-jupiter/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-jupiter/references/helius-wallet-api.md
+++ b/.agents/skills/helius-jupiter/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/.agents/skills/helius-okx/SKILL.md
+++ b/.agents/skills/helius-okx/SKILL.md
@@ -2,7 +2,7 @@
 
 ---
 name: helius-okx
-version: "1.0.0"
+version: "1.0.1"
 description: >
   Build Solana trading and intelligence applications combining OKX DEX aggregation
   with Helius infrastructure. Use this skill when: executing swaps via OKX's 500+

--- a/.agents/skills/helius-okx/prompts/claude.system.md
+++ b/.agents/skills/helius-okx/prompts/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-okx/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-okx/prompts/full.md
+++ b/.agents/skills/helius-okx/prompts/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius-okx/SKILL.md — do not edit -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 
 # Helius x OKX — Build Trading & Intelligence Apps on Solana
@@ -483,7 +483,7 @@ Helius parseTransactions ──> Trade History
 3. **Price charts**: OKX `market kline` for candlestick data on selected tokens
 4. **PnL analysis**: OKX `portfolio-overview` for realized/unrealized PnL and win rate
 5. **Trade history**: Helius `parseTransactions` for human-readable transaction log
-6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity
+6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity — accepts an address or SNS/ANS domain
 
 ### Multi-Chain Extension
 

--- a/.agents/skills/helius-okx/prompts/openai.developer.md
+++ b/.agents/skills/helius-okx/prompts/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-okx/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-okx/references/integration-patterns.md
+++ b/.agents/skills/helius-okx/references/integration-patterns.md
@@ -306,7 +306,7 @@ Helius parseTransactions ──> Trade History
 3. **Price charts**: OKX `market kline` for candlestick data on selected tokens
 4. **PnL analysis**: OKX `portfolio-overview` for realized/unrealized PnL and win rate
 5. **Trade history**: Helius `parseTransactions` for human-readable transaction log
-6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity
+6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity — accepts an address or SNS/ANS domain
 
 ### Multi-Chain Extension
 

--- a/.agents/skills/helius-phantom/SKILL.md
+++ b/.agents/skills/helius-phantom/SKILL.md
@@ -2,7 +2,7 @@
 
 ---
 name: helius-phantom
-version: "1.0.0"
+version: "1.0.1"
 description: >
   Build frontend Solana applications with Phantom Connect SDK and Helius
   infrastructure. Use this skill when: connecting Phantom wallet in React,

--- a/.agents/skills/helius-phantom/prompts/claude.system.md
+++ b/.agents/skills/helius-phantom/prompts/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-phantom/prompts/full.md
+++ b/.agents/skills/helius-phantom/prompts/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 
 # Helius x Phantom — Build Frontend Solana Apps
@@ -2610,8 +2610,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -2642,11 +2642,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/.agents/skills/helius-phantom/prompts/openai.developer.md
+++ b/.agents/skills/helius-phantom/prompts/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius-phantom/references/helius-wallet-api.md
+++ b/.agents/skills/helius-phantom/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/.agents/skills/helius/SKILL.md
+++ b/.agents/skills/helius/SKILL.md
@@ -2,7 +2,7 @@
 
 ---
 name: helius
-version: "1.1.0"
+version: "1.1.1"
 description: >
   Build Solana applications with Helius infrastructure. Use this skill when:
   sending transactions (SOL, SPL tokens, swaps), querying assets/NFTs (DAS API),

--- a/.agents/skills/helius/prompts/claude.system.md
+++ b/.agents/skills/helius/prompts/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius/prompts/full.md
+++ b/.agents/skills/helius/prompts/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 
 # Helius — Build on Solana
@@ -2184,8 +2184,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -2216,11 +2216,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/.agents/skills/helius/prompts/openai.developer.md
+++ b/.agents/skills/helius/prompts/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 ## Runtime Notes
 

--- a/.agents/skills/helius/references/wallet-api.md
+++ b/.agents/skills/helius/references/wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-cli/README.md
+++ b/helius-cli/README.md
@@ -131,8 +131,8 @@ helius config clear               # Reset config
 
 | Command | Description |
 |---|---|
-| `helius wallet identity <address>` | Look up wallet identity |
-| `helius wallet identity-batch <addresses...>` | Look up identities for multiple wallets |
+| `helius wallet identity <address-or-domain>` | Look up wallet identity (address or SNS/ANS domain) |
+| `helius wallet identity-batch <entries...>` | Look up identities for multiple wallets (addresses and/or domains) |
 | `helius wallet balances <address>` | Get all token balances with USD values |
 | `helius wallet history <address>` | Get transaction history with balance changes |
 | `helius wallet transfers <address>` | Get token transfers |

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -556,21 +556,24 @@ const walletCmd = program
   .description("Wallet API commands (balances, identity, history)");
 
 walletCmd
-  .command("identity <address>")
-  .description("Look up wallet identity")
+  .command("identity <address-or-domain>")
+  .description("Look up wallet identity (accepts address or SNS/ANS domain, mainnet only for domains)")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
-  $ helius wallet identity 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY`)
+  $ helius wallet identity 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY
+  $ helius wallet identity toly.sol
+  $ helius wallet identity helius.bonk`)
   .action(function(this: any, address: string) { walletIdentityCommand(address, opts(this)); });
 
 walletCmd
-  .command("identity-batch <addresses...>")
-  .description("Look up identities for multiple wallets")
+  .command("identity-batch <entries...>")
+  .description("Look up identities for multiple wallets (accepts addresses and/or SNS/ANS domains)")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
-  $ helius wallet identity-batch 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA --json`)
+  $ helius wallet identity-batch 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA --json
+  $ helius wallet identity-batch toly.sol 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY`)
   .action(function(this: any, addresses: string[]) { walletIdentityBatchCommand(addresses, opts(this)); });
 
 walletCmd

--- a/helius-cli/src/commands/wallet.ts
+++ b/helius-cli/src/commands/wallet.ts
@@ -2,14 +2,14 @@ import chalk from "chalk";
 import { resolveApiKey, restRequest, type ResolveOptions } from "../lib/helius.js";
 import { formatAddress, formatTable, formatEnumLabel, type TableColumn } from "../lib/formatters.js";
 import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
-import { validateAddress, validateAddresses } from "../lib/validation.js";
+import { validateAddress, validateAddressOrDomain, validateAddressesOrDomains } from "../lib/validation.js";
 
 interface WalletOptions extends OutputOptions, ResolveOptions, RetryOptions {}
 
 export async function walletIdentityCommand(address: string, options: WalletOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const addrErr = validateAddress(address);
+    const addrErr = validateAddressOrDomain(address);
     if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -34,7 +34,7 @@ export async function walletIdentityCommand(address: string, options: WalletOpti
 export async function walletIdentityBatchCommand(addresses: string[], options: WalletOptions = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {
-    const addrErr = validateAddresses(addresses);
+    const addrErr = validateAddressesOrDomains(addresses);
     if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
     spinner?.start("Resolving API key...");
     const apiKey = await resolveApiKey(options);
@@ -48,11 +48,22 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
     const identities = Array.isArray(result) ? result : [];
     console.log(chalk.bold(`\nWallet Identities (${identities.length}):\n`));
     for (const id of identities) {
-      if (id.name || id.type) {
-        console.log(`  ${chalk.cyan(id.address || "?")} - ${chalk.green(id.name || "Unknown")} (${id.type ? formatEnumLabel(id.type) : "N/A"})`);
+      if (id.unresolved) continue;
+      const subject = id.inputDomain && id.address
+        ? `${chalk.cyan(id.inputDomain)} ${chalk.gray("→")} ${chalk.cyan(id.address)}`
+        : chalk.cyan(id.address || id.inputDomain || "?");
+      if (id.name || (id.type && id.type !== "unknown")) {
+        console.log(`  ${subject} - ${chalk.green(id.name || "Unknown")} (${id.type ? formatEnumLabel(id.type) : "N/A"})`);
       }
     }
-    const unknown = identities.filter((i: any) => !i.name && !i.type);
+    const unresolved = identities.filter((i: any) => i.unresolved);
+    if (unresolved.length) {
+      console.log(chalk.yellow(`\n  ${unresolved.length} domain(s) could not be resolved:`));
+      for (const id of unresolved) {
+        console.log(chalk.yellow(`    ${id.inputDomain || "?"}`));
+      }
+    }
+    const unknown = identities.filter((i: any) => !i.unresolved && !i.name && (!i.type || i.type === "unknown"));
     if (unknown.length) {
       console.log(chalk.gray(`\n  ${unknown.length} wallet(s) have no known identity`));
     }

--- a/helius-cli/src/commands/wallet.ts
+++ b/helius-cli/src/commands/wallet.ts
@@ -17,11 +17,15 @@ export async function walletIdentityCommand(address: string, options: WalletOpti
     const result = await withRetry(() => restRequest(`/v1/wallet/${address}/identity`, apiKey), options, spinner);
     spinner?.stop();
     if (options.json) { outputJson(result); return; }
+    const resolved = result?.address || address;
+    const header = result?.inputDomain && result?.address
+      ? `${chalk.cyan(result.inputDomain)} ${chalk.gray("→")} ${chalk.cyan(result.address)}`
+      : chalk.cyan(resolved);
     if (!result || (!result.name && !result.type)) {
-      console.log(chalk.yellow(`\nNo known identity for ${address}`));
+      console.log(chalk.yellow(`\nNo known identity for ${header}`));
       return;
     }
-    console.log(chalk.bold(`\nWallet Identity for ${chalk.cyan(address)}:\n`));
+    console.log(chalk.bold(`\nWallet Identity for ${header}:\n`));
     if (result.name) console.log(`  ${chalk.gray("Name:")}     ${chalk.green(result.name)}`);
     if (result.type) console.log(`  ${chalk.gray("Type:")}     ${formatEnumLabel(result.type)}`);
     if (result.category) console.log(`  ${chalk.gray("Category:")} ${result.category}`);
@@ -52,8 +56,11 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
       const subject = id.inputDomain && id.address
         ? `${chalk.cyan(id.inputDomain)} ${chalk.gray("→")} ${chalk.cyan(id.address)}`
         : chalk.cyan(id.address || id.inputDomain || "?");
-      if (id.name || (id.type && id.type !== "unknown")) {
+      const hasIdentity = id.name || (id.type && id.type !== "unknown");
+      if (hasIdentity) {
         console.log(`  ${subject} - ${chalk.green(id.name || "Unknown")} (${id.type ? formatEnumLabel(id.type) : "N/A"})`);
+      } else if (id.inputDomain) {
+        console.log(`  ${subject} - ${chalk.gray("no known identity")}`);
       }
     }
     const unresolved = identities.filter((i: any) => i.unresolved);
@@ -63,7 +70,7 @@ export async function walletIdentityBatchCommand(addresses: string[], options: W
         console.log(chalk.yellow(`    ${id.inputDomain || "?"}`));
       }
     }
-    const unknown = identities.filter((i: any) => !i.unresolved && !i.name && (!i.type || i.type === "unknown"));
+    const unknown = identities.filter((i: any) => !i.unresolved && !i.inputDomain && !i.name && (!i.type || i.type === "unknown"));
     if (unknown.length) {
       console.log(chalk.gray(`\n  ${unknown.length} wallet(s) have no known identity`));
     }

--- a/helius-cli/src/lib/validation.ts
+++ b/helius-cli/src/lib/validation.ts
@@ -8,6 +8,12 @@ const VALID_PERIODS = new Set(["monthly", "yearly"]);
 // Base58 character set (no 0, O, I, l)
 const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 
+// Mirror of the wallet-api server's isValidDomainName so any input the server
+// accepts (SNS .sol, ANS .bonk/.poor/etc., multi-label subdomains, underscores)
+// passes client validation.
+const DOMAIN_RE = /^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]+)+$/;
+const DOMAIN_MAX_LEN = 255;
+
 export function validateSignupPlan(plan: string): string | null {
   if (!SIGNUP_PLANS.has(plan.toLowerCase())) {
     const available = [...SIGNUP_PLANS].join(", ");
@@ -48,6 +54,20 @@ export function validateAddress(addr: string): string | null {
 export function validateAddresses(addrs: string[]): string | null {
   for (const addr of addrs) {
     const err = validateAddress(addr);
+    if (err) return err;
+  }
+  return null;
+}
+
+export function validateAddressOrDomain(input: string): string | null {
+  if (BASE58_RE.test(input)) return null;
+  if (input.length <= DOMAIN_MAX_LEN && DOMAIN_RE.test(input)) return null;
+  return `Invalid Solana address or domain: ${input}`;
+}
+
+export function validateAddressesOrDomains(inputs: string[]): string | null {
+  for (const s of inputs) {
+    const err = validateAddressOrDomain(s);
     if (err) return err;
   }
   return null;

--- a/helius-cursor/skills/build/SKILL.md
+++ b/helius-cursor/skills/build/SKILL.md
@@ -2,7 +2,7 @@
 name: build
 description: Build Solana applications with Helius infrastructure. Covers transaction sending (Sender), asset/NFT queries (DAS API), real-time streaming (WebSockets, Laserstream), event pipelines (webhooks), priority fees, wallet analysis, and agent onboarding.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 # Helius — Build on Solana

--- a/helius-cursor/skills/build/references/wallet-api.md
+++ b/helius-cursor/skills/build/references/wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-cursor/skills/dflow/SKILL.md
+++ b/helius-cursor/skills/dflow/SKILL.md
@@ -2,7 +2,7 @@
 name: dflow
 description: Build Solana trading applications combining DFlow trading APIs with Helius infrastructure. Covers spot swaps (imperative and declarative), prediction markets, real-time market streaming, Proof KYC, the DFlow Agent CLI for autonomous trading, transaction submission via Sender, fee optimization, shred-level streaming via LaserStream, and wallet intelligence.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 # Helius x DFlow — Build Trading Apps on Solana

--- a/helius-cursor/skills/dflow/references/helius-wallet-api.md
+++ b/helius-cursor/skills/dflow/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-cursor/skills/jupiter/SKILL.md
+++ b/helius-cursor/skills/jupiter/SKILL.md
@@ -2,7 +2,7 @@
 name: jupiter
 description: Build Solana DeFi applications combining Jupiter APIs with Helius infrastructure. Covers token swaps (Swap API V2), lending/borrowing (Lend protocol), limit orders (Trigger), DCA (Recurring), token/price data, transaction submission via Sender, fee optimization, real-time streaming, and wallet intelligence.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Helius x Jupiter — Build DeFi Apps on Solana

--- a/helius-cursor/skills/jupiter/references/helius-wallet-api.md
+++ b/helius-cursor/skills/jupiter/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-cursor/skills/okx/SKILL.md
+++ b/helius-cursor/skills/okx/SKILL.md
@@ -2,7 +2,7 @@
 name: okx
 description: Build Solana trading and intelligence applications combining OKX DEX aggregation with Helius infrastructure. Integration-only layer — describes when and how to compose OKX tools with Helius tools for swaps, token discovery, smart money signals, meme token analysis, and portfolio intelligence.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Helius x OKX — Build Trading & Intelligence Apps on Solana

--- a/helius-cursor/skills/okx/references/integration-patterns.md
+++ b/helius-cursor/skills/okx/references/integration-patterns.md
@@ -306,7 +306,7 @@ Helius parseTransactions ──> Trade History
 3. **Price charts**: OKX `market kline` for candlestick data on selected tokens
 4. **PnL analysis**: OKX `portfolio-overview` for realized/unrealized PnL and win rate
 5. **Trade history**: Helius `parseTransactions` for human-readable transaction log
-6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity
+6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity — accepts an address or SNS/ANS domain
 
 ### Multi-Chain Extension
 

--- a/helius-cursor/skills/phantom/SKILL.md
+++ b/helius-cursor/skills/phantom/SKILL.md
@@ -2,7 +2,7 @@
 name: phantom
 description: Build frontend Solana applications with Phantom Connect SDK and Helius infrastructure. Covers React, React Native, and browser SDK integration, transaction signing via Helius Sender, API key proxying, token gating, NFT minting, crypto payments, real-time updates, and secure frontend architecture.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Helius x Phantom — Build Frontend Solana Apps

--- a/helius-cursor/skills/phantom/references/helius-wallet-api.md
+++ b/helius-cursor/skills/phantom/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-mcp/src/tools/wallet.ts
+++ b/helius-mcp/src/tools/wallet.ts
@@ -19,10 +19,12 @@ export function registerWalletTools(server: McpServer) {
 
       try {
         const client = getHeliusClient();
-        const data = await client.wallet.getIdentity({ wallet: address });
+        // TODO: drop `any` once helius-sdk types include inputDomain on the identity response
+        const data = await client.wallet.getIdentity({ wallet: address }) as any;
 
         const lines = ['**Wallet Identity**', ''];
-        lines.push(`**Address:** ${formatAddress(address)}`);
+        if (data.inputDomain) lines.push(`**Input:** ${data.inputDomain}`);
+        lines.push(`**Address:** ${formatAddress(data.address || address)}`);
         if (data.name) lines.push(`**Name:** ${data.name}`);
         if (data.type) lines.push(`**Type:** ${data.type}`);
         if (data.category) lines.push(`**Category:** ${data.category}`);
@@ -42,28 +44,29 @@ export function registerWalletTools(server: McpServer) {
     'batchWalletIdentity',
     'BEST FOR: identifying multiple wallets at once (up to 100). PREFER getWalletIdentity for a single address. Look up identities for up to 100 entries. Returns names, types, and categories. Entries may be addresses or SNS/ANS domains (mainnet only); unresolved domains are returned with `unresolved: true`. Credit cost: 100 credits.',
     {
-      addresses: z.array(z.string()).describe('Array of up to 100 entries — each a base58 address or SNS/ANS domain')
+      entries: z.array(z.string()).describe('Array of up to 100 entries — each a base58 address or SNS/ANS domain')
     },
-    async ({ addresses }) => {
+    async ({ entries }) => {
       if (!hasApiKey()) return noApiKeyResponse();
 
-      if (addresses.length > 100) {
+      if (entries.length > 100) {
         return mcpError(
-          'Maximum 100 addresses per batch request.',
-          { type: 'VALIDATION', code: 'TOO_MANY_ITEMS', retryable: false, recovery: 'Reduce batch to 100 or fewer addresses.' }
+          'Maximum 100 entries per batch request.',
+          { type: 'VALIDATION', code: 'TOO_MANY_ITEMS', retryable: false, recovery: 'Reduce batch to 100 or fewer entries.' }
         );
       }
 
       try {
         const client = getHeliusClient();
-        const results = await client.wallet.getBatchIdentity({ addresses });
+        const results = await client.wallet.getBatchIdentity({ addresses: entries });
 
         if (results.length === 0) {
-          return mcpText(`**Batch Identity Lookup** (${addresses.length} addresses)\n\nNo identities found.`);
+          return mcpText(`**Batch Identity Lookup** (${entries.length} entries)\n\nNo identities found.`);
         }
 
         const lines = [`**Batch Identity Lookup** (${results.length} results)`, ''];
 
+        // TODO: drop `Array<any>` once helius-sdk types include inputDomain/unresolved on the batch response
         for (const entry of results as Array<any>) {
           if (entry.unresolved) {
             lines.push(`- \`${entry.inputDomain || '?'}\` — Unresolved domain`);

--- a/helius-mcp/src/tools/wallet.ts
+++ b/helius-mcp/src/tools/wallet.ts
@@ -10,9 +10,9 @@ export function registerWalletTools(server: McpServer) {
   // ─── Get Wallet Identity ───
   server.tool(
     'getWalletIdentity',
-    'BEST FOR: identifying a single known wallet. PREFER batchWalletIdentity for multiple addresses. Identify known wallets (exchanges, protocols, institutions). Returns name, type, category, tags. Credit cost: 100 credits.',
+    'BEST FOR: identifying a single known wallet. PREFER batchWalletIdentity for multiple addresses. Identify known wallets (exchanges, protocols, institutions). Returns name, type, category, tags. Also accepts SNS/ANS domains (e.g., `toly.sol`, `helius.bonk`) — mainnet only. Credit cost: 100 credits.',
     {
-      address: z.string().describe('Solana wallet address (base58 encoded)')
+      address: z.string().describe('Solana wallet address (base58) or SNS/ANS domain (e.g., toly.sol, helius.bonk — mainnet only)')
     },
     async ({ address }) => {
       if (!hasApiKey()) return noApiKeyResponse();
@@ -40,9 +40,9 @@ export function registerWalletTools(server: McpServer) {
   // ─── Batch Wallet Identity ───
   server.tool(
     'batchWalletIdentity',
-    'BEST FOR: identifying multiple wallets at once (up to 100). PREFER getWalletIdentity for a single address. Look up identities for up to 100 Solana addresses. Returns names, types, and categories. Credit cost: 100 credits.',
+    'BEST FOR: identifying multiple wallets at once (up to 100). PREFER getWalletIdentity for a single address. Look up identities for up to 100 entries. Returns names, types, and categories. Entries may be addresses or SNS/ANS domains (mainnet only); unresolved domains are returned with `unresolved: true`. Credit cost: 100 credits.',
     {
-      addresses: z.array(z.string()).describe('Array of Solana wallet addresses (base58 encoded, max 100)')
+      addresses: z.array(z.string()).describe('Array of up to 100 entries — each a base58 address or SNS/ANS domain')
     },
     async ({ addresses }) => {
       if (!hasApiKey()) return noApiKeyResponse();
@@ -64,23 +64,30 @@ export function registerWalletTools(server: McpServer) {
 
         const lines = [`**Batch Identity Lookup** (${results.length} results)`, ''];
 
-        for (const entry of results) {
+        for (const entry of results as Array<any>) {
+          if (entry.unresolved) {
+            lines.push(`- \`${entry.inputDomain || '?'}\` — Unresolved domain`);
+            continue;
+          }
           const addr = formatAddress(entry.address || '');
+          const subject = entry.inputDomain && entry.address
+            ? `\`${entry.inputDomain}\` → ${addr}`
+            : addr;
           if (entry.name) {
-            lines.push(`- **${entry.name}** — ${addr}`);
+            lines.push(`- **${entry.name}** — ${subject}`);
             const details: string[] = [];
             if (entry.type) details.push(entry.type);
             if (entry.category) details.push(entry.category);
             if (details.length > 0) lines.push(`  ${details.join(' | ')}`);
           } else {
-            lines.push(`- ${addr} — Unknown`);
+            lines.push(`- ${subject} — Unknown`);
           }
         }
 
         return mcpText(lines.join('\n'));
       } catch (err) {
         return handleToolError(err, 'Error fetching batch identities', [
-          addressError('Batch Identity'),
+          addressError('Batch Identity', 'Entries must be base58 addresses or SNS/ANS domains.'),
         ]);
       }
     }

--- a/helius-mcp/system-prompts/helius-dflow/claude.system.md
+++ b/helius-mcp/system-prompts/helius-dflow/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-dflow/full.md
+++ b/helius-mcp/system-prompts/helius-dflow/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 
 # Helius x DFlow — Build Trading Apps on Solana
@@ -2963,8 +2963,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -2995,11 +2995,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-mcp/system-prompts/helius-dflow/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-dflow/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-dflow/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-jupiter/claude.system.md
+++ b/helius-mcp/system-prompts/helius-jupiter/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-jupiter/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-jupiter/full.md
+++ b/helius-mcp/system-prompts/helius-jupiter/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius-jupiter/SKILL.md — do not edit -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 
 # Helius x Jupiter — Build DeFi Apps on Solana
@@ -1869,8 +1869,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -1901,11 +1901,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-mcp/system-prompts/helius-jupiter/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-jupiter/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-jupiter/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-okx/claude.system.md
+++ b/helius-mcp/system-prompts/helius-okx/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-okx/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-okx/full.md
+++ b/helius-mcp/system-prompts/helius-okx/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius-okx/SKILL.md — do not edit -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 
 # Helius x OKX — Build Trading & Intelligence Apps on Solana
@@ -483,7 +483,7 @@ Helius parseTransactions ──> Trade History
 3. **Price charts**: OKX `market kline` for candlestick data on selected tokens
 4. **PnL analysis**: OKX `portfolio-overview` for realized/unrealized PnL and win rate
 5. **Trade history**: Helius `parseTransactions` for human-readable transaction log
-6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity
+6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity — accepts an address or SNS/ANS domain
 
 ### Multi-Chain Extension
 

--- a/helius-mcp/system-prompts/helius-okx/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-okx/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-okx/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-phantom/claude.system.md
+++ b/helius-mcp/system-prompts/helius-phantom/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius-phantom/full.md
+++ b/helius-mcp/system-prompts/helius-phantom/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 
 # Helius x Phantom — Build Frontend Solana Apps
@@ -2610,8 +2610,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -2642,11 +2642,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-mcp/system-prompts/helius-phantom/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-phantom/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius-phantom/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.0.0 -->
+<!-- Version: 1.0.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius/claude.system.md
+++ b/helius-mcp/system-prompts/helius/claude.system.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
 <!-- Claude API — use as a system prompt block -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 ## Runtime Notes
 

--- a/helius-mcp/system-prompts/helius/full.md
+++ b/helius-mcp/system-prompts/helius/full.md
@@ -1,5 +1,5 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 
 # Helius — Build on Solana
@@ -2184,8 +2184,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -2216,11 +2216,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-mcp/system-prompts/helius/openai.developer.md
+++ b/helius-mcp/system-prompts/helius/openai.developer.md
@@ -1,6 +1,6 @@
 <!-- Generated from helius-skills/helius/SKILL.md — do not edit -->
 <!-- OpenAI Responses / Chat Completions API — use as a `developer` message -->
-<!-- Version: 1.1.0 -->
+<!-- Version: 1.1.1 -->
 
 ## Runtime Notes
 

--- a/helius-plugin/skills/build/SKILL.md
+++ b/helius-plugin/skills/build/SKILL.md
@@ -2,7 +2,7 @@
 name: build
 description: Build Solana applications with Helius infrastructure. Covers transaction sending (Sender), asset/NFT queries (DAS API), real-time streaming (WebSockets, Laserstream), event pipelines (webhooks), priority fees, wallet analysis, and agent onboarding.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 # Helius — Build on Solana

--- a/helius-plugin/skills/build/references/wallet-api.md
+++ b/helius-plugin/skills/build/references/wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-plugin/skills/dflow/SKILL.md
+++ b/helius-plugin/skills/dflow/SKILL.md
@@ -2,7 +2,7 @@
 name: dflow
 description: Build Solana trading applications combining DFlow trading APIs with Helius infrastructure. Covers spot swaps (imperative and declarative), prediction markets, real-time market streaming, Proof KYC, the DFlow Agent CLI for autonomous trading, transaction submission via Sender, fee optimization, shred-level streaming via LaserStream, and wallet intelligence.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 # Helius x DFlow — Build Trading Apps on Solana

--- a/helius-plugin/skills/dflow/references/helius-wallet-api.md
+++ b/helius-plugin/skills/dflow/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-plugin/skills/jupiter/SKILL.md
+++ b/helius-plugin/skills/jupiter/SKILL.md
@@ -2,7 +2,7 @@
 name: jupiter
 description: Build Solana DeFi applications combining Jupiter APIs with Helius infrastructure. Covers token swaps (Swap API V2), lending/borrowing (Lend protocol), limit orders (Trigger), DCA (Recurring), token/price data, transaction submission via Sender, fee optimization, real-time streaming, and wallet intelligence.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Helius x Jupiter — Build DeFi Apps on Solana

--- a/helius-plugin/skills/jupiter/references/helius-wallet-api.md
+++ b/helius-plugin/skills/jupiter/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-plugin/skills/okx/SKILL.md
+++ b/helius-plugin/skills/okx/SKILL.md
@@ -2,7 +2,7 @@
 name: okx
 description: Build Solana trading and intelligence applications combining OKX DEX aggregation with Helius infrastructure. Integration-only layer — describes when and how to compose OKX tools with Helius tools for swaps, token discovery, smart money signals, meme token analysis, and portfolio intelligence.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Helius x OKX — Build Trading & Intelligence Apps on Solana

--- a/helius-plugin/skills/okx/references/integration-patterns.md
+++ b/helius-plugin/skills/okx/references/integration-patterns.md
@@ -306,7 +306,7 @@ Helius parseTransactions ──> Trade History
 3. **Price charts**: OKX `market kline` for candlestick data on selected tokens
 4. **PnL analysis**: OKX `portfolio-overview` for realized/unrealized PnL and win rate
 5. **Trade history**: Helius `parseTransactions` for human-readable transaction log
-6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity
+6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity — accepts an address or SNS/ANS domain
 
 ### Multi-Chain Extension
 

--- a/helius-plugin/skills/phantom/SKILL.md
+++ b/helius-plugin/skills/phantom/SKILL.md
@@ -2,7 +2,7 @@
 name: phantom
 description: Build frontend Solana applications with Phantom Connect SDK and Helius infrastructure. Covers React, React Native, and browser SDK integration, transaction signing via Helius Sender, API key proxying, token gating, NFT minting, crypto payments, real-time updates, and secure frontend architecture.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Helius x Phantom — Build Frontend Solana Apps

--- a/helius-plugin/skills/phantom/references/helius-wallet-api.md
+++ b/helius-plugin/skills/phantom/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-skills/helius-dflow/SKILL.md
+++ b/helius-skills/helius-dflow/SKILL.md
@@ -4,7 +4,7 @@ description: Build Solana trading applications combining DFlow trading APIs with
 license: MIT
 metadata:
   author: Helius Labs
-  version: "1.1.0"
+  version: "1.1.1"
   tags:
     - solana
     - trading

--- a/helius-skills/helius-dflow/references/helius-wallet-api.md
+++ b/helius-skills/helius-dflow/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-skills/helius-jupiter/SKILL.md
+++ b/helius-skills/helius-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Build Solana DeFi applications combining Jupiter APIs with Helius i
 license: MIT
 metadata:
   author: Helius Labs
-  version: "1.0.0"
+  version: "1.0.1"
   tags:
     - solana
     - defi

--- a/helius-skills/helius-jupiter/references/helius-wallet-api.md
+++ b/helius-skills/helius-jupiter/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-skills/helius-okx/SKILL.md
+++ b/helius-skills/helius-okx/SKILL.md
@@ -4,7 +4,7 @@ description: Build Solana trading and intelligence applications combining OKX DE
 license: MIT
 metadata:
   author: Helius Labs
-  version: "1.0.0"
+  version: "1.0.1"
   tags:
     - solana
     - trading

--- a/helius-skills/helius-okx/references/integration-patterns.md
+++ b/helius-skills/helius-okx/references/integration-patterns.md
@@ -306,7 +306,7 @@ Helius parseTransactions ──> Trade History
 3. **Price charts**: OKX `market kline` for candlestick data on selected tokens
 4. **PnL analysis**: OKX `portfolio-overview` for realized/unrealized PnL and win rate
 5. **Trade history**: Helius `parseTransactions` for human-readable transaction log
-6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity
+6. **Identity**: Helius `getWalletIdentity` to check if wallet is a known entity — accepts an address or SNS/ANS domain
 
 ### Multi-Chain Extension
 

--- a/helius-skills/helius-phantom/SKILL.md
+++ b/helius-skills/helius-phantom/SKILL.md
@@ -4,7 +4,7 @@ description: Build frontend Solana applications with Phantom Connect SDK and Hel
 license: MIT
 metadata:
   author: Helius Labs
-  version: "1.0.0"
+  version: "1.0.1"
   tags:
     - solana
     - phantom

--- a/helius-skills/helius-phantom/references/helius-wallet-api.md
+++ b/helius-skills/helius-phantom/references/helius-wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/helius-skills/helius/SKILL.md
+++ b/helius-skills/helius/SKILL.md
@@ -3,7 +3,7 @@ name: helius
 description: Build Solana applications with Helius infrastructure. Covers transaction sending (Sender), asset/NFT queries (DAS API), real-time streaming (WebSockets, Laserstream), event pipelines (webhooks), priority fees, wallet analysis, and agent onboarding.
 metadata:
   author: Helius Labs
-  version: "1.1.0"
+  version: "1.1.1"
   mcp-server: helius-mcp
 ---
 

--- a/helius-skills/helius/references/wallet-api.md
+++ b/helius-skills/helius/references/wallet-api.md
@@ -18,8 +18,8 @@ All Wallet API endpoints have direct MCP tools. ALWAYS use these instead of gene
 
 | MCP Tool | Endpoint | What It Does |
 |---|---|---|
-| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions) |
-| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 addresses in one request |
+| `getWalletIdentity` | `GET /v1/wallet/{wallet}/identity` | Identify known wallets (exchanges, protocols, institutions). Accepts an address or an SNS/ANS domain (mainnet only). |
+| `batchWalletIdentity` | `POST /v1/wallet/batch-identity` | Bulk lookup up to 100 entries in one request. Entries may be addresses or SNS/ANS domains (mainnet only). |
 | `getWalletBalances` | `GET /v1/wallet/{wallet}/balances` | Token + NFT balances with USD values, sorted by value |
 | `getWalletHistory` | `GET /v1/wallet/{wallet}/history` | Transaction history with balance changes per tx |
 | `getWalletTransfers` | `GET /v1/wallet/{wallet}/transfers` | Token transfers with direction (in/out) and counterparty |
@@ -50,11 +50,39 @@ The identity endpoint identifies known wallets powered by Orb's tagging. Returns
 
 **Covers**: Binance, Coinbase, Kraken, OKX, Bybit, Jupiter, Raydium, Marinade, Jito, Kamino, Jump Trading, Wintermute, notable KOLs, bridges, validators, treasuries, stake pools, and known exploiters/scammers.
 
+### Domain Resolution (SNS + ANS)
+
+Both identity endpoints accept domain names in addition to base58 addresses:
+
+- **SNS** — `.sol` domains (e.g., `toly.sol`, `my_wallet.sol`, `sub.toly.sol`)
+- **ANS** — custom TLDs (e.g., `helius.bonk`, `miester.poor`, `degen.superteam`)
+
+Semantics:
+
+- **Single endpoint (`getWalletIdentity`)**: unresolvable domain → HTTP 404; invalid input (neither address nor domain) → 400; non-mainnet request with a domain → 400 ("Domain resolution is only available on mainnet"). Valid addresses with no identity in the tagging DB still return 200 with `type: "unknown"` — unchanged behavior.
+- **Batch endpoint (`batchWalletIdentity`)**: non-fail-fast. Each entry returns its own row. Resolved domain rows gain `inputDomain: "<domain>"`. Unresolvable domain rows come back as `{ address: null, type: "unknown", inputDomain: "<domain>", unresolved: true }`. On non-mainnet all domain entries are returned as `unresolved: true`.
+
+Response type (identity endpoints):
+
+```ts
+interface IdentityResponse {
+  address: string | null;   // null only for unresolved domains in batch
+  type: AccountType;
+  name?: string;
+  category?: string;
+  tags?: string[];
+  inputDomain?: string;     // present when input was a domain
+  unresolved?: boolean;     // true only in batch when a domain could not be resolved
+  // ...other tagging fields
+}
+```
+
 ### When to use batch vs single
 
 - Investigating one wallet: `getWalletIdentity`
 - Enriching a transaction list with counterparty names: `batchWalletIdentity` (collect all unique addresses, batch in chunks of 100)
 - Building a UI that shows human-readable names: `batchWalletIdentity`
+- Accepting user-typed inputs (domains or addresses): `getWalletIdentity` (single) or `batchWalletIdentity` (mixed list)
 
 ## Funding Source Tracking
 

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
-  "helius": "1.1.0",
-  "helius-dflow": "1.1.0",
-  "helius-jupiter": "1.0.0",
-  "helius-okx": "1.0.0",
-  "helius-phantom": "1.0.0",
+  "helius": "1.1.1",
+  "helius-dflow": "1.1.1",
+  "helius-jupiter": "1.0.1",
+  "helius-okx": "1.0.1",
+  "helius-phantom": "1.0.1",
   "svm": "1.0.0"
 }


### PR DESCRIPTION
## Summary

Wraps upstream [helius-labs/monorepo#14132](https://github.com/helius-labs/monorepo/pull/14132) (SNS/ANS domain support on the Wallet Identity endpoints) for the CLI and MCP surfaces.

- **CLI**: new `validateAddressOrDomain` / `validateAddressesOrDomains` helpers mirror the server's `isValidDomainName` regex; wired into `wallet identity` + `wallet identity-batch` only. Batch output now surfaces the new `inputDomain` / `unresolved` response fields. `--help` text + `helius-cli/README.md` updated to advertise domain acceptance.
- **MCP**: `getWalletIdentity` / `batchWalletIdentity` tool + Zod descriptions now mention SNS/ANS (mainnet-only) so LLMs route `toly.sol`-style queries correctly. Batch formatter renders `inputDomain → address` for resolved domains and flags unresolved rows. Custom detail passed to `addressError('Batch Identity', ...)` to avoid the misleading "base58-encoded" fallback string.
- **Skill references**: new "Domain Resolution (SNS + ANS)" section added to `helius-skills/helius/references/wallet-api.md` and the three sibling `helius-wallet-api.md` copies (phantom, jupiter, dflow). Optional one-liner appended to the OKX identity step. All manually mirrored to `helius-plugin/` and `helius-cursor/`; `.agents/` + `helius-mcp/system-prompts/` regenerated via `scripts/compile-skills.ts`.
- **Versions**: patch-bump `helius`, `helius-dflow`, `helius-jupiter`, `helius-okx`, `helius-phantom`.

## Upstream contract notes

Verified against the upstream PR diff before coding:

- Batch body key is still `{ addresses: [...] }` — unchanged wire contract.
- Batch is **non-fail-fast**: unresolvable domains return as per-row `{ address: null, type: "unknown", inputDomain, unresolved: true }` at HTTP 200.
- Single endpoint: unresolvable domain → 404; invalid input → 400; non-mainnet + domain → 400.
- **Unknown-but-valid addresses still return 200** (not 404) — no CLI exit-code regression.
- Domain regex mirrors upstream exactly; accepts SNS `.sol`, ANS custom TLDs, underscores (`my_wallet.sol`), and multi-label subdomains (`sub.toly.sol`); rejects length > 255.

## Test plan

- [ ] `helius wallet identity 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY` (address — unchanged behavior)
- [ ] `helius wallet identity toly.sol` (SNS resolves on mainnet)
- [ ] `helius wallet identity helius.bonk` (ANS resolves on mainnet)
- [ ] `helius wallet identity bogus.sol` → exit 55 (NOT_FOUND)
- [ ] `helius wallet identity not-a-real-thing` → exit 52 (INVALID_ADDRESS, client-side)
- [ ] `helius wallet identity toly.sol --network devnet` → exit 53 (INVALID_INPUT, "Domain resolution is only available on mainnet")
- [ ] `helius wallet identity-batch toly.sol 86xC...MMY --json` → mixed JSON output with `inputDomain` on the domain entry
- [ ] MCP inspector: `getWalletIdentity { address: "toly.sol" }` returns identity; tool description advertises SNS/ANS
- [ ] CI sync-check passes (canonical vs `helius-plugin/`/`helius-cursor/` mirrors all clean)
- [ ] `pnpm -C helius-cli build && pnpm -C helius-mcp build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)