### PR TITLE
fix mcp config recovery, telemetry, and laserstream api handling

### DIFF
--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -10,7 +10,6 @@ const HELIUS_DIR = path.join(os.homedir(), '.helius');
 const KEYPAIR_PATH = path.join(HELIUS_DIR, 'keypair.json');
 const WALLET_CACHE_PATH = path.join(HELIUS_DIR, 'wallet-address');
 
-let feedbackEnabled = true;
 let walletAddress: string | null = null;
 let identifySent = false;
 
@@ -76,8 +75,6 @@ function getDistinctId(): string {
 }
 
 function posthogCapture(event: string, properties: Record<string, unknown>): void {
-  if (!feedbackEnabled) return;
-
   fetch(POSTHOG_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -87,7 +84,7 @@ function posthogCapture(event: string, properties: Record<string, unknown>): voi
       properties,
     }),
   }).catch(() => {
-    feedbackEnabled = false;
+    /* ignore delivery failure */
   });
 }
 

--- a/helius-mcp/src/tools/laserstream.ts
+++ b/helius-mcp/src/tools/laserstream.ts
@@ -1,7 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { getLaserstreamUrl, getNetwork } from '../utils/helius.js';
+import { getLaserstreamUrl, getNetwork, hasApiKey } from '../utils/helius.js';
 import { mcpText, mcpError, validateEnum, handleToolError, warnInvalidAddresses, warnAddressConflicts } from '../utils/errors.js';
+import { noApiKeyResponse } from './shared.js';
 import { fetchDoc, extractSections, truncateDoc } from '../utils/docs.js';
 
 export function registerLaserstreamTools(server: McpServer) {
@@ -27,6 +28,8 @@ export function registerLaserstreamTools(server: McpServer) {
       keepalive: z.boolean().optional().default(true).describe('Send gRPC keepalive pings to maintain the connection (default: true). Set to false only if your client handles its own keepalive.')
     },
     async (params) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
       let err;
       err = validateEnum(params.region, ['ewr', 'pitt', 'slc', 'lax', 'lon', 'ams', 'fra', 'tyo', 'sgp'], 'Laserstream Error', 'region');
       if (err) return err;

--- a/helius-mcp/src/tools/laserstream.ts
+++ b/helius-mcp/src/tools/laserstream.ts
@@ -170,12 +170,7 @@ export function registerLaserstreamTools(server: McpServer) {
     'Get Helius Laserstream gRPC capabilities, regions, pricing, and plan requirements. Lowest latency Solana streaming with 24h replay. Fetches live from official documentation.',
     {},
     async () => {
-      let endpoint: string;
-      try {
-        endpoint = getLaserstreamUrl();
-      } catch (err) {
-        return handleToolError(err, 'Laserstream Error');
-      }
+      const endpoint = getLaserstreamUrl();
 
       let content: string;
       try {

--- a/helius-mcp/src/utils/config.ts
+++ b/helius-mcp/src/utils/config.ts
@@ -23,16 +23,92 @@ function ensureDir(): void {
   }
 }
 
-export function loadConfig(): HeliusConfig {
-  try {
-    if (fs.existsSync(SHARED_CONFIG_PATH)) {
-      const data = fs.readFileSync(SHARED_CONFIG_PATH, "utf-8");
-      return JSON.parse(data);
+/** Best-effort recovery when config.json is corrupted (matches helius-cli behavior). */
+function recoverPartialConfig(raw: string): HeliusConfig {
+  const recovered: HeliusConfig = {};
+  const patterns: { key: keyof HeliusConfig; regex: RegExp }[] = [
+    { key: "jwt", regex: /"jwt"\s*:\s*"([^"]+)"/ },
+    { key: "apiKey", regex: /"apiKey"\s*:\s*"([^"]+)"/ },
+    { key: "network", regex: /"network"\s*:\s*"([^"]+)"/ },
+    { key: "projectId", regex: /"projectId"\s*:\s*"([^"]+)"/ },
+  ];
+
+  for (const { key, regex } of patterns) {
+    const match = raw.match(regex);
+    if (match) {
+      (recovered as Record<string, string>)[key] = match[1];
     }
-  } catch {
-    // Return empty config on error
   }
-  return {};
+
+  const budgetMatch = raw.match(/"budget"\s*:\s*"(free|developer|business|professional)"/);
+  const complexityMatch = raw.match(/"complexity"\s*:\s*"(low|medium|high)"/);
+  if (budgetMatch || complexityMatch) {
+    recovered.preferences = {};
+    if (budgetMatch) {
+      recovered.preferences.budget = budgetMatch[1] as NonNullable<
+        HeliusConfig["preferences"]
+      >["budget"];
+    }
+    if (complexityMatch) {
+      recovered.preferences.complexity = complexityMatch[1] as NonNullable<
+        HeliusConfig["preferences"]
+      >["complexity"];
+    }
+  }
+
+  return recovered;
+}
+
+function recoveredFieldSummary(cfg: HeliusConfig): string {
+  const keys: string[] = [];
+  for (const k of Object.keys(cfg) as (keyof HeliusConfig)[]) {
+    if (k === "preferences" && cfg.preferences) {
+      for (const pk of Object.keys(cfg.preferences)) {
+        keys.push(`preferences.${pk}`);
+      }
+    } else if (k !== "preferences") {
+      keys.push(k);
+    }
+  }
+  return keys.join(", ");
+}
+
+export function loadConfig(): HeliusConfig {
+  if (!fs.existsSync(SHARED_CONFIG_PATH)) {
+    return {};
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(SHARED_CONFIG_PATH, "utf-8");
+  } catch {
+    console.error(`Warning: ${SHARED_CONFIG_PATH} exists but could not be read.`);
+    return {};
+  }
+
+  try {
+    return JSON.parse(raw) as HeliusConfig;
+  } catch {
+    const recovered = recoverPartialConfig(raw);
+    const summary = recoveredFieldSummary(recovered);
+
+    if (summary.length > 0) {
+      console.error(
+        `Warning: ${SHARED_CONFIG_PATH} is corrupted (invalid JSON). Recovered fields: ${summary}.`,
+      );
+      saveConfig(recovered);
+      console.error("Repaired config saved. Fields that did not match known keys may have been lost.");
+      return recovered;
+    }
+
+    console.error(
+      `Warning: ${SHARED_CONFIG_PATH} is corrupted (invalid JSON) and could not be recovered.`,
+    );
+    console.error(
+      'Run Helius MCP config helpers or edit the file manually; see CLI `helius config clear` if you use helius-cli.',
+    );
+    return {};
+  }
 }
 
 export function saveConfig(config: HeliusConfig): void {

--- a/helius-mcp/src/utils/config.ts
+++ b/helius-mcp/src/utils/config.ts
@@ -29,7 +29,10 @@ function recoverPartialConfig(raw: string): HeliusConfig {
   const patterns: { key: keyof HeliusConfig; regex: RegExp }[] = [
     { key: "jwt", regex: /"jwt"\s*:\s*"([^"]+)"/ },
     { key: "apiKey", regex: /"apiKey"\s*:\s*"([^"]+)"/ },
-    { key: "network", regex: /"network"\s*:\s*"([^"]+)"/ },
+    {
+      key: "network",
+      regex: /"network"\s*:\s*"(mainnet|mainnet-beta|devnet)"/,
+    },
     { key: "projectId", regex: /"projectId"\s*:\s*"([^"]+)"/ },
   ];
 

