### PR TITLE
feat(cli): Always emit suggestion in JSON error envelopes

### DIFF
--- a/helius-cli/CLAUDE.md
+++ b/helius-cli/CLAUDE.md
@@ -47,7 +47,7 @@ All data commands follow this pattern:
 3. Get SDK client via `getClient(apiKey, network)`
 4. Call SDK method
 5. Output: formatted terminal (chalk) or `outputJson(payload)` for `--json`. As of v1.3, `outputJson()` auto-wraps its argument in `{ ok: true, v: 1, data: <payload> }` — callers still pass the raw payload.
-6. Error: use `handleCommandError(error, options, spinner)` — classifies the error, emits the error envelope (`{ ok: false, v: 1, error_code, category, error, recoverable, suggestion?, details? }`) or spinner output, and exits with the classified exit code
+6. Error: use `handleCommandError(error, options, spinner)` — classifies the error, emits the error envelope (`{ ok: false, v: 1, error_code, category, error, recoverable, suggestion, details? }`) or spinner output, and exits with the classified exit code
 
 Standard catch block template (all commands except `ws.ts`):
 ```ts
@@ -95,7 +95,7 @@ New in v1.3: exit code 23 `INSUFFICIENT_FUNDS` — signup/upgrade paths where bo
 All `--json` output goes through one of two shapes, defined in `src/lib/output.ts`:
 
 - **Success:** `{ ok: true, v: 1, data: <payload> }` — `outputJson(payload)` wraps automatically.
-- **Error:** `{ ok: false, v: 1, error_code, category, error, recoverable, suggestion?, details? }` — built by `buildErrorEnvelope()` and written by `handleCommandError()` / `exitWithError()`.
+- **Error:** `{ ok: false, v: 1, error_code, category, error, recoverable, suggestion, details? }` — built by `buildErrorEnvelope()` and written by `handleCommandError()` / `exitWithError()`. `suggestion` is always present (falls back to a generic "re-run with --debug" hint if the error code has no `CLI_GUIDANCE` entry).
 
 Exported types: `Envelope<T>`, `SuccessEnvelope<T>`, `ErrorEnvelope`, `Category`.
 
@@ -103,7 +103,7 @@ When adding a new error code:
 1. Add it to `ExitCode` (pick the right range — 10-19 auth, 20-29 payment, etc.).
 2. Add it to `errorToExitCode`.
 3. Add it to `exitCodeToCategory` (pick the public `Category`).
-4. Optionally add a human-readable hint to `CLI_GUIDANCE` (shows up as `suggestion`).
+4. Add a human-readable hint to `CLI_GUIDANCE` (required — `suggestion` is always present in JSON output; missing entries fall back to a generic "re-run with --debug" hint, which is agent-useless).
 
 `getExitCode()` logs a `debug()` warning when handed an unknown code. Under `--debug`, run your command once; if you see the warning, the new code isn't wired up yet.
 

--- a/helius-cli/README.md
+++ b/helius-cli/README.md
@@ -306,7 +306,7 @@ Fields:
 - `category` (error only) — coarse bucket; one of: `success`, `general`, `auth`, `payment`, `project`, `api`, `sdk`, `validation`, `not_found`, `rate_limit`, `server`, `network`. Use this when you want to group errors without enumerating every code.
 - `error` (error only) — human-readable message.
 - `recoverable` (error only) — `true` if retrying may succeed (rate limits, transient 5xx, network). `false` for permanent errors like invalid address or invalid API key.
-- `suggestion` (error only, optional) — actionable hint when one is available. Not every error code has one.
+- `suggestion` (error only, always present) — a short actionable next step for the given error code.
 - `details` (error only, optional) — extra structured context (e.g. `projects` list for `MULTIPLE_PROJECTS`, `missing` array for `INSUFFICIENT_FUNDS`). Under `--debug`, also includes a `stack` field for unclassified errors.
 
 Envelope keys are intentionally `snake_case` (`error_code`, not `errorCode`) for ergonomic shell use — `jq '.error_code'` reads naturally. Internal TypeScript names elsewhere in the codebase still use `camelCase`.

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -148,7 +148,7 @@ export type ErrorEnvelope = {
   category: Category;
   error: string;
   recoverable: boolean;
-  suggestion?: string;
+  suggestion: string;
   details?: Record<string, unknown>;
 };
 
@@ -197,7 +197,8 @@ function buildErrorEnvelope(
   details?: Record<string, unknown>,
   stack?: string,
 ): ErrorEnvelope {
-  const guidance = CLI_GUIDANCE[errorCode];
+  const guidance = CLI_GUIDANCE[errorCode]
+    ?? 'An error occurred. Re-run with --debug for more details.';
   const mergedDetails = details || stack
     ? { ...(details ?? {}), ...(stack ? { stack } : {}) }
     : undefined;
@@ -208,7 +209,7 @@ function buildErrorEnvelope(
     category: getCategory(exitCode),
     error: message,
     recoverable: retryable,  // internal 'retryable' → public 'recoverable'
-    ...(guidance ? { suggestion: guidance } : {}),
+    suggestion: guidance,
     ...(mergedDetails ? { details: mergedDetails } : {}),
   };
 }
@@ -347,6 +348,11 @@ export const CLI_GUIDANCE: Record<string, string> = {
   PROJECT_NOT_FOUND: 'Run `helius projects` to list available projects.',
   NO_API_KEYS: 'Run `helius apikeys create` to create an API key.',
   INVALID_INPUT: 'Check command usage with --help.',
+  AUTH_FAILED: 'Your credentials are invalid or expired. Run `helius login` to re-authenticate.',
+  PROJECT_EXISTS: 'A project with this name already exists. Run `helius projects` to list them or pick a different name.',
+  API_ERROR: 'The Helius management API returned an error. Retry, or inspect `details` for more information.',
+  SDK_ERROR: 'Unclassified SDK error. Re-run with --debug for a stack trace.',
+  INVALID_ADDRESS: 'The provided address is not a valid base58 Solana pubkey. Verify the address format.',
 };
 
 export function handleCommandError(


### PR DESCRIPTION
## Summary

- Populate `CLI_GUIDANCE` for the 5 error codes without entries (`AUTH_FAILED`, `PROJECT_EXISTS`, `API_ERROR`, `SDK_ERROR`, `INVALID_ADDRESS`). `SDK_ERROR` is the common unclassified-error bucket, so this was a visible gap.
- Make `ErrorEnvelope.suggestion` required (drop the `?`) and emit it unconditionally in `buildErrorEnvelope()`, with a generic "re-run with --debug" fallback for any code that ever slips past the map.
- Docs: `README.md` Output Format section and `CLAUDE.md` envelope-shape comments now say `suggestion` is always present.

### Why

Agents get `{ error, recoverable, error_code, category }` on `--json` failure and today have to parse the human `error` string to know what to do. With `suggestion` guaranteed to be a short actionable next step (command to run, config to fix, etc.), agents can self-correct or surface the hint directly.

### Not changed

- `README.md:11` migration note still shows the v1.3 `suggestion?` shape for historical accuracy.
- `ws.ts:52` `handleWsError()` uses an ad-hoc object literal (not `ErrorEnvelope`), so the tighter type won't catch it. Existing conditional spread stays — worth aligning in a follow-up.

## Test plan

- [x] `tsc --noEmit` clean on changed code (pre-existing `signup.ts:217` error is on `main`, unrelated).
- [x] `helius balance --json not-a-real-address` → `suggestion` present on `INVALID_ADDRESS` (was missing before).
- [x] `HELIUS_API_KEY=bad helius balance --json <pubkey>` → `suggestion` still present on `INVALID_API_KEY`.
- [x] `helius tx parse --json BADSIG` → `suggestion` present on `INVALID_INPUT`.
- [x] `rg '"ok":\s*false|ok:\s*false' src/` confirms `buildErrorEnvelope()` is the only error-envelope emitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)