--- a/helius-mcp/src/utils/feedback.ts
+++ b/helius-mcp/src/utils/feedback.ts
@@ -20,7 +20,6 @@ interface FeedbackEvent {
 }
 
 let clientInfo: { name: string; version: string } | null = null;
-let feedbackEnabled = true;
 let walletAddress: string | null = null;
 let identifySent = false;
 
@@ -62,8 +61,6 @@ function getDistinctId(): string {
 }
 
 function posthogCapture(event: string, properties: Record<string, unknown>): void {
-  if (!feedbackEnabled) return;
-
   fetch(POSTHOG_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -73,7 +70,7 @@ function posthogCapture(event: string, properties: Record<string, unknown>): voi
       properties,
     }),
   }).catch(() => {
-    feedbackEnabled = false;
+    /* ignore delivery failure */
   });
 }
 

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -73,7 +73,8 @@ export function getEnhancedWebSocketUrl(): string {
 }
 
 export function getLaserstreamUrl(region?: 'ewr' | 'pitt' | 'slc' | 'lax' | 'lon' | 'ams' | 'fra' | 'tyo' | 'sgp'): string {
-  const apiKey = getApiKey();
+  // Endpoint host is public; clients pass apiKey separately (e.g. @helius/laserstream subscribe options).
+  // Do not call getApiKey() here or docs tools like getLaserstreamInfo fail unnecessarily.
   const network = getNetwork();
   if (network === 'devnet') {
     return `https://laserstream-devnet-ewr.helius-rpc.com`;


### PR DESCRIPTION
hey, went through the mcp and cli telemetry paths and a few things stood out.

first, getLaserstreamUrl was calling getApiKey() even though the returned URL does not embed the key (the laserstream sdk takes apiKey in subscribe options). that meant getLaserstreamInfo could throw NO_API_KEY before showing public endpoint text. i dropped the unused getApiKey call and gate laserstreamSubscribe with the same noApiKeyResponse() pattern as the other rpc tools.

second, posthog delivery used .catch(() => { feedbackEnabled = false }). any single fetch failure flipped the flag off for the whole process so every later analytics event became a noop. flaky network or relay hiccup should not permanently silence telemetry.

third, helius-cli already repairs corrupted ~/.helius/config.json with regex salvage. helius-mcp loadConfig silently returned {} on bad json, so api keys nested in corrupt files disappeared without clues. mirrored the salvage + stderr warnings + repaired save behavior for aligned config between cli and mcp.

cheers
moon