### PR TITLE
feat(cli+mcp): unified crypto checkout — signup / upgrade / credits / pay

### DIFF
--- a/.agents/skills/helius-dflow/SKILL.md
+++ b/.agents/skills/helius-dflow/SKILL.md
@@ -192,7 +192,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`, `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-dflow/prompts/claude.system.md
+++ b/.agents/skills/helius-dflow/prompts/claude.system.md
@@ -192,7 +192,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md, `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-dflow/prompts/full.md
+++ b/.agents/skills/helius-dflow/prompts/full.md
@@ -182,7 +182,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md (inlined below), `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys
@@ -1950,15 +1950,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -1972,37 +1972,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -2016,8 +2029,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -2026,28 +2039,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -2059,8 +2082,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -2074,8 +2095,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -2090,7 +2111,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -2098,13 +2119,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -2112,10 +2133,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -2124,6 +2146,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -2137,19 +2160,22 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes
 
 
 ---

--- a/.agents/skills/helius-dflow/prompts/openai.developer.md
+++ b/.agents/skills/helius-dflow/prompts/openai.developer.md
@@ -192,7 +192,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md, `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-dflow/references/helius-onboarding.md
+++ b/.agents/skills/helius-dflow/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/.agents/skills/helius-jupiter/SKILL.md
+++ b/.agents/skills/helius-jupiter/SKILL.md
@@ -185,7 +185,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`, `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-jupiter/prompts/claude.system.md
+++ b/.agents/skills/helius-jupiter/prompts/claude.system.md
@@ -185,7 +185,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md, `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-jupiter/prompts/full.md
+++ b/.agents/skills/helius-jupiter/prompts/full.md
@@ -175,7 +175,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md (inlined below), `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys
@@ -940,15 +940,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -962,37 +962,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -1006,8 +1019,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -1016,28 +1029,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -1045,18 +1068,16 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **RPC RPS** | 10 | 50 | 200 | 500 |
 | **sendTransaction** | 1/s | 5/s | 50/s | 100/s |
 | **DAS** | 2/s | 10/s | 50/s | 100/s |
-| **WS connections** | 5 | 150 | 250 | 250 |
-| **Enhanced WS** | No | No | 100 conn | 100 conn |
-| **LaserStream** | No | Devnet | Devnet | Full (mainnet + devnet) |
+| **WS connections** | 5 | 150 | 250 | 1,000 |
+| **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
+| **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
 - **0 credits**: Helius Sender (sendSmartTransaction, sendJitoBundle)
 - **1 credit**: Standard RPC calls, sendTransaction, Priority Fee API, webhook events
-- **3 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets)
+- **2 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets, Standard WebSockets)
 - **10 credits**: getProgramAccounts, DAS API, historical data
 - **100 credits**: Enhanced Transactions API, Wallet API, webhook management
 
@@ -1064,12 +1085,12 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
-| Enhanced WebSockets | Business |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
+| Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
-| LaserStream (mainnet) | Professional |
-| LaserStream data add-ons | Professional ($500+/mo) |
+| LaserStream (mainnet) | Business |
+| LaserStream data add-ons | Business+ ($400+/mo) |
 
 Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current details.
 
@@ -1080,7 +1101,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -1088,13 +1109,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -1102,10 +1123,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -1114,6 +1136,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -1127,19 +1150,22 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes
 
 
 ---

--- a/.agents/skills/helius-jupiter/prompts/openai.developer.md
+++ b/.agents/skills/helius-jupiter/prompts/openai.developer.md
@@ -185,7 +185,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md, `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-jupiter/references/helius-onboarding.md
+++ b/.agents/skills/helius-jupiter/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -114,18 +137,16 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **RPC RPS** | 10 | 50 | 200 | 500 |
 | **sendTransaction** | 1/s | 5/s | 50/s | 100/s |
 | **DAS** | 2/s | 10/s | 50/s | 100/s |
-| **WS connections** | 5 | 150 | 250 | 250 |
-| **Enhanced WS** | No | No | 100 conn | 100 conn |
-| **LaserStream** | No | Devnet | Devnet | Full (mainnet + devnet) |
+| **WS connections** | 5 | 150 | 250 | 1,000 |
+| **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
+| **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
 - **0 credits**: Helius Sender (sendSmartTransaction, sendJitoBundle)
 - **1 credit**: Standard RPC calls, sendTransaction, Priority Fee API, webhook events
-- **3 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets)
+- **2 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets, Standard WebSockets)
 - **10 credits**: getProgramAccounts, DAS API, historical data
 - **100 credits**: Enhanced Transactions API, Wallet API, webhook management
 
@@ -133,12 +154,12 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
-| Enhanced WebSockets | Business |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
+| Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
-| LaserStream (mainnet) | Professional |
-| LaserStream data add-ons | Professional ($500+/mo) |
+| LaserStream (mainnet) | Business |
+| LaserStream data add-ons | Business+ ($400+/mo) |
 
 Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current details.
 
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/.agents/skills/helius-phantom/SKILL.md
+++ b/.agents/skills/helius-phantom/SKILL.md
@@ -201,7 +201,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-phantom/prompts/claude.system.md
+++ b/.agents/skills/helius-phantom/prompts/claude.system.md
@@ -201,7 +201,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-phantom/prompts/full.md
+++ b/.agents/skills/helius-phantom/prompts/full.md
@@ -191,7 +191,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md (inlined below)
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys
@@ -1707,15 +1707,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -1729,37 +1729,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -1773,8 +1786,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -1783,28 +1796,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -1816,8 +1839,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -1831,8 +1852,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -1847,7 +1868,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -1855,13 +1876,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -1869,10 +1890,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -1881,6 +1903,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -1894,19 +1917,22 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes
 
 
 ---

--- a/.agents/skills/helius-phantom/prompts/openai.developer.md
+++ b/.agents/skills/helius-phantom/prompts/openai.developer.md
@@ -201,7 +201,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/.agents/skills/helius-phantom/references/helius-onboarding.md
+++ b/.agents/skills/helius-phantom/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/.agents/skills/helius/SKILL.md
+++ b/.agents/skills/helius/SKILL.md
@@ -40,9 +40,9 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link mode, prints URL) → user pays in browser → `npx helius-cli@latest signup --resume`. Or autopay: `... signup --plan agent --pay`.
 
 ## Routing
 
@@ -107,7 +107,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting

--- a/.agents/skills/helius/prompts/claude.system.md
+++ b/.agents/skills/helius/prompts/claude.system.md
@@ -41,9 +41,9 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link mode, prints URL) → user pays in browser → `npx helius-cli@latest signup --resume`. Or autopay: `... signup --plan agent --pay`.
 
 ## Routing
 
@@ -108,7 +108,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting

--- a/.agents/skills/helius/prompts/full.md
+++ b/.agents/skills/helius/prompts/full.md
@@ -31,9 +31,9 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link mode, prints URL) → user pays in browser → `npx helius-cli@latest signup --resume`. Or autopay: `... signup --plan agent --pay`.
 
 ## Routing
 
@@ -98,7 +98,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md (inlined below)
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -1172,15 +1172,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -1194,37 +1194,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -1238,8 +1251,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -1248,28 +1261,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -1281,8 +1304,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -1296,8 +1317,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -1312,7 +1333,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -1320,13 +1341,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -1334,10 +1355,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -1346,6 +1368,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -1359,19 +1382,22 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes
 
 
 ---

--- a/.agents/skills/helius/prompts/openai.developer.md
+++ b/.agents/skills/helius/prompts/openai.developer.md
@@ -41,9 +41,9 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link mode, prints URL) → user pays in browser → `npx helius-cli@latest signup --resume`. Or autopay: `... signup --plan agent --pay`.
 
 ## Routing
 
@@ -108,7 +108,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting

--- a/.agents/skills/helius/references/onboarding.md
+++ b/.agents/skills/helius/references/onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,9 @@ Most tools require a Helius API key. Three paths:
 
 **Path A — Existing key:** Set the `HELIUS_API_KEY` environment variable, or call the `setHeliusApiKey` MCP tool.
 
-**Path B — Agentic signup:** Call `generateKeypair` → fund the wallet with ~0.001 SOL + 1 USDC → `checkSignupBalance` → `agenticSignup`. The API key is configured automatically.
+**Path B — Signup:** Call `generateKeypair` → `signup` with `mode: "link"` (returns a hosted `paymentUrl` the user opens in a browser) → after payment, `signup` with `mode: "resume"`. Or `mode: "autopay"` to pay USDC from the local keypair (wallet must hold ~0.001 SOL + the plan amount in USDC). API key is configured automatically.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link) → user pays in browser → `npx helius-cli@latest signup --resume`. Or `--pay` to autopay.
 
 Get keys from https://dashboard.helius.dev.
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ An all-in-one [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-cod
 The plugin auto-starts the MCP server, but you still need a Helius API key. On first use, Claude will guide you through one of these paths:
 
 - **Existing key**: Use the `setHeliusApiKey` tool with your key from https://dashboard.helius.dev
-- **New account**: Autonomous signup via `generateKeypair` → fund wallet → `agenticSignup`
-- **CLI**: `npx helius-cli@latest keygen` → fund → `npx helius-cli@latest signup`
+- **New account**: `generateKeypair` → `signup` with `mode: "link"` (browser pay) or `mode: "autopay"` (pay USDC from local keypair) → after browser payment, `signup` with `mode: "resume"`
+- **CLI**: `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent` (link) → user pays in browser → `npx helius-cli@latest signup --resume` (or `--pay` to autopay)
 
 ### Local Testing
 

--- a/helius-cli/README.md
+++ b/helius-cli/README.md
@@ -35,23 +35,38 @@ Get your key from [dashboard.helius.dev](https://dashboard.helius.dev).
 
 ### New users — create an account
 
+The default flow returns a hosted-checkout link. Open it in a browser, pay USDC, then resume the CLI to provision your API key.
+
 ```bash
-# 1. Generate a keypair
+# 1. Generate a keypair (auto-runs on first signup if missing)
 helius keygen
 
-# 2. Fund the wallet address shown above:
-#    - ~0.001 SOL for transaction fees
-#    - 1 USDC for the basic plan ($1 one-time)
+# 2. Start signup — prints a payment URL and exits.
+helius signup --email you@example.com --first-name Jane --last-name Doe
 
-# 3. Create account
-helius signup
+# 3. Open the URL in a browser, pay USDC. Then back in the terminal:
+helius signup --resume
 
 # 4. Start querying
 helius balance <wallet-address>
 helius tx parse <signature>
 ```
 
-Paid plans: add `--plan developer` ($49/mo), `--plan business` ($499/mo), or `--plan professional` ($999/mo) to `helius signup`, with `--email`, `--first-name`, `--last-name` required.
+Default plan: `agent` — $10 USDC one-time, 1,000,000 starting credits. Pass `--plan developer` ($49/mo), `--plan business` ($499/mo), or `--plan professional` ($999/mo) for subscription tiers (with optional `--period yearly`).
+
+#### Auto-pay (CLI keypair pays for itself)
+
+Skip the browser — let the CLI keypair send USDC + memo directly to the treasury and poll activation:
+
+```bash
+helius signup --pay --email you@example.com --first-name Jane --last-name Doe
+```
+
+The wallet needs ~0.001 SOL for fees and the plan amount in USDC. On poll timeout the CLI prints `PENDING` with the `txSignature` so you can resume later.
+
+#### Pending intent reuse
+
+Re-running `helius signup` after starting a signup re-prints the same payment link — no duplicate intents are created. To start over, pass `--restart`. To keep polling without sending another USDC tx, pass `--resume` (does not load the keypair, does not require contact args).
 
 ## Configuration
 
@@ -84,7 +99,7 @@ helius config clear               # Reset config
 | Command | Description |
 |---|---|
 | `helius keygen` | Generate a new Solana keypair |
-| `helius signup` | Create a Helius account (default: basic $1; use `--plan` for paid) |
+| `helius signup` | Create a Helius account via crypto checkout (default: agent $10 one-time; `--pay` for autopay, `--resume` to finish) |
 | `helius login` | Authenticate with an existing wallet |
 | `helius upgrade --plan <name>` | Upgrade to a paid plan |
 | `helius pay <payment-intent-id>` | Pay a renewal or pending payment intent |

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { signupCommand } from "../src/commands/signup.js";
 import { upgradeCommand } from "../src/commands/upgrade.js";
 import { payCommand } from "../src/commands/pay.js";
+import { creditsCommand } from "../src/commands/credits.js";
 import { loginCommand } from "../src/commands/login.js";
 import { projectsCommand } from "../src/commands/projects.js";
 import { projectCommand } from "../src/commands/project.js";
@@ -168,32 +169,71 @@ Examples:
 
 program
   .command("upgrade")
-  .description("Upgrade your Helius plan")
-  .requiredOption("--plan <name>", "Target plan: developer, business, professional")
+  .description("Upgrade your Helius plan via crypto checkout")
+  .option("--plan <name>", "Target plan: developer, business, professional")
   .option("--period <period>", "Billing period: monthly or yearly", "monthly")
   .option("--coupon <code>", "Coupon code")
-  .option("--email <email>", "Email address (required for first-time upgrades)")
-  .option("--first-name <name>", "First name (required for first-time upgrades)")
-  .option("--last-name <name>", "Last name (required for first-time upgrades)")
+  .option("--email <email>", "Email (only needed for first-time upgrades; backend auto-fetches otherwise)")
+  .option("--first-name <name>", "First name (only needed for first-time upgrades)")
+  .option("--last-name <name>", "Last name (only needed for first-time upgrades)")
   .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
-  .option("-y, --yes", "Skip confirmation prompt")
+  .option("--pay", "Auto-pay USDC + memo from the local keypair")
+  .option("--resume", "Poll an existing pending upgrade stored in config")
+  .option("--restart", "Discard any stored pending upgrade and start fresh")
   .option("--json", "Output in JSON format")
-  .addHelpText('after', `
+  .addHelpText("after", `
 Examples:
-  $ helius upgrade --plan developer
-  $ helius upgrade --plan business --period yearly --yes`)
-  .action(function(this: any) { upgradeCommand(opts(this)); });
+  $ helius upgrade --plan business --period yearly
+      Print the upgrade payment URL and exit. Open it in a browser, pay USDC,
+      then run \`helius upgrade --resume\` to confirm locally.
+
+  $ helius upgrade --plan developer --pay
+      Auto-pay from the local keypair, poll activation, surface SUCCESS / PENDING.
+
+  $ helius upgrade --resume
+      Poll the stored pending upgrade and confirm activation.`)
+  .action(function (this: any) { upgradeCommand(opts(this)); });
 
 program
   .command("pay <payment-intent-id>")
-  .description("Pay an existing payment intent (e.g., renewal)")
+  .description("Pay an existing renewal payment intent (e.g., from email)")
   .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
-  .option("-y, --yes", "Skip confirmation prompt")
+  .option("--pay", "Auto-pay USDC + memo from the local keypair")
+  .option("--resume", "Poll status of an in-flight payment")
   .option("--json", "Output in JSON format")
-  .addHelpText('after', `
+  .addHelpText("after", `
 Examples:
-  $ helius pay pi_abc123 --yes`)
-  .action(function(this: any, id: string) { payCommand(id, opts(this)); });
+  $ helius pay pi_abc123
+      Print the renewal payment URL and exit. Open it in a browser to pay.
+
+  $ helius pay pi_abc123 --pay
+      Auto-pay USDC + memo from the local keypair, poll until confirmed.
+
+  $ helius pay pi_abc123 --resume
+      Poll status of an already-sent payment.`)
+  .action(function (this: any, id: string) { payCommand(id, opts(this)); });
+
+program
+  .command("credits")
+  .description("Top up prepaid credits on an agent-plan project")
+  .option("--qty <n>", "Quantity multiplier (each unit = 1,000,000 credits)", "1")
+  .option("--coupon <code>", "Coupon code")
+  .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
+  .option("--pay", "Auto-pay USDC + memo from the local keypair")
+  .option("--resume", "Poll an existing pending credits purchase")
+  .option("--restart", "Discard any stored pending credits purchase and start fresh")
+  .option("--json", "Output in JSON format")
+  .addHelpText("after", `
+Examples:
+  $ helius credits --qty 2
+      Print the payment URL for 2 × 1M credits ($20 USDC). Open in browser.
+
+  $ helius credits --pay
+      Auto-pay 1 × 1M credits from the local keypair.
+
+  $ helius credits --resume
+      Poll the stored pending credits purchase.`)
+  .action(function (this: any) { creditsCommand(opts(this)); });
 
 program
   .command("login")

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -215,8 +215,8 @@ Examples:
 
 program
   .command("credits")
-  .description("Top up prepaid credits on an agent-plan project")
-  .option("--qty <n>", "Quantity multiplier (each unit = 1,000,000 credits)", "1")
+  .description("Buy prepaid credits as a one-time USDC top-up. Agent plan only ($10 per 1M credits). Subscription plans (developer/business/professional) handle overage at $5/M auto-billed on the subscription — they cannot use this command.")
+  .option("--qty <n>", "Quantity multiplier (each unit = 1M credits at $10 USDC)", "1")
   .option("--coupon <code>", "Coupon code")
   .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
   .option("--pay", "Auto-pay USDC + memo from the local keypair")

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -127,24 +127,44 @@ Examples:
 
 program
   .command("signup")
-  .description("Create a Helius account (default: $1 basic plan, or specify a paid plan)")
+  .description("Create a Helius account via crypto checkout (default plan: agent — $10 USDC one-time, 1M starting credits)")
   .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
-  .option("--plan <plan>", "Plan: basic ($1), developer ($49/mo), business ($499/mo), professional ($999/mo)")
-  .option("--period <period>", "Billing period: monthly or yearly (paid plans only)", "monthly")
-  .option("--coupon <code>", "Coupon code (paid plans only)")
-  .option("--email <email>", "Email address (required for paid plans)")
-  .option("--first-name <name>", "First name (required for paid plans)")
-  .option("--last-name <name>", "Last name (required for paid plans)")
+  .option(
+    "--plan <plan>",
+    "Plan: agent ($10 one-time, default), developer ($49/mo), business ($499/mo), professional ($999/mo)",
+    "agent",
+  )
+  .option("--period <period>", "Billing period: monthly or yearly (subscription plans only)", "monthly")
+  .option("--coupon <code>", "Coupon code")
+  .option("--email <email>", "Email address (required for fresh signup)")
+  .option("--first-name <name>", "First name (required for fresh signup)")
+  .option("--last-name <name>", "Last name (required for fresh signup)")
   .option("--discovery-path <text>", "How did you discover Helius?")
   .option("--friction-points <text>", "What friction did you hit finding or setting up Helius?")
-  .option("--wait", "Poll for funds if balance is insufficient, then continue signup automatically")
+  .option("--pay", "Auto-pay USDC + memo from the local keypair instead of printing only the link")
+  .option("--resume", "Poll an existing pending signup intent stored in config, then provision the API key")
+  .option("--restart", "Discard any stored pending signup and start a fresh one")
   .option("--json", "Output in JSON format")
-  .addHelpText('after', `
+  .addHelpText("after", `
 Examples:
-  $ helius signup
-  $ helius signup --plan developer --email you@example.com --first-name Jane --last-name Doe
-  $ helius signup --wait`)
-  .action(signupCommand);
+  $ helius signup --email you@example.com --first-name Jane --last-name Doe
+      Default link mode — prints a hosted-checkout URL and exits.
+      Open the URL in a browser, pay USDC, then run \`helius signup --resume\`
+      to finish setup. Re-running this command without --restart re-prints the
+      stored link instead of creating a duplicate intent.
+
+  $ helius signup --pay --email you@example.com --first-name Jane --last-name Doe
+      Auto-pay flow — the CLI keypair sends USDC + memo to the treasury and
+      polls activation. On poll timeout, prints PENDING with the txSignature
+      so you can resume later.
+
+  $ helius signup --resume
+      Polls the stored intent and provisions the API key when the backend
+      reports the subscription is active. Does NOT load the keypair.
+
+  $ helius signup --restart --plan developer --period yearly ...
+      Discards the stored pending intent and starts a fresh signup.`)
+  .action(function (this: any) { signupCommand(opts(this)); });
 
 program
   .command("upgrade")

--- a/helius-cli/package.json
+++ b/helius-cli/package.json
@@ -24,7 +24,7 @@
     "@solana/kit": "^5.5.1",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
-    "helius-sdk": "^2.2.2",
+    "helius-sdk": "^3.0.0",
     "ora": "^8.0.0"
   },
   "devDependencies": {

--- a/helius-cli/package.json
+++ b/helius-cli/package.json
@@ -15,6 +15,8 @@
     "prebuild": "node -p \"'export const version = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",
     "build": "tsc",
     "dev": "tsx bin/helius.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
@@ -28,6 +30,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/helius-cli/pnpm-lock.yaml
+++ b/helius-cli/pnpm-lock.yaml
@@ -36,8 +36,20 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@20.19.33)(vite@8.0.10(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0))
 
 packages:
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -194,6 +206,116 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@solana-program/compute-budget@0.11.0':
     resolution: {integrity: sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==}
@@ -570,11 +692,59 @@ packages:
       typescript:
         optional: true
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/node@20.19.33':
     resolution: {integrity: sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==}
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   base-x@5.0.1:
@@ -582,6 +752,10 @@ packages:
 
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -603,13 +777,39 @@ packages:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -638,13 +838,98 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -654,6 +939,20 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -661,9 +960,27 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -676,6 +993,21 @@ packages:
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -696,6 +1028,95 @@ packages:
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -709,6 +1130,22 @@ packages:
         optional: true
 
 snapshots:
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -787,6 +1224,68 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(typescript@5.9.3))':
     dependencies:
@@ -1228,17 +1727,78 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
   '@types/node@20.19.33':
     dependencies:
       undici-types: 6.21.0
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   ansi-regex@6.2.2: {}
+
+  assertion-error@2.0.1: {}
 
   base-x@5.0.1: {}
 
   bs58@6.0.0:
     dependencies:
       base-x: 5.0.1
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -1252,7 +1812,13 @@ snapshots:
 
   commander@14.0.2: {}
 
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
   emoji-regex@10.6.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1282,6 +1848,16 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fsevents@2.3.3:
     optional: true
@@ -1313,12 +1889,69 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   mimic-function@5.0.1: {}
+
+  nanoid@3.3.12: {}
+
+  obug@2.1.1: {}
 
   onetime@7.0.0:
     dependencies:
@@ -1336,6 +1969,18 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
@@ -1343,7 +1988,36 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -1356,6 +2030,17 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tslib@2.8.1: {}
 
@@ -1371,5 +2056,50 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.22.0: {}
+
+  vite@8.0.10(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.33
+      esbuild: 0.27.3
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.1.5(@types/node@20.19.33)(vite@8.0.10(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@20.19.33)(esbuild@0.27.3)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.33
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.19.0: {}

--- a/helius-cli/pnpm-lock.yaml
+++ b/helius-cli/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^12.0.0
         version: 12.1.0
       helius-sdk:
-        specifier: ^2.2.2
-        version: 2.2.2(typescript@5.9.3)
+        specifier: ^3.0.0
+        version: 3.0.0(@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(typescript@5.9.3)))(@solana-program/stake@0.5.0(@solana/kit@5.5.1(typescript@5.9.3)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(typescript@5.9.3)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(typescript@5.9.3)))(@solana/kit@5.5.1(typescript@5.9.3))
       ora:
         specifier: ^8.0.0
         version: 8.2.0
@@ -823,8 +823,15 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
-  helius-sdk@2.2.2:
-    resolution: {integrity: sha512-T7H9fJOYAB9HUZomDQ47EnKYPE//SgweZz4PbWF6q0Y1/jA0J+7xY15kFpZLJHyAGd4AXXxDCSISRdABmpCjfQ==}
+  helius-sdk@3.0.0:
+    resolution: {integrity: sha512-fd6s8jtgs85qBRxRveEjnfsb8JjkJPydtM2Na5F5UdT9PKjrbcTkqKe9isr9Kh8rYW5sQ1WbZzGapgersTbrMg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@solana-program/compute-budget': ^0.15.0
+      '@solana-program/stake': ^0.6.1
+      '@solana-program/system': ^0.12.0
+      '@solana-program/token': ^0.13.0
+      '@solana/kit': ^6.9.0
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -1868,7 +1875,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  helius-sdk@2.2.2(typescript@5.9.3):
+  helius-sdk@3.0.0(@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(typescript@5.9.3)))(@solana-program/stake@0.5.0(@solana/kit@5.5.1(typescript@5.9.3)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(typescript@5.9.3)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(typescript@5.9.3)))(@solana/kit@5.5.1(typescript@5.9.3)):
     dependencies:
       '@solana-program/compute-budget': 0.11.0(@solana/kit@5.5.1(typescript@5.9.3))
       '@solana-program/stake': 0.5.0(@solana/kit@5.5.1(typescript@5.9.3))
@@ -1877,11 +1884,6 @@ snapshots:
       '@solana/kit': 5.5.1(typescript@5.9.3)
       bs58: 6.0.0
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
 
   is-interactive@2.0.0: {}
 

--- a/helius-cli/src/commands/credits.test.ts
+++ b/helius-cli/src/commands/credits.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockPurchaseCredits = vi.fn();
 const mockPayPaymentLink = vi.fn();
 const mockGetPaymentStatus = vi.fn();
+const mockGetPaymentIntent = vi.fn();
 const mockListProjects = vi.fn();
 const mockWalletSignup = vi.fn();
 
@@ -10,6 +11,7 @@ vi.mock("../lib/api.js", () => ({
   walletSignup: (...args: unknown[]) => mockWalletSignup(...args),
   listProjects: (...args: unknown[]) => mockListProjects(...args),
   getPaymentStatus: (...args: unknown[]) => mockGetPaymentStatus(...args),
+  getPaymentIntent: (...args: unknown[]) => mockGetPaymentIntent(...args),
   payPaymentLink: (...args: unknown[]) => mockPayPaymentLink(...args),
   purchaseCredits: (...args: unknown[]) => mockPurchaseCredits(...args),
 }));
@@ -187,6 +189,23 @@ describe("credits command", () => {
     const { json } = await captureStdout(() => creditsCommand({ ...baseOpts, resume: true } as any));
     expect(json?.data.status).toBe("SUCCESS");
     expect(json?.data.qty).toBe(1);
+    expect(mockClearPendingCredits).toHaveBeenCalled();
+  });
+
+  it("--resume SUCCESS without stored txSignature backfills it from getPaymentIntent", async () => {
+    mockGetPendingCredits.mockReturnValue({ ...samplePending });
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    mockGetPaymentIntent.mockResolvedValue({ txSignature: "tx-from-intent" });
+    const { json } = await captureStdout(() => creditsCommand({ ...baseOpts, resume: true } as any));
+    expect(json?.data.status).toBe("SUCCESS");
+    expect(json?.data.txSignature).toBe("tx-from-intent");
+    expect(mockGetPaymentIntent).toHaveBeenCalledWith(samplePending.jwt, samplePending.paymentIntentId);
     expect(mockClearPendingCredits).toHaveBeenCalled();
   });
 

--- a/helius-cli/src/commands/credits.test.ts
+++ b/helius-cli/src/commands/credits.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPurchaseCredits = vi.fn();
+const mockPayPaymentLink = vi.fn();
+const mockGetPaymentStatus = vi.fn();
+const mockListProjects = vi.fn();
+const mockWalletSignup = vi.fn();
+
+vi.mock("../lib/api.js", () => ({
+  walletSignup: (...args: unknown[]) => mockWalletSignup(...args),
+  listProjects: (...args: unknown[]) => mockListProjects(...args),
+  getPaymentStatus: (...args: unknown[]) => mockGetPaymentStatus(...args),
+  payPaymentLink: (...args: unknown[]) => mockPayPaymentLink(...args),
+  purchaseCredits: (...args: unknown[]) => mockPurchaseCredits(...args),
+}));
+
+const mockSetJwt = vi.fn();
+const mockGetPendingCredits = vi.fn();
+const mockSetPendingCredits = vi.fn();
+const mockUpdatePendingCredits = vi.fn();
+const mockClearPendingCredits = vi.fn();
+
+vi.mock("../lib/config.js", () => ({
+  setJwt: (...args: unknown[]) => mockSetJwt(...args),
+  getPendingCredits: () => mockGetPendingCredits(),
+  setPendingCredits: (...args: unknown[]) => mockSetPendingCredits(...args),
+  updatePendingCredits: (...args: unknown[]) => mockUpdatePendingCredits(...args),
+  clearPendingCredits: () => mockClearPendingCredits(),
+  SHARED_CONFIG_PATH: "/tmp/test-config.json",
+}));
+
+const mockKeypairExists = vi.fn();
+vi.mock("./keygen.js", () => ({
+  keypairExists: (...args: unknown[]) => mockKeypairExists(...args),
+  getDefaultKeypairPath: () => "/tmp/keypair.json",
+}));
+
+const mockLoadKeypair = vi.fn();
+const mockGetAddress = vi.fn();
+const mockSignAuthMessage = vi.fn();
+vi.mock("../lib/wallet.js", () => ({
+  loadKeypairFromFile: (...args: unknown[]) => mockLoadKeypair(...args),
+  getAddress: (...args: unknown[]) => mockGetAddress(...args),
+  signAuthMessage: (...args: unknown[]) => mockSignAuthMessage(...args),
+}));
+
+const mockCheckSolBalance = vi.fn();
+const mockCheckUsdcBalance = vi.fn();
+vi.mock("../lib/payment.js", () => ({
+  checkSolBalance: (...args: unknown[]) => mockCheckSolBalance(...args),
+  checkUsdcBalance: (...args: unknown[]) => mockCheckUsdcBalance(...args),
+}));
+
+vi.mock("../lib/feedback.js", () => ({
+  sendCommandEvent: vi.fn(),
+  getCurrentCommand: () => "credits",
+}));
+
+import { creditsCommand } from "./credits.js";
+
+interface CapturedJson {
+  ok: boolean;
+  v?: number;
+  data?: any;
+  error?: any;
+}
+
+function captureStdout(fn: () => Promise<void>) {
+  const chunks: string[] = [];
+  let exitCode: number | null = null;
+
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    chunks.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n");
+  });
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code: any) => {
+    exitCode = typeof code === "number" ? code : 0;
+    throw new Error("__test_exit__");
+  }) as never);
+
+  return fn()
+    .catch((e) => {
+      if (e instanceof Error && e.message === "__test_exit__") return;
+      throw e;
+    })
+    .finally(() => {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    })
+    .then(() => {
+      const raw = chunks.join("");
+      const trimmed = raw.trim();
+      let json: CapturedJson | null = null;
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed && "ok" in parsed) json = parsed;
+      } catch {
+        /* ignore */
+      }
+      return { json, raw, exitCode };
+    });
+}
+
+const baseOpts = {
+  keypair: "/tmp/keypair.json",
+  json: true,
+};
+
+const samplePending = {
+  paymentIntentId: "pi_credits",
+  paymentUrl: "https://dashboard.helius.dev/pay/pi_credits",
+  planName: "Prepaid credits (1 × 1M)",
+  amountCents: 1000,
+  destinationWallet: "Treasury",
+  solanaPayUrl: "solana:Treasury?amount=10",
+  memo: "pi_credits",
+  expiresAt: new Date(Date.now() + 1_800_000).toISOString(),
+  jwt: "jwt-1",
+  projectId: "proj-1",
+  qty: 1,
+  createdAt: new Date().toISOString(),
+};
+
+describe("credits command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKeypairExists.mockReturnValue(true);
+    mockLoadKeypair.mockResolvedValue({ secretKey: new Uint8Array(64) });
+    mockGetAddress.mockResolvedValue("Wallet111");
+    mockSignAuthMessage.mockResolvedValue({ message: "m", signature: "s" });
+    mockWalletSignup.mockResolvedValue({ token: "jwt-1", refId: "r", newUser: false });
+    mockListProjects.mockResolvedValue([{ id: "proj-1" }]);
+    mockCheckSolBalance.mockResolvedValue(2_000_000n);
+    mockCheckUsdcBalance.mockResolvedValue(99_900_000_000n);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("PAYMENT_REQUIRED on fresh credits purchase", async () => {
+    mockGetPendingCredits.mockReturnValue(undefined);
+    mockPurchaseCredits.mockResolvedValue({
+      kind: "payment_required",
+      paymentLink: {
+        kind: "payment_required",
+        paymentIntentId: samplePending.paymentIntentId,
+        amountCents: samplePending.amountCents,
+        destinationWallet: samplePending.destinationWallet,
+        memo: samplePending.memo,
+        expiresAt: samplePending.expiresAt,
+        paymentUrl: samplePending.paymentUrl,
+        solanaPayUrl: samplePending.solanaPayUrl,
+        planName: samplePending.planName,
+      },
+    });
+
+    const { json } = await captureStdout(() => creditsCommand({ ...baseOpts, qty: "1" } as any));
+    expect(json?.data.status).toBe("PAYMENT_REQUIRED");
+    expect(json?.data.qty).toBe(1);
+    expect(json?.data.destinationWallet).toBe("Treasury");
+    expect(mockSetPendingCredits).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects --qty 0", async () => {
+    mockGetPendingCredits.mockReturnValue(undefined);
+    const { json } = await captureStdout(() => creditsCommand({ ...baseOpts, qty: "0" } as any));
+    expect(json?.ok).toBe(false);
+    expect(mockPurchaseCredits).not.toHaveBeenCalled();
+  });
+
+  it("--resume MISSING_PENDING_CREDITS when no stored intent", async () => {
+    mockGetPendingCredits.mockReturnValue(undefined);
+    const { json } = await captureStdout(() => creditsCommand({ ...baseOpts, resume: true } as any));
+    expect(json?.data.status).toBe("MISSING_PENDING_CREDITS");
+    expect(mockLoadKeypair).not.toHaveBeenCalled();
+  });
+
+  it("--resume SUCCESS when activation is ready", async () => {
+    mockGetPendingCredits.mockReturnValue({ ...samplePending, txSignature: "tx-sent" });
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    const { json } = await captureStdout(() => creditsCommand({ ...baseOpts, resume: true } as any));
+    expect(json?.data.status).toBe("SUCCESS");
+    expect(json?.data.qty).toBe(1);
+    expect(mockClearPendingCredits).toHaveBeenCalled();
+  });
+
+  it("--pay reuses stored pendingCredits and does NOT re-send when txSignature exists", async () => {
+    mockGetPendingCredits.mockReturnValue({ ...samplePending, txSignature: "tx-old" });
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    await captureStdout(() => creditsCommand({ ...baseOpts, pay: true } as any));
+    expect(mockPayPaymentLink).not.toHaveBeenCalled();
+    expect(mockClearPendingCredits).toHaveBeenCalled();
+  });
+});

--- a/helius-cli/src/commands/credits.ts
+++ b/helius-cli/src/commands/credits.ts
@@ -30,7 +30,7 @@ import {
   createSpinner,
   type OutputOptions,
 } from "../lib/output.js";
-import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
+import { checkSolBalance, checkUsdcBalance, checkBackendForRefresh } from "../lib/payment.js";
 
 interface CreditsOptions extends OutputOptions {
   keypair: string;
@@ -68,10 +68,34 @@ export async function creditsCommand(options: CreditsOptions): Promise<void> {
     if (stored && !options.restart) {
       if (options.pay) {
         await runPayWithStored(stored, options, spinner);
+        return;
+      }
+
+      // Local expiry past → query backend before reprinting a stale URL.
+      // `qty` is already validated above and stays in scope for the
+      // fall-through-to-fresh path on `cleared`.
+      const localExpired = Date.parse(stored.expiresAt) <= Date.now();
+      if (localExpired) {
+        const { verdict } = await checkBackendForRefresh(
+          stored.jwt,
+          stored.paymentIntentId,
+          spinner,
+        );
+        if (verdict === "completed") {
+          await pollAndEmit(stored, stored.txSignature, options, spinner);
+          return;
+        }
+        if (verdict === "cleared") {
+          clearPendingCredits();
+          // Fall through to fresh credits path.
+        } else {
+          emitPaymentRequired(stored, true, options);
+          return;
+        }
       } else {
         emitPaymentRequired(stored, true, options);
+        return;
       }
-      return;
     }
 
     if (!keypairExists(options.keypair)) {
@@ -122,6 +146,7 @@ export async function creditsCommand(options: CreditsOptions): Promise<void> {
       jwt: auth.token,
       projectId: project.id,
       qty,
+      payerWallet: walletAddress,
       createdAt: new Date().toISOString(),
     };
     setPendingCredits(pending);
@@ -210,6 +235,18 @@ async function runPayWithStored(
   const secretKey = freshSecretKey ?? (await loadSecretKey(options));
   const keypair = await loadKeypairFromFile(options.keypair);
   const payerAddress = await getAddress(keypair);
+
+  // Guard against keypair rotation between intent creation and --pay.
+  // `payerWallet` is undefined for intents stored before this field was
+  // introduced; skip the check in that case.
+  if (stored.payerWallet && payerAddress !== stored.payerWallet) {
+    exitWithError(
+      "INVALID_INPUT",
+      `Local keypair wallet (${payerAddress}) does not match the wallet that created this credits intent (${stored.payerWallet}). Run \`helius credits --restart\` to start over.`,
+      undefined,
+      !!options.json,
+    );
+  }
 
   spinner?.start("Checking wallet balance...");
   const sol = await checkSolBalance(payerAddress);

--- a/helius-cli/src/commands/credits.ts
+++ b/helius-cli/src/commands/credits.ts
@@ -7,18 +7,18 @@ import {
 import {
   walletSignup,
   listProjects,
-  getPaymentStatus,
+  purchaseCredits as sdkPurchaseCredits,
   payPaymentLink,
-  upgradePlan as sdkUpgradePlan,
+  getPaymentStatus,
   type PaymentLink,
 } from "../lib/api.js";
 import {
   setJwt,
-  getPendingUpgrade,
-  setPendingUpgrade,
-  updatePendingUpgrade,
-  clearPendingUpgrade,
-  type PendingUpgrade,
+  getPendingCredits,
+  setPendingCredits,
+  updatePendingCredits,
+  clearPendingCredits,
+  type PendingCredits,
 } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import {
@@ -30,16 +30,11 @@ import {
   type OutputOptions,
 } from "../lib/output.js";
 import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
-import { validateUpgradePlan, validatePeriod, validateEmail } from "../lib/validation.js";
 
-interface UpgradeOptions extends OutputOptions {
+interface CreditsOptions extends OutputOptions {
   keypair: string;
-  plan?: string;
-  period?: string;
+  qty?: string;
   coupon?: string;
-  email?: string;
-  firstName?: string;
-  lastName?: string;
   pay?: boolean;
   resume?: boolean;
   restart?: boolean;
@@ -50,12 +45,12 @@ const SOL_FEE_THRESHOLD = 1_000_000n;
 const TX_EXPLORER = "https://orbmarkets.io/tx";
 
 /**
- * Phase 2 — `helius upgrade`. Mirrors `helius signup` with three modes:
- *   - default (link): print payment URL + save pendingUpgrade, exit.
- *   - --pay: autopay USDC + memo from local keypair, poll, surface SUCCESS / PENDING.
- *   - --resume: poll stored pendingUpgrade (no keypair load), provision on SUCCESS.
+ * Phase 2 — `helius credits` to top up prepaid credits on an agent-plan
+ * project. Mirrors signup/upgrade with three modes (default / --pay / --resume).
+ *
+ * Each unit of `--qty` grants 1,000,000 credits ($10 USDC each).
  */
-export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
+export async function creditsCommand(options: CreditsOptions): Promise<void> {
   const spinner = createSpinner(options);
 
   try {
@@ -64,22 +59,11 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
       return;
     }
 
-    if (options.plan) {
-      const planErr = validateUpgradePlan(options.plan);
-      if (planErr) exitWithError("INVALID_INPUT", planErr, undefined, !!options.json);
-    }
-    if (options.period) {
-      const periodErr = validatePeriod(options.period);
-      if (periodErr) exitWithError("INVALID_INPUT", periodErr, undefined, !!options.json);
-    }
-    if (options.email) {
-      const emailErr = validateEmail(options.email);
-      if (emailErr) exitWithError("INVALID_INPUT", emailErr, undefined, !!options.json);
-    }
+    const qty = parseQty(options.qty);
 
-    if (options.restart) clearPendingUpgrade();
+    if (options.restart) clearPendingCredits();
 
-    const stored = getPendingUpgrade();
+    const stored = getPendingCredits();
     if (stored && !options.restart) {
       if (options.pay) {
         await runPayWithStored(stored, options, spinner);
@@ -87,15 +71,6 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
         emitPaymentRequired(stored, true, options);
       }
       return;
-    }
-
-    if (!options.plan) {
-      exitWithError(
-        "INVALID_INPUT",
-        "--plan is required for upgrade (e.g. --plan business --period yearly).",
-        undefined,
-        !!options.json,
-      );
     }
 
     if (!keypairExists(options.keypair)) {
@@ -117,35 +92,24 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     setJwt(auth.token);
     spinner?.succeed("Authenticated");
 
-    spinner?.start("Locating project to upgrade...");
+    spinner?.start("Locating project...");
     const projects = await listProjects(auth.token);
     if (projects.length === 0) {
-      exitWithError("NO_PROJECTS", "No projects found for this wallet.", undefined, !!options.json);
+      exitWithError("NO_PROJECTS", "No projects found.", undefined, !!options.json);
     }
     const project = projects[0];
     spinner?.succeed(`Project: ${project.id}`);
 
-    const period = (options.period as "monthly" | "yearly") || "monthly";
-    const targetPlan = options.plan!.toLowerCase() as
-      | "agent"
-      | "developer"
-      | "business"
-      | "professional";
-
-    spinner?.start("Creating upgrade payment intent...");
-    const result = await sdkUpgradePlan({
+    spinner?.start("Creating credits payment intent...");
+    const result = await sdkPurchaseCredits({
       jwt: auth.token,
       projectId: project.id,
-      plan: targetPlan,
-      period,
+      qty,
       couponCode: options.coupon,
-      email: options.email,
-      firstName: options.firstName,
-      lastName: options.lastName,
     });
-    spinner?.succeed("Upgrade ready");
+    spinner?.succeed("Credits link ready");
 
-    const pending: PendingUpgrade = {
+    const pending: PendingCredits = {
       paymentIntentId: result.paymentLink.paymentIntentId,
       paymentUrl: result.paymentLink.paymentUrl,
       planName: result.paymentLink.planName,
@@ -156,11 +120,10 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
       expiresAt: result.paymentLink.expiresAt,
       jwt: auth.token,
       projectId: project.id,
-      targetPlan,
-      period,
+      qty,
       createdAt: new Date().toISOString(),
     };
-    setPendingUpgrade(pending);
+    setPendingCredits(pending);
 
     if (options.pay) {
       await runPayWithStored(pending, options, spinner, keypair.secretKey);
@@ -172,13 +135,22 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
   }
 }
 
+function parseQty(input: string | undefined): number {
+  if (input === undefined) return 1;
+  const n = Number(input);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`--qty must be a positive integer, got "${input}".`);
+  }
+  return n;
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // --pay path
 // ────────────────────────────────────────────────────────────────────────────
 
 async function runPayWithStored(
-  stored: PendingUpgrade,
-  options: UpgradeOptions,
+  stored: PendingCredits,
+  options: CreditsOptions,
   spinner: ReturnType<typeof createSpinner>,
   freshSecretKey?: Uint8Array,
 ): Promise<void> {
@@ -206,7 +178,7 @@ async function runPayWithStored(
     status = await getPaymentStatus(stored.jwt, stored.paymentIntentId);
   } catch (error) {
     if (error instanceof Error && error.message.includes("410")) {
-      clearPendingUpgrade();
+      clearPendingCredits();
       emitExpired(stored, options);
       return;
     }
@@ -215,17 +187,17 @@ async function runPayWithStored(
   spinner?.succeed(`Status: ${status.phase}`);
 
   if (status.readyToRedirect) {
-    clearPendingUpgrade();
+    clearPendingCredits();
     emitSuccess(stored, undefined, options);
     return;
   }
   if (status.phase === "expired") {
-    clearPendingUpgrade();
+    clearPendingCredits();
     emitExpired(stored, options);
     return;
   }
   if (status.phase === "failed") {
-    clearPendingUpgrade();
+    clearPendingCredits();
     emitFailed(stored, status.message, options);
     return;
   }
@@ -235,30 +207,27 @@ async function runPayWithStored(
   }
 
   const secretKey = freshSecretKey ?? (await loadSecretKey(options));
-
-  spinner?.start("Checking wallet balance...");
-  const sol = await checkSolBalance(stored.destinationWallet);
-  void sol; // The destinationWallet is the treasury, not the payer; check payer instead.
-  // (Keypair-derived wallet pays; just sanity-check fees are present on it.)
   const keypair = await loadKeypairFromFile(options.keypair);
   const payerAddress = await getAddress(keypair);
-  const payerSol = await checkSolBalance(payerAddress);
-  const payerUsdc = await checkUsdcBalance(payerAddress);
+
+  spinner?.start("Checking wallet balance...");
+  const sol = await checkSolBalance(payerAddress);
+  const usdc = await checkUsdcBalance(payerAddress);
   const required = BigInt(stored.amountCents) * CENTS_TO_USDC_RAW;
-  if (payerSol < SOL_FEE_THRESHOLD) {
+  if (sol < SOL_FEE_THRESHOLD) {
     spinner?.fail("Insufficient SOL for fees");
     exitWithError(
       "INSUFFICIENT_SOL",
-      `Wallet ${payerAddress} needs ~0.001 SOL (have ${(Number(payerSol) / 1e9).toFixed(6)}).`,
+      `Wallet ${payerAddress} needs ~0.001 SOL (have ${(Number(sol) / 1e9).toFixed(6)}).`,
       undefined,
       !!options.json,
     );
   }
-  if (payerUsdc < required) {
+  if (usdc < required) {
     spinner?.fail("Insufficient USDC");
     exitWithError(
       "INSUFFICIENT_USDC",
-      `Wallet ${payerAddress} needs ${stored.amountCents / 100} USDC (have ${(Number(payerUsdc) / 1e6).toFixed(2)}).`,
+      `Wallet ${payerAddress} needs ${stored.amountCents / 100} USDC (have ${(Number(usdc) / 1e6).toFixed(2)}).`,
       undefined,
       !!options.json,
     );
@@ -268,15 +237,15 @@ async function runPayWithStored(
   spinner?.start(`Sending ${stored.amountCents / 100} USDC + memo...`);
   const { txSignature } = await payPaymentLink(secretKey, link);
   spinner?.succeed(`Sent: ${txSignature}`);
-  updatePendingUpgrade({ txSignature });
+  updatePendingCredits({ txSignature });
 
   await pollAndEmit(stored, txSignature, options, spinner);
 }
 
 async function pollAndEmit(
-  stored: PendingUpgrade,
+  stored: PendingCredits,
   txSignature: string | undefined,
-  options: UpgradeOptions,
+  options: CreditsOptions,
   spinner: ReturnType<typeof createSpinner>,
 ): Promise<void> {
   const deadline = Date.now() + 60_000;
@@ -288,26 +257,25 @@ async function pollAndEmit(
       status = await getPaymentStatus(stored.jwt, stored.paymentIntentId);
     } catch (error) {
       if (error instanceof Error && error.message.includes("410")) {
-        clearPendingUpgrade();
+        clearPendingCredits();
         emitExpired(stored, options);
         return;
       }
       throw error;
     }
-
     if (status.readyToRedirect) {
-      spinner?.succeed("Upgraded");
-      clearPendingUpgrade();
+      spinner?.succeed("Credits added");
+      clearPendingCredits();
       emitSuccess(stored, txSignature, options);
       return;
     }
     if (status.phase === "failed") {
-      clearPendingUpgrade();
+      clearPendingCredits();
       emitFailed(stored, status.message, options);
       return;
     }
     if (status.phase === "expired") {
-      clearPendingUpgrade();
+      clearPendingCredits();
       emitExpired(stored, options);
       return;
     }
@@ -323,23 +291,23 @@ async function pollAndEmit(
 // ────────────────────────────────────────────────────────────────────────────
 
 async function runResume(
-  options: UpgradeOptions,
+  options: CreditsOptions,
   spinner: ReturnType<typeof createSpinner>,
 ): Promise<void> {
-  const stored = getPendingUpgrade();
+  const stored = getPendingCredits();
   if (!stored) {
     if (options.json) {
-      outputJson({ status: "MISSING_PENDING_UPGRADE" });
+      outputJson({ status: "MISSING_PENDING_CREDITS" });
       return;
     }
     exitWithError(
-      "MISSING_PENDING_UPGRADE",
-      "No pending upgrade found in config. Run `helius upgrade --plan ...` first.",
+      "MISSING_PENDING_CREDITS",
+      "No pending credits purchase. Run `helius credits` first.",
       undefined,
       !!options.json,
     );
   }
-  spinner?.start("Polling upgrade status...");
+  spinner?.start("Polling credits status...");
   await pollAndEmit(stored!, stored!.txSignature, options, spinner);
 }
 
@@ -348,9 +316,9 @@ async function runResume(
 // ────────────────────────────────────────────────────────────────────────────
 
 function emitPaymentRequired(
-  stored: PendingUpgrade,
+  stored: PendingCredits,
   reused: boolean,
-  options: UpgradeOptions,
+  options: CreditsOptions,
 ): void {
   if (options.json) {
     outputJson({
@@ -358,8 +326,7 @@ function emitPaymentRequired(
       paymentUrl: stored.paymentUrl,
       paymentIntentId: stored.paymentIntentId,
       projectId: stored.projectId,
-      targetPlan: stored.targetPlan,
-      period: stored.period,
+      qty: stored.qty,
       expiresAt: stored.expiresAt,
       amountCents: stored.amountCents,
       planName: stored.planName,
@@ -372,9 +339,15 @@ function emitPaymentRequired(
   }
   console.log();
   if (reused) {
-    console.log(chalk.gray("(Resuming previous upgrade — re-run with --restart to start over.)"));
+    console.log(
+      chalk.gray("(Resuming previous credits purchase — re-run with --restart to start over.)"),
+    );
   }
-  console.log(chalk.bold(`Pay ${stored.amountCents / 100} USDC to upgrade to ${stored.planName}:`));
+  console.log(
+    chalk.bold(
+      `Pay ${stored.amountCents / 100} USDC to top up ${stored.qty.toLocaleString()} × 1M credits:`,
+    ),
+  );
   console.log();
   console.log(`  ${chalk.cyan(stored.paymentUrl)}`);
   console.log();
@@ -382,36 +355,34 @@ function emitPaymentRequired(
   console.log(chalk.gray(`  Treasury: ${stored.destinationWallet}`));
   console.log(chalk.gray(`  Memo:     ${stored.memo}`));
   console.log();
-  console.log(chalk.gray("Once paid, run `helius upgrade --resume` to confirm locally."));
+  console.log(chalk.gray("Once paid, run `helius credits --resume` to confirm locally."));
 }
 
 function emitSuccess(
-  stored: PendingUpgrade,
+  stored: PendingCredits,
   txSignature: string | undefined,
-  options: UpgradeOptions,
+  options: CreditsOptions,
 ): void {
   if (options.json) {
     outputJson({
       status: "SUCCESS",
       projectId: stored.projectId,
-      newPlan: stored.targetPlan,
-      period: stored.period,
+      qty: stored.qty,
       paymentIntentId: stored.paymentIntentId,
       txSignature: txSignature ?? null,
     });
     return;
   }
-  console.log("\n" + chalk.green(`Upgraded to ${stored.planName}!`));
-  console.log(`\nProject ID: ${chalk.cyan(stored.projectId)}`);
+  console.log("\n" + chalk.green(`Topped up ${(stored.qty * 1_000_000).toLocaleString()} credits!`));
   if (txSignature) {
     console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
   }
 }
 
 function emitPending(
-  stored: PendingUpgrade,
+  stored: PendingCredits,
   txSignature: string | undefined,
-  options: UpgradeOptions,
+  options: CreditsOptions,
 ): void {
   if (options.json) {
     outputJson({
@@ -423,28 +394,27 @@ function emitPending(
     });
     return;
   }
-  console.log("\n" + chalk.yellow("Upgrade still being confirmed."));
+  console.log("\n" + chalk.yellow("Credits purchase still being confirmed."));
   console.log(`\n  Payment URL: ${chalk.cyan(stored.paymentUrl)}`);
   if (txSignature) {
     console.log(`  Transaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
   }
-  console.log(chalk.gray(`\nRun \`helius upgrade --resume\` again in a moment.`));
+  console.log(chalk.gray(`\nRun \`helius credits --resume\` again in a moment.`));
 }
 
-function emitExpired(stored: PendingUpgrade, options: UpgradeOptions): void {
+function emitExpired(stored: PendingCredits, options: CreditsOptions): void {
   if (options.json) {
     outputJson({ status: "EXPIRED", paymentIntentId: stored.paymentIntentId });
     return;
   }
-  console.error("\n" + chalk.red("Upgrade payment intent expired."));
-  console.error(chalk.gray("Run `helius upgrade --plan ...` to start fresh."));
+  console.error("\n" + chalk.red("Credits payment intent expired."));
   process.exit(ExitCode.GENERAL_ERROR);
 }
 
 function emitFailed(
-  stored: PendingUpgrade,
+  stored: PendingCredits,
   reason: string | undefined,
-  options: UpgradeOptions,
+  options: CreditsOptions,
 ): void {
   if (options.json) {
     outputJson({
@@ -454,12 +424,12 @@ function emitFailed(
     });
     return;
   }
-  console.error("\n" + chalk.red("Upgrade payment failed."));
+  console.error("\n" + chalk.red("Credits payment failed."));
   if (reason) console.error(chalk.gray(reason));
   process.exit(ExitCode.GENERAL_ERROR);
 }
 
-async function loadSecretKey(options: UpgradeOptions): Promise<Uint8Array> {
+async function loadSecretKey(options: CreditsOptions): Promise<Uint8Array> {
   if (!keypairExists(options.keypair)) {
     exitWithError(
       "KEYPAIR_NOT_FOUND",

--- a/helius-cli/src/commands/credits.ts
+++ b/helius-cli/src/commands/credits.ts
@@ -10,6 +10,7 @@ import {
   purchaseCredits as sdkPurchaseCredits,
   payPaymentLink,
   getPaymentStatus,
+  getPaymentIntent,
   type PaymentLink,
 } from "../lib/api.js";
 import {
@@ -188,7 +189,7 @@ async function runPayWithStored(
 
   if (status.readyToRedirect) {
     clearPendingCredits();
-    emitSuccess(stored, undefined, options);
+    await emitSuccess(stored, undefined, options);
     return;
   }
   if (status.phase === "expired") {
@@ -266,7 +267,7 @@ async function pollAndEmit(
     if (status.readyToRedirect) {
       spinner?.succeed("Credits added");
       clearPendingCredits();
-      emitSuccess(stored, txSignature, options);
+      await emitSuccess(stored, txSignature, options);
       return;
     }
     if (status.phase === "failed") {
@@ -358,24 +359,36 @@ function emitPaymentRequired(
   console.log(chalk.gray("Once paid, run `helius credits --resume` to confirm locally."));
 }
 
-function emitSuccess(
+async function emitSuccess(
   stored: PendingCredits,
   txSignature: string | undefined,
   options: CreditsOptions,
-): void {
+): Promise<void> {
+  // Backfill txSignature from the backend for browser-pay flows where the
+  // SDK never saw the on-chain signature.
+  let resolvedTxSignature = txSignature;
+  if (!resolvedTxSignature) {
+    try {
+      const intent = await getPaymentIntent(stored.jwt, stored.paymentIntentId);
+      resolvedTxSignature = intent.txSignature;
+    } catch {
+      // Best-effort.
+    }
+  }
+
   if (options.json) {
     outputJson({
       status: "SUCCESS",
       projectId: stored.projectId,
       qty: stored.qty,
       paymentIntentId: stored.paymentIntentId,
-      txSignature: txSignature ?? null,
+      txSignature: resolvedTxSignature ?? null,
     });
     return;
   }
   console.log("\n" + chalk.green(`Topped up ${(stored.qty * 1_000_000).toLocaleString()} credits!`));
-  if (txSignature) {
-    console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
+  if (resolvedTxSignature) {
+    console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${resolvedTxSignature}`)}`);
   }
 }
 

--- a/helius-cli/src/commands/keygen.ts
+++ b/helius-cli/src/commands/keygen.ts
@@ -62,7 +62,7 @@ export async function keygenCommand(options: KeygenOptions = {}): Promise<void> 
     console.log(chalk.yellow("To use this wallet, fund it with:"));
     console.log(`  - ${chalk.cyan("~0.001 SOL")} for transaction fees`);
     console.log(`  - USDC for your chosen plan:`);
-    console.log(`      ${"basic".padEnd(15)}${chalk.cyan("$1")} (one-time)`);
+    console.log(`      ${"agent".padEnd(15)}${chalk.cyan("$10")} (one-time)`);
     for (const [key, plan] of Object.entries(PLAN_CATALOG)) {
       const price = `$${plan.monthlyPrice / 100}`;
       console.log(`      ${key.padEnd(15)}${chalk.cyan(price)}/mo`);

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
-import { signup } from "../lib/api.js";
+import { walletSignup } from "../lib/api.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
 import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
@@ -31,7 +31,7 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
 
     // Call login API
     spinner?.start("Authenticating...");
-    const authResult = await signup(message, signature, walletAddress);
+    const authResult = await walletSignup(message, signature, walletAddress);
     setJwt(authResult.token);
     spinner?.succeed("Authenticated");
 

--- a/helius-cli/src/commands/pay.test.ts
+++ b/helius-cli/src/commands/pay.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPayRenewal = vi.fn();
+const mockPayPaymentLink = vi.fn();
+const mockGetPaymentStatus = vi.fn();
+const mockWalletSignup = vi.fn();
+
+vi.mock("../lib/api.js", () => ({
+  walletSignup: (...args: unknown[]) => mockWalletSignup(...args),
+  getPaymentStatus: (...args: unknown[]) => mockGetPaymentStatus(...args),
+  payPaymentLink: (...args: unknown[]) => mockPayPaymentLink(...args),
+  payRenewal: (...args: unknown[]) => mockPayRenewal(...args),
+}));
+
+const mockSetJwt = vi.fn();
+vi.mock("../lib/config.js", () => ({
+  setJwt: (...args: unknown[]) => mockSetJwt(...args),
+  SHARED_CONFIG_PATH: "/tmp/test-config.json",
+}));
+
+const mockKeypairExists = vi.fn();
+vi.mock("./keygen.js", () => ({
+  keypairExists: (...args: unknown[]) => mockKeypairExists(...args),
+}));
+
+const mockLoadKeypair = vi.fn();
+const mockGetAddress = vi.fn();
+const mockSignAuthMessage = vi.fn();
+vi.mock("../lib/wallet.js", () => ({
+  loadKeypairFromFile: (...args: unknown[]) => mockLoadKeypair(...args),
+  getAddress: (...args: unknown[]) => mockGetAddress(...args),
+  signAuthMessage: (...args: unknown[]) => mockSignAuthMessage(...args),
+}));
+
+const mockCheckSolBalance = vi.fn();
+const mockCheckUsdcBalance = vi.fn();
+vi.mock("../lib/payment.js", () => ({
+  checkSolBalance: (...args: unknown[]) => mockCheckSolBalance(...args),
+  checkUsdcBalance: (...args: unknown[]) => mockCheckUsdcBalance(...args),
+}));
+
+vi.mock("../lib/feedback.js", () => ({
+  sendCommandEvent: vi.fn(),
+  getCurrentCommand: () => "pay",
+}));
+
+import { payCommand } from "./pay.js";
+
+interface CapturedJson {
+  ok: boolean;
+  data?: any;
+  error?: any;
+}
+
+function captureStdout(fn: () => Promise<void>) {
+  const chunks: string[] = [];
+  let exitCode: number | null = null;
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    chunks.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n");
+  });
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code: any) => {
+    exitCode = typeof code === "number" ? code : 0;
+    throw new Error("__test_exit__");
+  }) as never);
+
+  return fn()
+    .catch((e) => {
+      if (e instanceof Error && e.message === "__test_exit__") return;
+      throw e;
+    })
+    .finally(() => {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    })
+    .then(() => {
+      const raw = chunks.join("");
+      const trimmed = raw.trim();
+      let json: CapturedJson | null = null;
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed && "ok" in parsed) json = parsed;
+      } catch {
+        /* ignore */
+      }
+      return { json, raw, exitCode };
+    });
+}
+
+const baseOpts = {
+  keypair: "/tmp/keypair.json",
+  json: true,
+};
+
+const renewalLink = {
+  kind: "payment_required" as const,
+  paymentIntentId: "pi_renew",
+  amountCents: 4900,
+  destinationWallet: "Treasury",
+  memo: "pi_renew",
+  expiresAt: new Date(Date.now() + 1_800_000).toISOString(),
+  paymentUrl: "https://dashboard.helius.dev/pay/pi_renew",
+  solanaPayUrl: "solana:...",
+  planName: "Subscription renewal",
+};
+
+describe("pay command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKeypairExists.mockReturnValue(true);
+    mockLoadKeypair.mockResolvedValue({ secretKey: new Uint8Array(64) });
+    mockGetAddress.mockResolvedValue("Wallet111");
+    mockSignAuthMessage.mockResolvedValue({ message: "m", signature: "s" });
+    mockWalletSignup.mockResolvedValue({ token: "jwt-1", refId: "r", newUser: false });
+    mockCheckSolBalance.mockResolvedValue(2_000_000n);
+    mockCheckUsdcBalance.mockResolvedValue(99_900_000_000n);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("default link mode prints the renewal payment URL", async () => {
+    mockPayRenewal.mockResolvedValue({ kind: "payment_required", paymentLink: renewalLink });
+    const { json } = await captureStdout(() => payCommand("pi_renew", baseOpts));
+    expect(json?.data.status).toBe("PAYMENT_REQUIRED");
+    expect(json?.data.paymentUrl).toBe(renewalLink.paymentUrl);
+    expect(json?.data.amountCents).toBe(4900);
+    expect(mockPayPaymentLink).not.toHaveBeenCalled();
+  });
+
+  it("--pay sends USDC then polls for completion", async () => {
+    mockPayRenewal.mockResolvedValue({ kind: "payment_required", paymentLink: renewalLink });
+    mockPayPaymentLink.mockResolvedValue({ txSignature: "tx-renew" });
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+
+    const { json } = await captureStdout(() =>
+      payCommand("pi_renew", { ...baseOpts, pay: true } as any),
+    );
+    expect(json?.data.status).toBe("SUCCESS");
+    expect(json?.data.txSignature).toBe("tx-renew");
+    expect(mockPayPaymentLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("--resume polls existing intent and surfaces SUCCESS", async () => {
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+
+    const { json } = await captureStdout(() =>
+      payCommand("pi_renew", { ...baseOpts, resume: true } as any),
+    );
+    expect(json?.data.status).toBe("SUCCESS");
+    expect(mockPayPaymentLink).not.toHaveBeenCalled();
+  });
+
+  it("--resume returns FAILED when backend reports failed", async () => {
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "failed",
+      phase: "failed",
+      subscriptionActive: false,
+      readyToRedirect: false,
+      message: "boom",
+    });
+    const { json } = await captureStdout(() =>
+      payCommand("pi_renew", { ...baseOpts, resume: true } as any),
+    );
+    expect(json?.data.status).toBe("FAILED");
+  });
+});

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -1,108 +1,289 @@
 import chalk from "chalk";
-import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
-import { walletSignup } from "../lib/api.js";
-import { getPaymentIntent, executeRenewal } from "../lib/checkout.js";
+import {
+  loadKeypairFromFile,
+  signAuthMessage,
+  getAddress,
+} from "../lib/wallet.js";
+import {
+  walletSignup,
+  payRenewal as sdkPayRenewal,
+  payPaymentLink,
+  getPaymentStatus,
+} from "../lib/api.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
-import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, isAgent, createSpinner, confirm, type OutputOptions } from "../lib/output.js";
+import {
+  outputJson,
+  exitWithError,
+  ExitCode,
+  handleCommandError,
+  createSpinner,
+  type OutputOptions,
+} from "../lib/output.js";
+import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
 
 interface PayOptions extends OutputOptions {
   keypair: string;
-  yes?: boolean;
+  pay?: boolean;
+  resume?: boolean;
 }
 
-export async function payCommand(paymentIntentId: string, options: PayOptions): Promise<void> {
+const CENTS_TO_USDC_RAW = 10_000n;
+const SOL_FEE_THRESHOLD = 1_000_000n;
+const TX_EXPLORER = "https://orbmarkets.io/tx";
+
+/**
+ * Phase 2 — `helius pay <paymentIntentId>` for renewal flows.
+ *
+ * Modes:
+ *   - default (link): print the renewal payment URL, exit. User opens it
+ *     in a browser or sends USDC + memo manually.
+ *   - --pay: autopay USDC + memo from the local keypair, poll, surface
+ *     SUCCESS / PENDING.
+ *   - --resume: poll the existing intent, no USDC send.
+ *
+ * Renewals don't have a webhook activation gate (the subscription is
+ * already active), so `readyToRedirect` flips on payment confirmation alone.
+ */
+export async function payCommand(
+  paymentIntentId: string,
+  options: PayOptions,
+): Promise<void> {
   const spinner = createSpinner(options);
 
   try {
-    // Check keypair exists
+    // Always need a JWT to fetch the renewal intent + poll status.
     if (!keypairExists(options.keypair)) {
-      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, !!options.json);
+      exitWithError(
+        "KEYPAIR_NOT_FOUND",
+        `Keypair not found at ${options.keypair}`,
+        undefined,
+        !!options.json,
+      );
     }
-
-    // 1. Load keypair and authenticate
     spinner?.start("Loading keypair...");
     const keypair = await loadKeypairFromFile(options.keypair);
     const walletAddress = await getAddress(keypair);
-    spinner?.succeed(`Wallet: ${chalk.cyan(walletAddress)}`);
+    spinner?.succeed(`Wallet: ${walletAddress}`);
 
     spinner?.start("Authenticating...");
     const { message, signature } = await signAuthMessage(keypair.secretKey);
-    const authResult = await walletSignup(message, signature, walletAddress);
-    setJwt(authResult.token);
+    const auth = await walletSignup(message, signature, walletAddress);
+    setJwt(auth.token);
     spinner?.succeed("Authenticated");
 
-    // 2. Fetch payment intent details
-    spinner?.start("Fetching payment intent...");
-    const intent = await getPaymentIntent(authResult.token, paymentIntentId);
-    spinner?.succeed("Payment intent loaded");
-
-    const amountUsdc = intent.amount / 100;
-    const expiresAt = new Date(intent.expiresAt).toLocaleString();
-
-    if (!options.json) {
-      console.log("");
-      console.log(`  Payment ID:  ${chalk.cyan(intent.id)}`);
-      console.log(`  Amount:      ${chalk.bold(`$${amountUsdc.toFixed(2)} USDC`)}`);
-      console.log(`  Status:      ${formatEnumLabel(intent.status)}`);
-      console.log(`  Expires:     ${expiresAt}`);
-      console.log("");
+    if (options.resume) {
+      await pollAndEmit(auth.token, paymentIntentId, undefined, options, spinner);
+      return;
     }
 
-    if (intent.status !== "pending") {
-      exitWithError("PAYMENT_FAILED", `Payment intent is ${intent.status}, cannot pay`, { intentId: intent.id }, !!options.json);
-    }
-
-    if (!options.yes) {
-      if (isAgent) {
-        outputJson({
-          action: "preview",
-          paymentIntentId: intent.id,
-          amount: intent.amount,
-          amountUsdc,
-          status: intent.status,
-          expiresAt: intent.expiresAt,
-        });
-        return;
-      }
-      const ok = await confirm(`  Pay $${amountUsdc.toFixed(2)} USDC? (y/N) `);
-      if (!ok) {
-        console.log(chalk.gray("  Cancelled."));
-        return;
-      }
-    }
-
-    // 3. Execute renewal payment
-    spinner?.start("Processing payment...");
-    const result = await executeRenewal(
-      keypair.secretKey,
-      authResult.token,
-      paymentIntentId,
-    );
-
-    if (result.status !== "completed") {
-      throw new Error(
-        `Payment ${result.status}${result.txSignature ? `. TX: ${result.txSignature}` : ""}`
+    if (options.pay) {
+      await runPay(
+        auth.token,
+        paymentIntentId,
+        keypair.secretKey,
+        walletAddress,
+        options,
+        spinner,
       );
+      return;
     }
-    spinner?.succeed("Payment complete");
+
+    // Default: print the renewal link.
+    spinner?.start("Fetching renewal payment intent...");
+    const result = await sdkPayRenewal(auth.token, paymentIntentId);
+    spinner?.succeed("Renewal link ready");
 
     if (options.json) {
       outputJson({
-        status: "SUCCESS",
-        paymentIntentId: intent.id,
-        amount: intent.amount,
-        transaction: result.txSignature,
+        status: "PAYMENT_REQUIRED",
+        paymentUrl: result.paymentLink.paymentUrl,
+        paymentIntentId: result.paymentLink.paymentIntentId,
+        expiresAt: result.paymentLink.expiresAt,
+        amountCents: result.paymentLink.amountCents,
+        planName: result.paymentLink.planName,
+        destinationWallet: result.paymentLink.destinationWallet,
+        memo: result.paymentLink.memo,
+        solanaPayUrl: result.paymentLink.solanaPayUrl,
       });
       return;
     }
 
-    console.log("\n" + chalk.green("✓ Payment complete!"));
-    if (result.txSignature) {
-      console.log(`\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`);
-    }
+    console.log();
+    console.log(
+      chalk.bold(
+        `Pay ${result.paymentLink.amountCents / 100} USDC to renew your subscription:`,
+      ),
+    );
+    console.log();
+    console.log(`  ${chalk.cyan(result.paymentLink.paymentUrl)}`);
+    console.log();
+    console.log(chalk.gray("Or send USDC directly to:"));
+    console.log(chalk.gray(`  Treasury: ${result.paymentLink.destinationWallet}`));
+    console.log(chalk.gray(`  Memo:     ${result.paymentLink.memo}`));
+    console.log();
+    console.log(
+      chalk.gray(
+        `Once paid, run \`helius pay ${paymentIntentId} --resume\` to confirm locally.`,
+      ),
+    );
   } catch (error) {
     handleCommandError(error, options, spinner, "PAYMENT_FAILED");
   }
+}
+
+async function runPay(
+  jwt: string,
+  paymentIntentId: string,
+  secretKey: Uint8Array,
+  walletAddress: string,
+  options: PayOptions,
+  spinner: ReturnType<typeof createSpinner>,
+): Promise<void> {
+  spinner?.start("Fetching renewal intent...");
+  const result = await sdkPayRenewal(jwt, paymentIntentId);
+  const link = result.paymentLink;
+  spinner?.succeed(`Renewal: ${link.amountCents / 100} USDC`);
+
+  // Pre-flight balance check.
+  spinner?.start("Checking wallet balance...");
+  const sol = await checkSolBalance(walletAddress);
+  const usdc = await checkUsdcBalance(walletAddress);
+  const required = BigInt(link.amountCents) * CENTS_TO_USDC_RAW;
+  if (sol < SOL_FEE_THRESHOLD) {
+    spinner?.fail("Insufficient SOL for fees");
+    exitWithError(
+      "INSUFFICIENT_SOL",
+      `Wallet ${walletAddress} needs ~0.001 SOL (have ${(Number(sol) / 1e9).toFixed(6)}).`,
+      undefined,
+      !!options.json,
+    );
+  }
+  if (usdc < required) {
+    spinner?.fail("Insufficient USDC");
+    exitWithError(
+      "INSUFFICIENT_USDC",
+      `Wallet ${walletAddress} needs ${link.amountCents / 100} USDC (have ${(Number(usdc) / 1e6).toFixed(2)}).`,
+      undefined,
+      !!options.json,
+    );
+  }
+  spinner?.succeed("Balance OK");
+
+  spinner?.start(`Sending ${link.amountCents / 100} USDC + memo...`);
+  const { txSignature } = await payPaymentLink(secretKey, link);
+  spinner?.succeed(`Sent: ${txSignature}`);
+
+  await pollAndEmit(jwt, paymentIntentId, txSignature, options, spinner);
+}
+
+async function pollAndEmit(
+  jwt: string,
+  paymentIntentId: string,
+  txSignature: string | undefined,
+  options: PayOptions,
+  spinner: ReturnType<typeof createSpinner>,
+): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  spinner?.start("Confirming payment...");
+
+  while (Date.now() < deadline) {
+    let status;
+    try {
+      status = await getPaymentStatus(jwt, paymentIntentId);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("410")) {
+        emitExpired(paymentIntentId, options);
+        return;
+      }
+      throw error;
+    }
+    if (status.readyToRedirect) {
+      spinner?.succeed("Renewal complete");
+      emitSuccess(paymentIntentId, txSignature, options);
+      return;
+    }
+    if (status.phase === "failed") {
+      emitFailed(paymentIntentId, status.message, options);
+      return;
+    }
+    if (status.phase === "expired") {
+      emitExpired(paymentIntentId, options);
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 1_000));
+  }
+
+  spinner?.warn("Polling timed out");
+  emitPending(paymentIntentId, txSignature, options);
+}
+
+function emitSuccess(
+  paymentIntentId: string,
+  txSignature: string | undefined,
+  options: PayOptions,
+): void {
+  if (options.json) {
+    outputJson({
+      status: "SUCCESS",
+      paymentIntentId,
+      txSignature: txSignature ?? null,
+    });
+    return;
+  }
+  console.log("\n" + chalk.green("Renewal payment complete!"));
+  if (txSignature) {
+    console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
+  }
+}
+
+function emitPending(
+  paymentIntentId: string,
+  txSignature: string | undefined,
+  options: PayOptions,
+): void {
+  if (options.json) {
+    outputJson({
+      status: "PENDING",
+      paymentIntentId,
+      ...(txSignature && { txSignature }),
+    });
+    return;
+  }
+  console.log("\n" + chalk.yellow("Payment is still being confirmed."));
+  if (txSignature) {
+    console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
+  }
+  console.log(
+    chalk.gray(
+      `\nRun \`helius pay ${paymentIntentId} --resume\` again in a moment.`,
+    ),
+  );
+}
+
+function emitExpired(paymentIntentId: string, options: PayOptions): void {
+  if (options.json) {
+    outputJson({ status: "EXPIRED", paymentIntentId });
+    return;
+  }
+  console.error("\n" + chalk.red("Payment intent expired."));
+  process.exit(ExitCode.GENERAL_ERROR);
+}
+
+function emitFailed(
+  paymentIntentId: string,
+  reason: string | undefined,
+  options: PayOptions,
+): void {
+  if (options.json) {
+    outputJson({
+      status: "FAILED",
+      paymentIntentId,
+      ...(reason && { reason }),
+    });
+    return;
+  }
+  console.error("\n" + chalk.red("Payment failed."));
+  if (reason) console.error(chalk.gray(reason));
+  process.exit(ExitCode.GENERAL_ERROR);
 }

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
-import { signup } from "../lib/api.js";
+import { walletSignup } from "../lib/api.js";
 import { getPaymentIntent, executeRenewal } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
@@ -29,7 +29,7 @@ export async function payCommand(paymentIntentId: string, options: PayOptions): 
 
     spinner?.start("Authenticating...");
     const { message, signature } = await signAuthMessage(keypair.secretKey);
-    const authResult = await signup(message, signature, walletAddress);
+    const authResult = await walletSignup(message, signature, walletAddress);
     setJwt(authResult.token);
     spinner?.succeed("Authenticated");
 

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -95,6 +95,23 @@ export async function payCommand(
     const result = await sdkPayRenewal(auth.token, paymentIntentId);
     spinner?.succeed("Renewal link ready");
 
+    // Defensive narrowing: today PayRenewalResult is a single-variant union
+    // (kind: "payment_required"). The exhaustive default keeps this correct
+    // if the SDK adds new variants without forcing a TS error today.
+    switch (result.kind) {
+      case "payment_required":
+        break;
+      default: {
+        const _exhaustive: never = result.kind;
+        exitWithError(
+          "API_ERROR",
+          `Unexpected payRenewal result kind: ${String(_exhaustive)}`,
+          undefined,
+          !!options.json,
+        );
+      }
+    }
+
     if (options.json) {
       outputJson({
         status: "PAYMENT_REQUIRED",
@@ -143,6 +160,19 @@ async function runPay(
 ): Promise<void> {
   spinner?.start("Fetching renewal intent...");
   const result = await sdkPayRenewal(jwt, paymentIntentId);
+  switch (result.kind) {
+    case "payment_required":
+      break;
+    default: {
+      const _exhaustive: never = result.kind;
+      exitWithError(
+        "API_ERROR",
+        `Unexpected payRenewal result kind: ${String(_exhaustive)}`,
+        undefined,
+        !!options.json,
+      );
+    }
+  }
   const link = result.paymentLink;
   spinner?.succeed(`Renewal: ${link.amountCents / 100} USDC`);
 

--- a/helius-cli/src/commands/pay.ts
+++ b/helius-cli/src/commands/pay.ts
@@ -9,6 +9,7 @@ import {
   payRenewal as sdkPayRenewal,
   payPaymentLink,
   getPaymentStatus,
+  getPaymentIntent,
 } from "../lib/api.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists } from "./keygen.js";
@@ -200,7 +201,7 @@ async function pollAndEmit(
     }
     if (status.readyToRedirect) {
       spinner?.succeed("Renewal complete");
-      emitSuccess(paymentIntentId, txSignature, options);
+      await emitSuccess(jwt, paymentIntentId, txSignature, options);
       return;
     }
     if (status.phase === "failed") {
@@ -218,22 +219,35 @@ async function pollAndEmit(
   emitPending(paymentIntentId, txSignature, options);
 }
 
-function emitSuccess(
+async function emitSuccess(
+  jwt: string,
   paymentIntentId: string,
   txSignature: string | undefined,
   options: PayOptions,
-): void {
+): Promise<void> {
+  // Backfill txSignature from the backend for browser-pay flows where the
+  // SDK never saw the on-chain signature.
+  let resolvedTxSignature = txSignature;
+  if (!resolvedTxSignature) {
+    try {
+      const intent = await getPaymentIntent(jwt, paymentIntentId);
+      resolvedTxSignature = intent.txSignature;
+    } catch {
+      // Best-effort.
+    }
+  }
+
   if (options.json) {
     outputJson({
       status: "SUCCESS",
       paymentIntentId,
-      txSignature: txSignature ?? null,
+      txSignature: resolvedTxSignature ?? null,
     });
     return;
   }
   console.log("\n" + chalk.green("Renewal payment complete!"));
-  if (txSignature) {
-    console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
+  if (resolvedTxSignature) {
+    console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${resolvedTxSignature}`)}`);
   }
 }
 

--- a/helius-cli/src/commands/signup.test.ts
+++ b/helius-cli/src/commands/signup.test.ts
@@ -55,10 +55,19 @@ vi.mock("../lib/wallet.js", () => ({
 
 const mockCheckSolBalance = vi.fn();
 const mockCheckUsdcBalance = vi.fn();
-vi.mock("../lib/payment.js", () => ({
-  checkSolBalance: (...args: unknown[]) => mockCheckSolBalance(...args),
-  checkUsdcBalance: (...args: unknown[]) => mockCheckUsdcBalance(...args),
-}));
+// Keep the real `checkBackendForRefresh` — it delegates to `getPaymentStatus`
+// (mocked above via api.js), so the expired-pending tests still assert against
+// `mockGetPaymentStatus`. Only the balance helpers are stubbed.
+vi.mock("../lib/payment.js", async () => {
+  const actual = await vi.importActual<typeof import("../lib/payment.js")>(
+    "../lib/payment.js",
+  );
+  return {
+    ...actual,
+    checkSolBalance: (...args: unknown[]) => mockCheckSolBalance(...args),
+    checkUsdcBalance: (...args: unknown[]) => mockCheckUsdcBalance(...args),
+  };
+});
 
 vi.mock("../lib/feedback.js", () => ({
   sendDiscoveryEvent: vi.fn(),

--- a/helius-cli/src/commands/signup.test.ts
+++ b/helius-cli/src/commands/signup.test.ts
@@ -1,0 +1,646 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocked dependencies ──────────────────────────────────────────────────
+
+const mockSignup = vi.fn();
+const mockPayPaymentLink = vi.fn();
+const mockGetPaymentStatus = vi.fn();
+const mockListProjects = vi.fn();
+const mockGetProject = vi.fn();
+const mockCreateApiKey = vi.fn();
+
+vi.mock("../lib/api.js", () => ({
+  signup: (...args: unknown[]) => mockSignup(...args),
+  payPaymentLink: (...args: unknown[]) => mockPayPaymentLink(...args),
+  getPaymentStatus: (...args: unknown[]) => mockGetPaymentStatus(...args),
+  listProjects: (...args: unknown[]) => mockListProjects(...args),
+  getProject: (...args: unknown[]) => mockGetProject(...args),
+  createApiKey: (...args: unknown[]) => mockCreateApiKey(...args),
+}));
+
+const mockSetJwt = vi.fn();
+const mockSetApiKey = vi.fn();
+const mockSetSharedApiKey = vi.fn();
+const mockSetProjectId = vi.fn();
+const mockGetPendingSignup = vi.fn();
+const mockSetPendingSignup = vi.fn();
+const mockUpdatePendingSignup = vi.fn();
+const mockClearPendingSignup = vi.fn();
+
+vi.mock("../lib/config.js", () => ({
+  setJwt: (...args: unknown[]) => mockSetJwt(...args),
+  setApiKey: (...args: unknown[]) => mockSetApiKey(...args),
+  setSharedApiKey: (...args: unknown[]) => mockSetSharedApiKey(...args),
+  setProjectId: (...args: unknown[]) => mockSetProjectId(...args),
+  getPendingSignup: () => mockGetPendingSignup(),
+  setPendingSignup: (...args: unknown[]) => mockSetPendingSignup(...args),
+  updatePendingSignup: (...args: unknown[]) => mockUpdatePendingSignup(...args),
+  clearPendingSignup: () => mockClearPendingSignup(),
+  SHARED_CONFIG_PATH: "/tmp/test-config.json",
+}));
+
+const mockKeypairExists = vi.fn();
+const mockKeygenCommand = vi.fn();
+vi.mock("./keygen.js", () => ({
+  keypairExists: (...args: unknown[]) => mockKeypairExists(...args),
+  keygenCommand: (...args: unknown[]) => mockKeygenCommand(...args),
+}));
+
+const mockLoadKeypair = vi.fn();
+const mockGetAddress = vi.fn();
+vi.mock("../lib/wallet.js", () => ({
+  loadKeypairFromFile: (...args: unknown[]) => mockLoadKeypair(...args),
+  getAddress: (...args: unknown[]) => mockGetAddress(...args),
+}));
+
+const mockCheckSolBalance = vi.fn();
+const mockCheckUsdcBalance = vi.fn();
+vi.mock("../lib/payment.js", () => ({
+  checkSolBalance: (...args: unknown[]) => mockCheckSolBalance(...args),
+  checkUsdcBalance: (...args: unknown[]) => mockCheckUsdcBalance(...args),
+}));
+
+vi.mock("../lib/feedback.js", () => ({
+  sendDiscoveryEvent: vi.fn(),
+  sendCommandEvent: vi.fn(),
+  getCurrentCommand: () => "signup",
+}));
+
+// ── Imports under test (must come AFTER vi.mock calls) ──
+
+import { signupCommand } from "./signup.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+interface CapturedJson {
+  ok: boolean;
+  v?: number;
+  data?: any;
+  error?: any;
+}
+
+function captureStdout(fn: () => Promise<void>): Promise<{
+  json: CapturedJson | null;
+  raw: string;
+  exitCode: number | null;
+}> {
+  const chunks: string[] = [];
+  let exitCode: number | null = null;
+
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    chunks.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n");
+  });
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code: any) => {
+    exitCode = typeof code === "number" ? code : 0;
+    throw new Error("__test_exit__");
+  }) as never);
+
+  return fn()
+    .catch((e) => {
+      if (e instanceof Error && e.message === "__test_exit__") return;
+      throw e;
+    })
+    .finally(() => {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    })
+    .then(() => {
+      const raw = chunks.join("");
+      // Envelope JSON is pretty-printed across multiple lines. Find the LAST
+      // balanced JSON object that contains an "ok" key by scanning the raw
+      // stream for `{`...`}` pairs.
+      let json: CapturedJson | null = null;
+      const tryParse = (text: string): CapturedJson | null => {
+        try {
+          const parsed = JSON.parse(text);
+          return parsed && typeof parsed === "object" && "ok" in parsed
+            ? parsed
+            : null;
+        } catch {
+          return null;
+        }
+      };
+      // Try the entire trimmed buffer first.
+      const trimmed = raw.trim();
+      json = tryParse(trimmed);
+      if (!json) {
+        // Fall back: find balanced top-level objects, prefer the FIRST
+        // envelope (a `process.exit` mock that throws can cause a second,
+        // spurious envelope from handleCommandError catching the throw).
+        let depth = 0;
+        let start = -1;
+        const candidates: string[] = [];
+        for (let i = 0; i < trimmed.length; i++) {
+          if (trimmed[i] === "{") {
+            if (depth === 0) start = i;
+            depth++;
+          } else if (trimmed[i] === "}") {
+            depth--;
+            if (depth === 0 && start >= 0) {
+              candidates.push(trimmed.slice(start, i + 1));
+              start = -1;
+            }
+          }
+        }
+        for (const c of candidates) {
+          const parsed = tryParse(c);
+          if (parsed) {
+            json = parsed;
+            break;
+          }
+        }
+      }
+      return { json, raw, exitCode };
+    });
+}
+
+const baseOpts = {
+  keypair: "/tmp/test-keypair.json",
+  json: true,
+  email: "a@b.com",
+  firstName: "A",
+  lastName: "B",
+};
+
+const samplePending = {
+  paymentIntentId: "pi_abc",
+  paymentUrl: "https://dashboard.helius.dev/pay/pi_abc",
+  planName: "Agent Plan",
+  amountCents: 1000,
+  destinationWallet: "Treasury111",
+  solanaPayUrl: "solana:Treasury111?amount=10",
+  memo: "pi_abc",
+  expiresAt: new Date(Date.now() + 1_800_000).toISOString(),
+  walletAddress: "Wallet111",
+  refId: "ref-1",
+  jwt: "jwt-1",
+  createdAt: new Date().toISOString(),
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("signup command — JSON output shapes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKeypairExists.mockReturnValue(true);
+    mockLoadKeypair.mockResolvedValue({
+      publicKey: new Uint8Array(32),
+      secretKey: new Uint8Array(64),
+    });
+    mockGetAddress.mockResolvedValue("Wallet111");
+    mockCheckSolBalance.mockResolvedValue(2_000_000n);
+    mockCheckUsdcBalance.mockResolvedValue(20_000_000n);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("PAYMENT_REQUIRED for fresh signup (default link mode)", async () => {
+    mockGetPendingSignup.mockReturnValue(undefined);
+    mockSignup.mockResolvedValue({
+      kind: "payment_required",
+      jwt: "jwt-1",
+      refId: "ref-1",
+      walletAddress: "Wallet111",
+      paymentLink: {
+        kind: "payment_required",
+        paymentIntentId: "pi_abc",
+        amountCents: 1000,
+        destinationWallet: "Treasury111",
+        memo: "pi_abc",
+        expiresAt: samplePending.expiresAt,
+        paymentUrl: samplePending.paymentUrl,
+        solanaPayUrl: samplePending.solanaPayUrl,
+        planName: "Agent Plan",
+      },
+    });
+
+    const { json } = await captureStdout(() => signupCommand({ ...baseOpts }));
+
+    expect(json?.ok).toBe(true);
+    expect(json?.data.status).toBe("PAYMENT_REQUIRED");
+    expect(json?.data.paymentUrl).toBe(samplePending.paymentUrl);
+    expect(json?.data.destinationWallet).toBe("Treasury111");
+    expect(json?.data.memo).toBe("pi_abc");
+    expect(json?.data.amountCents).toBe(1000);
+    expect(json?.data.reused).toBeUndefined();
+    expect(mockSetPendingSignup).toHaveBeenCalledTimes(1);
+  });
+
+  it("PAYMENT_REQUIRED with reused:true on second invocation (pending intent reuse)", async () => {
+    mockGetPendingSignup.mockReturnValue(samplePending);
+
+    const { json } = await captureStdout(() =>
+      signupCommand({ ...baseOpts, email: undefined, firstName: undefined, lastName: undefined } as any),
+    );
+
+    expect(json?.data.status).toBe("PAYMENT_REQUIRED");
+    expect(json?.data.reused).toBe(true);
+    // No new intent created.
+    expect(mockSignup).not.toHaveBeenCalled();
+    expect(mockSetPendingSignup).not.toHaveBeenCalled();
+  });
+
+  it("ALREADY_SUBSCRIBED when wallet has matching project", async () => {
+    mockGetPendingSignup.mockReturnValue(undefined);
+    mockSignup.mockResolvedValue({
+      kind: "already_subscribed",
+      jwt: "jwt-1",
+      refId: "ref-1",
+      walletAddress: "Wallet111",
+      projectId: "proj-1",
+      apiKey: "key-1",
+      endpoints: {
+        mainnet: "https://mainnet.helius-rpc.com/?api-key=key-1",
+        devnet: "https://devnet.helius-rpc.com/?api-key=key-1",
+      },
+    });
+
+    const { json } = await captureStdout(() => signupCommand({ ...baseOpts }));
+
+    expect(json?.data.status).toBe("ALREADY_SUBSCRIBED");
+    expect(json?.data.apiKey).toBe("key-1");
+    expect(mockSetApiKey).toHaveBeenCalledWith("key-1");
+  });
+
+  it("UPGRADE_REQUIRED when wallet is on a different plan", async () => {
+    mockGetPendingSignup.mockReturnValue(undefined);
+    mockSignup.mockResolvedValue({
+      kind: "upgrade_required",
+      jwt: "jwt-1",
+      refId: "ref-1",
+      walletAddress: "Wallet111",
+      currentPlan: "developer_v4",
+      requestedPlan: "agent",
+    });
+
+    const { json, exitCode } = await captureStdout(() => signupCommand({ ...baseOpts }));
+
+    expect(json?.data.status).toBe("UPGRADE_REQUIRED");
+    expect(json?.data.currentPlan).toBe("developer_v4");
+    // emitUpgradeRequired calls process.exit only in non-JSON mode; JSON mode just returns.
+    expect(exitCode).toBeNull();
+  });
+
+  it("MISSING_PENDING_INTENT when --resume is passed with no stored intent", async () => {
+    mockGetPendingSignup.mockReturnValue(undefined);
+
+    const { json } = await captureStdout(() =>
+      signupCommand({ ...baseOpts, resume: true } as any),
+    );
+
+    expect(json?.data.status).toBe("MISSING_PENDING_INTENT");
+    expect(mockLoadKeypair).not.toHaveBeenCalled();
+  });
+});
+
+describe("signup command — --pay idempotency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKeypairExists.mockReturnValue(true);
+    mockLoadKeypair.mockResolvedValue({
+      publicKey: new Uint8Array(32),
+      secretKey: new Uint8Array(64),
+    });
+    mockGetAddress.mockResolvedValue("Wallet111");
+    mockCheckSolBalance.mockResolvedValue(2_000_000n);
+    mockCheckUsdcBalance.mockResolvedValue(20_000_000n);
+  });
+
+  it("--pay with stored txSignature does NOT re-send USDC", async () => {
+    mockGetPendingSignup.mockReturnValue({ ...samplePending, txSignature: "tx-already-sent" });
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    mockListProjects.mockResolvedValue([{ id: "proj-1" }]);
+    mockGetProject.mockResolvedValue({ apiKeys: [{ keyId: "key-1" }] });
+
+    await captureStdout(() =>
+      signupCommand({
+        ...baseOpts,
+        email: undefined,
+        firstName: undefined,
+        lastName: undefined,
+        pay: true,
+      } as any),
+    );
+
+    expect(mockPayPaymentLink).not.toHaveBeenCalled();
+    expect(mockClearPendingSignup).toHaveBeenCalledTimes(1);
+  });
+
+  it("--pay with completed && !readyToRedirect does NOT re-send USDC, keeps polling", async () => {
+    mockGetPendingSignup.mockReturnValue(samplePending); // no txSignature
+    mockGetPaymentStatus
+      .mockResolvedValueOnce({
+        status: "completed",
+        phase: "activating",
+        subscriptionActive: false,
+        readyToRedirect: false,
+        message: "activating",
+      })
+      .mockResolvedValueOnce({
+        status: "completed",
+        phase: "complete",
+        subscriptionActive: true,
+        readyToRedirect: true,
+        message: "ok",
+      });
+    mockListProjects.mockResolvedValue([{ id: "proj-1" }]);
+    mockGetProject.mockResolvedValue({ apiKeys: [{ keyId: "key-1" }] });
+
+    await captureStdout(() =>
+      signupCommand({
+        ...baseOpts,
+        email: undefined,
+        firstName: undefined,
+        lastName: undefined,
+        pay: true,
+      } as any),
+    );
+
+    expect(mockPayPaymentLink).not.toHaveBeenCalled();
+  });
+
+  it("--pay with status pending DOES send USDC and stores txSignature", async () => {
+    mockGetPendingSignup.mockReturnValue(samplePending);
+    mockGetPaymentStatus
+      .mockResolvedValueOnce({
+        status: "pending",
+        phase: "confirming",
+        subscriptionActive: false,
+        readyToRedirect: false,
+        message: "",
+      })
+      .mockResolvedValueOnce({
+        status: "completed",
+        phase: "complete",
+        subscriptionActive: true,
+        readyToRedirect: true,
+        message: "ok",
+      });
+    mockPayPaymentLink.mockResolvedValue({ txSignature: "tx-fresh" });
+    mockListProjects.mockResolvedValue([{ id: "proj-1" }]);
+    mockGetProject.mockResolvedValue({ apiKeys: [{ keyId: "key-1" }] });
+
+    await captureStdout(() =>
+      signupCommand({
+        ...baseOpts,
+        email: undefined,
+        firstName: undefined,
+        lastName: undefined,
+        pay: true,
+      } as any),
+    );
+
+    expect(mockPayPaymentLink).toHaveBeenCalledTimes(1);
+    expect(mockUpdatePendingSignup).toHaveBeenCalledWith({ txSignature: "tx-fresh" });
+  });
+});
+
+describe("signup command — --restart and --resume", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKeypairExists.mockReturnValue(true);
+    mockLoadKeypair.mockResolvedValue({
+      publicKey: new Uint8Array(32),
+      secretKey: new Uint8Array(64),
+    });
+    mockGetAddress.mockResolvedValue("Wallet111");
+  });
+
+  it("--restart clears stored intent and creates a fresh one", async () => {
+    // First call returns pending, but --restart clears it; subsequent
+    // getPendingSignup() (after clearPendingSignup) should return undefined.
+    let cleared = false;
+    mockClearPendingSignup.mockImplementation(() => {
+      cleared = true;
+    });
+    mockGetPendingSignup.mockImplementation(() =>
+      cleared ? undefined : samplePending,
+    );
+    mockSignup.mockResolvedValue({
+      kind: "payment_required",
+      jwt: "jwt-2",
+      refId: "ref-2",
+      walletAddress: "Wallet111",
+      paymentLink: {
+        kind: "payment_required",
+        paymentIntentId: "pi_new",
+        amountCents: 1000,
+        destinationWallet: "Treasury111",
+        memo: "pi_new",
+        expiresAt: samplePending.expiresAt,
+        paymentUrl: "https://dashboard.helius.dev/pay/pi_new",
+        solanaPayUrl: "solana:...",
+        planName: "Agent Plan",
+      },
+    });
+
+    await captureStdout(() => signupCommand({ ...baseOpts, restart: true } as any));
+
+    expect(mockClearPendingSignup).toHaveBeenCalled();
+    expect(mockSignup).toHaveBeenCalledTimes(1);
+  });
+
+  it("--resume does not load the keypair", async () => {
+    mockGetPendingSignup.mockReturnValue(samplePending);
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    mockListProjects.mockResolvedValue([{ id: "proj-1" }]);
+    mockGetProject.mockResolvedValue({ apiKeys: [{ keyId: "key-1" }] });
+
+    await captureStdout(() => signupCommand({ ...baseOpts, resume: true } as any));
+
+    expect(mockLoadKeypair).not.toHaveBeenCalled();
+    expect(mockGetAddress).not.toHaveBeenCalled();
+  });
+
+  it("--resume returns SUCCESS when activation is ready", async () => {
+    mockGetPendingSignup.mockReturnValue({ ...samplePending, txSignature: "tx-sent" });
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    mockListProjects.mockResolvedValue([{ id: "proj-1" }]);
+    mockGetProject.mockResolvedValue({ apiKeys: [{ keyId: "key-1" }] });
+
+    const { json } = await captureStdout(() =>
+      signupCommand({ ...baseOpts, resume: true } as any),
+    );
+
+    expect(json?.data.status).toBe("SUCCESS");
+    expect(json?.data.apiKey).toBe("key-1");
+    expect(json?.data.txSignature).toBe("tx-sent");
+    expect(mockClearPendingSignup).toHaveBeenCalled();
+  });
+
+  it("--resume after backend says EXPIRED clears stored intent", async () => {
+    mockGetPendingSignup.mockReturnValue(samplePending);
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "expired",
+      phase: "expired",
+      subscriptionActive: false,
+      readyToRedirect: false,
+      message: "expired",
+    });
+
+    const { json } = await captureStdout(() =>
+      signupCommand({ ...baseOpts, resume: true } as any),
+    );
+
+    expect(json?.data.status).toBe("EXPIRED");
+    expect(mockClearPendingSignup).toHaveBeenCalled();
+  });
+
+  it("--resume after backend says FAILED clears stored intent", async () => {
+    mockGetPendingSignup.mockReturnValue(samplePending);
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "failed",
+      phase: "failed",
+      subscriptionActive: false,
+      readyToRedirect: false,
+      message: "boom",
+    });
+
+    const { json } = await captureStdout(() =>
+      signupCommand({ ...baseOpts, resume: true } as any),
+    );
+
+    expect(json?.data.status).toBe("FAILED");
+    expect(json?.data.reason).toBe("boom");
+    expect(mockClearPendingSignup).toHaveBeenCalled();
+  });
+});
+
+describe("signup command — expired-pending in default link mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKeypairExists.mockReturnValue(true);
+    mockLoadKeypair.mockResolvedValue({
+      publicKey: new Uint8Array(32),
+      secretKey: new Uint8Array(64),
+    });
+    mockGetAddress.mockResolvedValue("Wallet111");
+  });
+
+  const expiredStored = {
+    ...samplePending,
+    expiresAt: new Date(Date.now() - 60_000).toISOString(),
+  };
+
+  it("queries backend when local expiresAt is past — backend says pending → reprints link", async () => {
+    mockGetPendingSignup.mockReturnValue(expiredStored);
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "pending",
+      phase: "confirming",
+      subscriptionActive: false,
+      readyToRedirect: false,
+      message: "",
+    });
+
+    const { json } = await captureStdout(() =>
+      signupCommand({ ...baseOpts, email: undefined, firstName: undefined, lastName: undefined } as any),
+    );
+
+    expect(mockGetPaymentStatus).toHaveBeenCalledWith(expiredStored.jwt, expiredStored.paymentIntentId);
+    expect(json?.data.status).toBe("PAYMENT_REQUIRED");
+    expect(json?.data.reused).toBe(true);
+    expect(mockClearPendingSignup).not.toHaveBeenCalled();
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+
+  it("queries backend when local expiresAt is past — backend says expired → clears + restarts fresh", async () => {
+    let cleared = false;
+    mockClearPendingSignup.mockImplementation(() => {
+      cleared = true;
+    });
+    mockGetPendingSignup.mockImplementation(() => (cleared ? undefined : expiredStored));
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "expired",
+      phase: "expired",
+      subscriptionActive: false,
+      readyToRedirect: false,
+      message: "expired",
+    });
+    mockSignup.mockResolvedValue({
+      kind: "payment_required",
+      jwt: "jwt-fresh",
+      refId: "ref-fresh",
+      walletAddress: "Wallet111",
+      paymentLink: {
+        kind: "payment_required",
+        paymentIntentId: "pi_new",
+        amountCents: 1000,
+        destinationWallet: "Treasury111",
+        memo: "pi_new",
+        expiresAt: new Date(Date.now() + 1_800_000).toISOString(),
+        paymentUrl: "https://dashboard.helius.dev/pay/pi_new",
+        solanaPayUrl: "solana:...",
+        planName: "Agent Plan",
+      },
+    });
+
+    const { json } = await captureStdout(() => signupCommand({ ...baseOpts }));
+
+    expect(mockClearPendingSignup).toHaveBeenCalled();
+    expect(mockSignup).toHaveBeenCalledTimes(1);
+    expect(json?.data.paymentIntentId).toBe("pi_new");
+    expect(json?.data.reused).toBeUndefined();
+  });
+
+  it("queries backend when local expiresAt is past — backend says completed → provisions instead of reprinting", async () => {
+    mockGetPendingSignup.mockReturnValue(expiredStored);
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    mockListProjects.mockResolvedValue([{ id: "proj-1" }]);
+    mockGetProject.mockResolvedValue({ apiKeys: [{ keyId: "key-1" }] });
+
+    const { json } = await captureStdout(() =>
+      signupCommand({ ...baseOpts, email: undefined, firstName: undefined, lastName: undefined } as any),
+    );
+
+    expect(json?.data.status).toBe("SUCCESS");
+    expect(mockClearPendingSignup).toHaveBeenCalled();
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+});
+
+describe("signup command — basic plan rejection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKeypairExists.mockReturnValue(true);
+    mockGetPendingSignup.mockReturnValue(undefined);
+  });
+
+  it("rejects --plan basic with a clear message pointing to --plan agent", async () => {
+    const { json } = await captureStdout(() =>
+      signupCommand({ ...baseOpts, plan: "basic" } as any),
+    );
+
+    expect(json?.ok).toBe(false);
+    const msg = (json as any)?.error ?? "";
+    expect(msg.toLowerCase()).toContain("basic");
+    expect(msg).toContain("--plan agent");
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+});

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -533,8 +533,8 @@ async function provisionAndEmit(
   console.log(chalk.bold("\nRPC Endpoints:"));
   console.log(`  Mainnet: ${chalk.blue(endpoints.mainnet)}`);
   console.log(`  Devnet:  ${chalk.blue(endpoints.devnet)}`);
-  if (txSignature) {
-    console.log(`\nTransaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
+  if (resolvedTxSignature) {
+    console.log(`\nTransaction: ${chalk.blue(`${TX_EXPLORER}/${resolvedTxSignature}`)}`);
   }
 }
 

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -1,14 +1,42 @@
 import chalk from "chalk";
 import { loadKeypairFromFile, getAddress } from "../lib/wallet.js";
-import { agenticSignup, listProjects } from "../lib/api.js";
-import { setJwt, setApiKey, setSharedApiKey, setProjectId, getSharedApiKey, SHARED_CONFIG_PATH } from "../lib/config.js";
+import {
+  signup as sdkSignup,
+  payPaymentLink,
+  getPaymentStatus,
+  listProjects,
+  getProject,
+  createApiKey,
+  type PaymentLink,
+} from "../lib/api.js";
+import {
+  setJwt,
+  setApiKey,
+  setSharedApiKey,
+  setProjectId,
+  getPendingSignup,
+  setPendingSignup,
+  updatePendingSignup,
+  clearPendingSignup,
+  SHARED_CONFIG_PATH,
+  type PendingSignup,
+} from "../lib/config.js";
 import { keypairExists, keygenCommand } from "./keygen.js";
-import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, ExitCode, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import {
+  outputJson,
+  exitWithError,
+  ExitCode,
+  handleCommandError,
+  createSpinner,
+  type OutputOptions,
+} from "../lib/output.js";
 import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
-import { PLAN_CATALOG } from "../lib/checkout.js";
 import { sendDiscoveryEvent } from "../lib/feedback.js";
-import { validateSignupPlan, validatePeriod, validateEmail } from "../lib/validation.js";
+import {
+  validateSignupPlan,
+  validatePeriod,
+  validateEmail,
+} from "../lib/validation.js";
 
 interface SignupOptions extends OutputOptions {
   keypair: string;
@@ -20,71 +48,45 @@ interface SignupOptions extends OutputOptions {
   lastName?: string;
   discoveryPath?: string;
   frictionPoints?: string;
-  wait?: boolean;
+  pay?: boolean;
+  resume?: boolean;
+  restart?: boolean;
 }
 
-const POLL_INTERVAL_MS = 5_000;
-const POLL_TIMEOUT_MS = 5 * 60 * 1_000; // 5 minutes
+/** USDC has 6 decimals; intent.amount is in cents. cents × 10_000 = raw. */
+const CENTS_TO_USDC_RAW = 10_000n;
+const SOL_FEE_THRESHOLD = 1_000_000n; // ~0.001 SOL
+const TX_EXPLORER = "https://orbmarkets.io/tx";
 
-interface FundingResult {
-  funded: boolean;
-  solFunded: boolean;
-  usdcFunded: boolean;
-}
+const buildEndpoints = (apiKey: string) => ({
+  mainnet: `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
+  devnet: `https://devnet.helius-rpc.com/?api-key=${apiKey}`,
+});
 
 /**
- * Polls SOL and USDC balances until both meet the required thresholds.
- * Returns which assets were funded so the caller can report accurate timeout status.
+ * Phase 1 signup. Three modes:
+ *  - Default (link mode): print payment URL, save full pendingSignup, exit.
+ *  - --pay: send USDC + memo from local keypair, poll, provision API key.
+ *  - --resume: poll the stored intent (no keypair load, no contact args).
+ *
+ * Pending-intent reuse: if config has a non-expired pendingSignup and the user
+ * does not pass --restart, the default and --pay paths reuse it instead of
+ * creating a new intent.
+ *
+ * Local expiresAt does NOT auto-clear pendingSignup. Cleanup only on:
+ * backend-reported expired/failed, successful provisioning, or --restart.
  */
-async function waitForFunding(
-  walletAddress: string,
-  requiredUsdcRaw: bigint,
-  spinner?: { start(text: string): void; succeed(text: string): void } | null,
-): Promise<FundingResult> {
-  const start = Date.now();
-  let solFunded = false;
-  let usdcFunded = false;
-
-  while (Date.now() - start < POLL_TIMEOUT_MS) {
-    const waiting = [!solFunded && "SOL", !usdcFunded && "USDC"].filter(Boolean).join(" + ");
-    spinner?.start(`Waiting for ${waiting}...`);
-
-    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-
-    try {
-      if (!solFunded) {
-        const solBalance = await checkSolBalance(walletAddress);
-        if (solBalance >= 1_000_000n) {
-          solFunded = true;
-          spinner?.succeed(`SOL received (${(Number(solBalance) / 1_000_000_000).toFixed(4)} SOL)`);
-        }
-      }
-
-      if (!usdcFunded) {
-        const usdcBalance = await checkUsdcBalance(walletAddress);
-        if (usdcBalance >= requiredUsdcRaw) {
-          usdcFunded = true;
-          spinner?.succeed(`USDC received (${(Number(usdcBalance) / 1_000_000).toFixed(2)} USDC)`);
-        }
-      }
-    } catch {
-      // Network blip — keep polling, don't abort the wait
-    }
-
-    if (solFunded && usdcFunded) {
-      return { funded: true, solFunded, usdcFunded };
-    }
-  }
-
-  console.error(chalk.red("\nTimed out waiting for funds (5 minutes). Please fund and run `helius signup --wait` again."));
-  return { funded: false, solFunded, usdcFunded };
-}
-
 export async function signupCommand(options: SignupOptions): Promise<void> {
   const spinner = createSpinner(options);
 
   try {
-    // Validate plan and period upfront
+    if (options.resume) {
+      await runResume(options, spinner);
+      return;
+    }
+
+    // ── Validation (skipped on --resume, runs for default + --pay) ──
+
     if (options.plan) {
       const planErr = validateSignupPlan(options.plan);
       if (planErr) exitWithError("INVALID_INPUT", planErr, undefined, !!options.json);
@@ -98,101 +100,94 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
       if (emailErr) exitWithError("INVALID_INPUT", emailErr, undefined, !!options.json);
     }
 
-    // Auto-generate keypair if none exists
+    // ── Pending-intent reuse runs first ──
+
+    if (options.restart) {
+      clearPendingSignup();
+    }
+
+    let stored = getPendingSignup();
+    if (stored && !options.restart) {
+      // --pay: idempotent reuse path (handles its own status check).
+      if (options.pay) {
+        await runPayWithStored(stored, options, spinner);
+        return;
+      }
+
+      // Default link mode. If the local `expiresAt` is past, the link in
+      // config might be stale — but local clocks lie, and a user could pay
+      // just before backend expiry yet return after. Source of truth is the
+      // backend; query it before deciding.
+      const now = Date.now();
+      const localExpired = Date.parse(stored.expiresAt) <= now;
+      if (localExpired) {
+        const refreshed = await refreshStoredFromBackend(stored, spinner, options);
+        if (refreshed === "cleared") {
+          // Backend says expired/failed (or 410). Stored intent has been
+          // cleared. Fall through to the fresh signup path below.
+          stored = undefined;
+        } else if (refreshed === "provisioned") {
+          // Backend reported activation already complete; provisioning
+          // completed inside refreshStoredFromBackend. Done.
+          return;
+        } else {
+          // Still payable on the backend. Re-print the link.
+          emitPaymentRequired(stored, true, options);
+          return;
+        }
+      } else {
+        emitPaymentRequired(stored, true, options);
+        return;
+      }
+    }
+
+    // ── Fresh signup path ──
+    //
+    // Contact-info validation lives in the SDK's no-project branch — that
+    // way already_subscribed / upgrade_required short-circuits don't demand
+    // --email/--first-name/--last-name when they're not needed.
+
+    const plan = (options.plan?.toLowerCase() || "agent") as
+      | "agent"
+      | "developer"
+      | "business"
+      | "professional";
+
+    // Auto-generate keypair if none exists (skipped in JSON mode)
     if (!keypairExists(options.keypair)) {
       if (options.json) {
-        // In JSON mode, don't do interactive keygen — just error
-        exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, !!options.json);
+        exitWithError(
+          "KEYPAIR_NOT_FOUND",
+          `Keypair not found at ${options.keypair}`,
+          undefined,
+          !!options.json,
+        );
       }
       console.log(chalk.yellow("No keypair found. Generating one automatically...\n"));
       await keygenCommand({ output: options.keypair });
       console.log();
     }
 
-    // Load keypair
     spinner?.start("Loading keypair...");
     const keypair = await loadKeypairFromFile(options.keypair);
     const walletAddress = await getAddress(keypair);
     spinner?.succeed(`Wallet loaded: ${walletAddress}`);
 
-    // Check balance before attempting payment
-    spinner?.start("Checking wallet balance...");
-    const solBalance = await checkSolBalance(walletAddress);
-    const usdcBalance = await checkUsdcBalance(walletAddress);
-    const solAmount = Number(solBalance) / 1_000_000_000;
-    const usdcAmount = Number(usdcBalance) / 1_000_000;
-    const solOk = solBalance >= 1_000_000n;    // ~0.001 SOL
-
-    // Compute required USDC based on selected plan
-    const planKey = options.plan?.toLowerCase();
-    const catalogEntry = planKey ? PLAN_CATALOG[planKey] : null;
-    let requiredUsdcRaw: bigint;
-    let requiredUsdcLabel: string;
-    if (catalogEntry) {
-      const period = options.period?.toLowerCase();
-      const priceInCents = period === "yearly" ? catalogEntry.yearlyPrice : catalogEntry.monthlyPrice;
-      requiredUsdcRaw = BigInt(priceInCents) * 10_000n; // cents → USDC raw (6 decimals)
-      requiredUsdcLabel = `${priceInCents / 100} USDC`;
-    } else {
-      requiredUsdcRaw = 1_000_000n; // $1 basic plan
-      requiredUsdcLabel = "1 USDC";
-    }
-    const usdcOk = usdcBalance >= requiredUsdcRaw;
-
-    if (!solOk || !usdcOk) {
-      spinner?.fail("Insufficient balance");
-      const missing: string[] = [];
-      if (!solOk) missing.push(`~0.001 SOL (have ${solAmount.toFixed(6)})`);
-      if (!usdcOk) missing.push(`${requiredUsdcLabel} (have ${usdcAmount.toFixed(2)})`);
-
-      if (!options.wait) {
-        // No polling — exit immediately
-        if (options.json) {
-          exitWithError("INSUFFICIENT_FUNDS", `Need more funds: ${missing.join(", ")}`, {
-            wallet: walletAddress,
-            required: { sol: solOk ? undefined : "~0.001 SOL", usdc: usdcOk ? undefined : requiredUsdcLabel },
-          }, !!options.json);
-        }
-        console.error(chalk.red(`\nInsufficient funds. Send the following to ${chalk.cyan(walletAddress)}:`));
-        for (const m of missing) {
-          console.error(`  • ${m}`);
-        }
-        console.error(chalk.gray("\nThen run `helius signup` again, or use `helius signup --wait` to poll until funded."));
-        process.exit(!solOk ? ExitCode.INSUFFICIENT_SOL : ExitCode.INSUFFICIENT_USDC);
-      }
-
-      // --wait: poll until wallet is funded
-      console.error(chalk.red(`\nInsufficient funds. Send the following to ${chalk.cyan(walletAddress)}:`));
-      for (const m of missing) {
-        console.error(`  • ${m}`);
-      }
-      console.log(chalk.gray("\nWaiting for funds... (Ctrl+C to cancel)\n"));
-      const result = await waitForFunding(walletAddress, requiredUsdcRaw, spinner);
-      if (!result.funded) {
-        process.exit(!result.solFunded ? ExitCode.INSUFFICIENT_SOL : ExitCode.INSUFFICIENT_USDC);
-      }
-    } else {
-      spinner?.succeed(`Balance OK: ${solAmount.toFixed(4)} SOL, ${usdcAmount.toFixed(2)} USDC`);
-    }
-
-    // Snapshot local config state before signup — used to detect recovery vs. duplicate
-    const hadLocalApiKey = !!getSharedApiKey();
-
-    // Run agenticSignup (handles all plan paths)
-    const planLabel = options.plan || "basic";
-    spinner?.start(`Signing up (${planLabel} plan)...`);
-
-    const result = await agenticSignup({
+    spinner?.start("Authenticating + creating payment intent...");
+    const result = await sdkSignup({
       secretKey: keypair.secretKey,
-      plan: options.plan,
+      plan,
       period: (options.period as "monthly" | "yearly") || undefined,
-      couponCode: options.coupon,
       email: options.email,
       firstName: options.firstName,
       lastName: options.lastName,
+      couponCode: options.coupon,
     });
+    spinner?.succeed("Signup ready");
 
-    spinner?.succeed("Signup complete");
+    // Top-level JWT is set so subsequent commands (helius login, etc.) reuse it,
+    // but pendingSignup carries its own JWT to survive top-level rotations.
+    setJwt(result.jwt);
 
     if (options.discoveryPath || options.frictionPoints) {
       sendDiscoveryEvent({
@@ -201,119 +196,479 @@ export async function signupCommand(options: SignupOptions): Promise<void> {
       });
     }
 
-    // Save config
-    if (result.jwt) {
-      setJwt(result.jwt);
-    }
-    if (result.apiKey) {
-      setApiKey(result.apiKey);
-      setSharedApiKey(result.apiKey);
-    }
-    if (result.projectId) {
-      setProjectId(result.projectId);
-    }
-
-    // Handle result statuses
-    if (result.status === "existing_project") {
-      // No prior local key = interrupted signup being recovered; otherwise a genuine re-run
-      const isRecovery = !hadLocalApiKey;
-      const allProjects = await listProjects(result.jwt);
-
-      if (options.json) {
-        outputJson({
-          status: isRecovery ? "RECOVERED" : "EXISTING_PROJECT",
-          wallet: result.walletAddress,
-          projectId: result.projectId,
-          apiKey: result.apiKey,
-          configPath: result.apiKey ? SHARED_CONFIG_PATH : null,
-          endpoints: result.endpoints,
-          credits: result.credits,
-          projects: allProjects.map((p) => ({ id: p.id, name: p.name })),
-        });
+    switch (result.kind) {
+      case "already_subscribed": {
+        // Persist the existing API key so other commands can use it.
+        setApiKey(result.apiKey);
+        setSharedApiKey(result.apiKey);
+        setProjectId(result.projectId);
+        emitAlreadySubscribed(result, options);
         return;
       }
-
-      if (isRecovery) {
-        console.log("\n" + chalk.green("Resuming previous signup — your account was already created."));
-      } else {
-        console.log("\n" + chalk.yellow("You already have project(s):"));
+      case "upgrade_required": {
+        emitUpgradeRequired(result, options);
+        return;
       }
-      for (const p of allProjects) {
-        console.log(`  ${chalk.cyan(p.id)} - ${p.name}`);
-        if (p.subscription) {
-          console.log(`    Plan: ${formatEnumLabel(p.subscription.plan)}`);
+      case "payment_required": {
+        const pending: PendingSignup = {
+          paymentIntentId: result.paymentLink.paymentIntentId,
+          paymentUrl: result.paymentLink.paymentUrl,
+          planName: result.paymentLink.planName,
+          amountCents: result.paymentLink.amountCents,
+          destinationWallet: result.paymentLink.destinationWallet,
+          solanaPayUrl: result.paymentLink.solanaPayUrl,
+          memo: result.paymentLink.memo,
+          expiresAt: result.paymentLink.expiresAt,
+          walletAddress: result.walletAddress,
+          refId: result.refId,
+          jwt: result.jwt,
+          createdAt: new Date().toISOString(),
+        };
+        // CRITICAL: write pendingSignup BEFORE attempting any USDC transfer so
+        // a crash mid-send is recoverable via --resume.
+        setPendingSignup(pending);
+
+        if (options.pay) {
+          await runPayWithStored(pending, options, spinner, keypair.secretKey);
+        } else {
+          emitPaymentRequired(pending, false, options);
         }
-      }
-      if (result.apiKey) {
-        console.log(`\nAPI Key: ${chalk.cyan(result.apiKey)}`);
-        console.log(chalk.green(`Saved to ${SHARED_CONFIG_PATH}`));
-      }
-      if (result.endpoints) {
-        console.log(chalk.bold("\nRPC Endpoints:"));
-        console.log(`  Mainnet: ${chalk.blue(result.endpoints.mainnet)}`);
-        console.log(`  Devnet:  ${chalk.blue(result.endpoints.devnet)}`);
-      }
-      if (!isRecovery) {
-        console.log(chalk.gray("\nNo payment required. Use `helius projects` to view details."));
-      }
-      return;
-    }
-
-    if (result.status === "upgraded") {
-      if (options.json) {
-        outputJson({
-          status: "UPGRADED",
-          wallet: result.walletAddress,
-          projectId: result.projectId,
-          apiKey: result.apiKey,
-          plan: planLabel,
-          transaction: result.txSignature || null,
-        });
         return;
       }
-
-      console.log("\n" + chalk.green(`Plan upgraded to ${planLabel}!`));
-      console.log(`\nProject ID: ${chalk.cyan(result.projectId)}`);
-      if (result.txSignature) {
-        console.log(
-          `Transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`
-        );
-      }
-      return;
-    }
-
-    // status === "success"
-    if (options.json) {
-      outputJson({
-        status: "SUCCESS",
-        wallet: result.walletAddress,
-        projectId: result.projectId,
-        apiKey: result.apiKey,
-        configPath: result.apiKey ? SHARED_CONFIG_PATH : null,
-        endpoints: result.endpoints,
-        credits: result.credits,
-        transaction: result.txSignature || null,
-      });
-      return;
-    }
-
-    console.log("\n" + chalk.green("Signup complete!"));
-    console.log(`\nProject ID: ${chalk.cyan(result.projectId)}`);
-    if (result.apiKey) {
-      console.log(`API Key: ${chalk.cyan(result.apiKey)}`);
-      console.log(chalk.green(`API key saved to ${SHARED_CONFIG_PATH}`));
-    }
-    if (result.endpoints) {
-      console.log(chalk.bold("\nRPC Endpoints:"));
-      console.log(`  Mainnet: ${chalk.blue(result.endpoints.mainnet)}`);
-      console.log(`  Devnet:  ${chalk.blue(result.endpoints.devnet)}`);
-    }
-    if (result.txSignature) {
-      console.log(
-        `\nView transaction: ${chalk.blue(`https://orbmarkets.io/tx/${result.txSignature}`)}`
-      );
     }
   } catch (error) {
     handleCommandError(error, options, spinner);
   }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// --pay path
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pay against a stored pending signup. Idempotent:
+ *   1. If pendingSignup.txSignature is already set → skip the send, just poll.
+ *   2. Else fetch backend status:
+ *        - readyToRedirect → skip send, provision.
+ *        - completed && !readyToRedirect → skip send, poll until ready.
+ *        - pending → send USDC, then poll.
+ *        - expired/failed → clear and exit with the matching status.
+ */
+async function runPayWithStored(
+  stored: PendingSignup,
+  options: SignupOptions,
+  spinner: ReturnType<typeof createSpinner>,
+  freshSecretKey?: Uint8Array,
+): Promise<void> {
+  const link: PaymentLink = {
+    kind: "payment_required",
+    paymentIntentId: stored.paymentIntentId,
+    amountCents: stored.amountCents,
+    destinationWallet: stored.destinationWallet,
+    memo: stored.memo,
+    expiresAt: stored.expiresAt,
+    paymentUrl: stored.paymentUrl,
+    solanaPayUrl: stored.solanaPayUrl,
+    planName: stored.planName,
+  };
+
+  // 1. Already-paid short-circuit.
+  if (stored.txSignature) {
+    spinner?.start("Resuming payment polling (USDC already sent)...");
+    await pollAndProvision(stored, stored.txSignature, options, spinner);
+    return;
+  }
+
+  // 2. Check backend status before sending.
+  spinner?.start("Checking payment status...");
+  let status;
+  try {
+    status = await getPaymentStatus(stored.jwt, stored.paymentIntentId);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("410")) {
+      clearPendingSignup();
+      emitExpired(stored, options);
+      return;
+    }
+    throw error;
+  }
+  spinner?.succeed(`Status: ${status.phase}`);
+
+  if (status.readyToRedirect) {
+    await provisionAndEmit(stored, undefined, options, spinner);
+    return;
+  }
+  if (status.phase === "expired") {
+    clearPendingSignup();
+    emitExpired(stored, options);
+    return;
+  }
+  if (status.phase === "failed") {
+    clearPendingSignup();
+    emitFailed(stored, status.message, options);
+    return;
+  }
+  if (status.status === "completed" && !status.readyToRedirect) {
+    // Payment already settled; just keep polling.
+    await pollAndProvision(stored, undefined, options, spinner);
+    return;
+  }
+
+  // 3. status === "pending" → send USDC.
+  const secretKey = freshSecretKey ?? (await loadSecretKey(options));
+  const walletAddress = stored.walletAddress;
+
+  spinner?.start("Checking wallet balance...");
+  const solBalance = await checkSolBalance(walletAddress);
+  const usdcBalance = await checkUsdcBalance(walletAddress);
+  const requiredUsdcRaw = BigInt(stored.amountCents) * CENTS_TO_USDC_RAW;
+  if (solBalance < SOL_FEE_THRESHOLD) {
+    spinner?.fail("Insufficient SOL for transaction fees");
+    exitWithError(
+      "INSUFFICIENT_SOL",
+      `Wallet ${walletAddress} needs ~0.001 SOL for fees (have ${(Number(solBalance) / 1e9).toFixed(6)}).`,
+      undefined,
+      !!options.json,
+    );
+  }
+  if (usdcBalance < requiredUsdcRaw) {
+    spinner?.fail("Insufficient USDC");
+    exitWithError(
+      "INSUFFICIENT_USDC",
+      `Wallet ${walletAddress} needs ${stored.amountCents / 100} USDC (have ${(Number(usdcBalance) / 1e6).toFixed(2)}).`,
+      undefined,
+      !!options.json,
+    );
+  }
+  spinner?.succeed("Balance OK");
+
+  spinner?.start(`Sending ${stored.amountCents / 100} USDC + memo...`);
+  const { txSignature } = await payPaymentLink(secretKey, link);
+  spinner?.succeed(`Sent: ${txSignature}`);
+
+  // Persist txSignature before activation polling so a crash here doesn't lose it.
+  updatePendingSignup({ txSignature });
+
+  await pollAndProvision(stored, txSignature, options, spinner);
+}
+
+async function pollAndProvision(
+  stored: PendingSignup,
+  txSignature: string | undefined,
+  options: SignupOptions,
+  spinner: ReturnType<typeof createSpinner>,
+): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  spinner?.start("Waiting for activation...");
+
+  while (Date.now() < deadline) {
+    let status;
+    try {
+      status = await getPaymentStatus(stored.jwt, stored.paymentIntentId);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("410")) {
+        clearPendingSignup();
+        emitExpired(stored, options);
+        return;
+      }
+      throw error;
+    }
+
+    if (status.readyToRedirect) {
+      spinner?.succeed("Activated");
+      await provisionAndEmit(stored, txSignature, options, spinner);
+      return;
+    }
+    if (status.phase === "failed") {
+      clearPendingSignup();
+      emitFailed(stored, status.message, options);
+      return;
+    }
+    if (status.phase === "expired") {
+      clearPendingSignup();
+      emitExpired(stored, options);
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 1_000));
+  }
+
+  spinner?.warn("Activation polling timed out");
+  emitPending(stored, txSignature, options);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// --resume path — never loads the keypair, never accepts contact args
+// ────────────────────────────────────────────────────────────────────────────
+
+async function runResume(
+  options: SignupOptions,
+  spinner: ReturnType<typeof createSpinner>,
+): Promise<void> {
+  const stored = getPendingSignup();
+  if (!stored) {
+    if (options.json) {
+      outputJson({ status: "MISSING_PENDING_INTENT" });
+      return;
+    }
+    exitWithError(
+      "MISSING_PENDING_INTENT",
+      "No pending signup found in config. Run `helius signup` first.",
+      undefined,
+      !!options.json,
+    );
+  }
+
+  spinner?.start("Polling payment status...");
+  await pollAndProvision(stored!, stored!.txSignature, options, spinner);
+}
+
+/**
+ * Default link-mode helper for the case where the locally-stored intent's
+ * `expiresAt` is already past. Queries the backend (the only source of
+ * truth) and reacts:
+ *
+ * - `expired` / `failed` / 410 Gone → clear stored intent, return "cleared"
+ *   so the caller can fall through to the fresh-signup path.
+ * - `completed` (whether or not `readyToRedirect` is true yet) → drive the
+ *   normal poll-and-provision flow; return "provisioned" so the caller
+ *   doesn't also re-print a link.
+ * - `pending` → return "still_payable"; the caller re-prints the existing
+ *   link (the backend is happy to accept payment despite the local clock).
+ */
+async function refreshStoredFromBackend(
+  stored: PendingSignup,
+  spinner: ReturnType<typeof createSpinner>,
+  options: SignupOptions,
+): Promise<"cleared" | "provisioned" | "still_payable"> {
+  spinner?.start("Stored payment link is past its local expiry — checking backend...");
+  let status;
+  try {
+    status = await getPaymentStatus(stored.jwt, stored.paymentIntentId);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("410")) {
+      clearPendingSignup();
+      spinner?.succeed("Stored intent expired on the backend; starting fresh");
+      return "cleared";
+    }
+    throw error;
+  }
+  spinner?.succeed(`Backend status: ${status.phase}`);
+
+  if (status.phase === "expired" || status.phase === "failed") {
+    clearPendingSignup();
+    return "cleared";
+  }
+  if (status.status === "completed" || status.readyToRedirect) {
+    await pollAndProvision(stored, stored.txSignature, options, spinner);
+    return "provisioned";
+  }
+  return "still_payable";
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Provisioning + output emitters
+// ────────────────────────────────────────────────────────────────────────────
+
+async function provisionAndEmit(
+  stored: PendingSignup,
+  txSignature: string | undefined,
+  options: SignupOptions,
+  spinner: ReturnType<typeof createSpinner>,
+): Promise<void> {
+  spinner?.start("Provisioning API key...");
+  const projects = await listProjects(stored.jwt);
+  if (projects.length === 0) {
+    spinner?.fail("No project provisioned yet — re-run --resume in a moment.");
+    emitPending(stored, txSignature, options);
+    return;
+  }
+  const projectId = projects[0].id;
+  const details = await getProject(stored.jwt, projectId);
+  let apiKey = details.apiKeys?.[0]?.keyId;
+  if (!apiKey) {
+    apiKey = (await createApiKey(stored.jwt, projectId, stored.walletAddress)).keyId;
+  }
+  spinner?.succeed("Provisioned");
+
+  setApiKey(apiKey);
+  setSharedApiKey(apiKey);
+  setProjectId(projectId);
+  clearPendingSignup();
+
+  const endpoints = buildEndpoints(apiKey);
+
+  if (options.json) {
+    outputJson({
+      status: "SUCCESS",
+      walletAddress: stored.walletAddress,
+      projectId,
+      apiKey,
+      endpoints,
+      paymentIntentId: stored.paymentIntentId,
+      txSignature: txSignature ?? null,
+    });
+    return;
+  }
+
+  console.log("\n" + chalk.green("Signup complete!"));
+  console.log(`\nProject ID: ${chalk.cyan(projectId)}`);
+  console.log(`API Key: ${chalk.cyan(apiKey)}`);
+  console.log(chalk.green(`Saved to ${SHARED_CONFIG_PATH}`));
+  console.log(chalk.bold("\nRPC Endpoints:"));
+  console.log(`  Mainnet: ${chalk.blue(endpoints.mainnet)}`);
+  console.log(`  Devnet:  ${chalk.blue(endpoints.devnet)}`);
+  if (txSignature) {
+    console.log(`\nTransaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
+  }
+}
+
+function emitPaymentRequired(
+  stored: PendingSignup,
+  reused: boolean,
+  options: SignupOptions,
+): void {
+  if (options.json) {
+    outputJson({
+      status: "PAYMENT_REQUIRED",
+      paymentUrl: stored.paymentUrl,
+      paymentIntentId: stored.paymentIntentId,
+      walletAddress: stored.walletAddress,
+      refId: stored.refId,
+      expiresAt: stored.expiresAt,
+      amountCents: stored.amountCents,
+      planName: stored.planName,
+      destinationWallet: stored.destinationWallet,
+      memo: stored.memo,
+      solanaPayUrl: stored.solanaPayUrl,
+      ...(reused && { reused: true }),
+    });
+    return;
+  }
+
+  console.log();
+  if (reused) {
+    console.log(chalk.gray("(Resuming previous signup — re-run with --restart to start over.)"));
+  }
+  console.log(chalk.bold(`Pay ${stored.amountCents / 100} USDC to activate ${stored.planName}:`));
+  console.log();
+  console.log(`  ${chalk.cyan(stored.paymentUrl)}`);
+  console.log();
+  console.log(chalk.gray("Or send USDC directly to:"));
+  console.log(chalk.gray(`  Treasury: ${stored.destinationWallet}`));
+  console.log(chalk.gray(`  Memo:     ${stored.memo}`));
+  console.log();
+  console.log(chalk.gray(`Once paid, run \`helius signup --resume\` to finish setup.`));
+}
+
+function emitAlreadySubscribed(
+  result: Extract<
+    Awaited<ReturnType<typeof sdkSignup>>,
+    { kind: "already_subscribed" }
+  >,
+  options: SignupOptions,
+): void {
+  if (options.json) {
+    outputJson({
+      status: "ALREADY_SUBSCRIBED",
+      walletAddress: result.walletAddress,
+      projectId: result.projectId,
+      apiKey: result.apiKey,
+      endpoints: result.endpoints,
+    });
+    return;
+  }
+  console.log("\n" + chalk.green("Wallet already has a project on this plan."));
+  console.log(`\nProject ID: ${chalk.cyan(result.projectId)}`);
+  console.log(`API Key: ${chalk.cyan(result.apiKey)}`);
+  console.log(chalk.green(`Saved to ${SHARED_CONFIG_PATH}`));
+  console.log(chalk.bold("\nRPC Endpoints:"));
+  console.log(`  Mainnet: ${chalk.blue(result.endpoints.mainnet)}`);
+  console.log(`  Devnet:  ${chalk.blue(result.endpoints.devnet)}`);
+}
+
+function emitUpgradeRequired(
+  result: Extract<
+    Awaited<ReturnType<typeof sdkSignup>>,
+    { kind: "upgrade_required" }
+  >,
+  options: SignupOptions,
+): void {
+  const message = `Wallet is already on plan "${result.currentPlan}". Plan changes go through \`helius upgrade\`.`;
+  if (options.json) {
+    outputJson({
+      status: "UPGRADE_REQUIRED",
+      walletAddress: result.walletAddress,
+      currentPlan: result.currentPlan,
+      requestedPlan: result.requestedPlan,
+      message,
+    });
+    return;
+  }
+  console.error("\n" + chalk.yellow(message));
+  process.exit(ExitCode.GENERAL_ERROR);
+}
+
+function emitPending(
+  stored: PendingSignup,
+  txSignature: string | undefined,
+  options: SignupOptions,
+): void {
+  if (options.json) {
+    outputJson({
+      status: "PENDING",
+      paymentIntentId: stored.paymentIntentId,
+      paymentUrl: stored.paymentUrl,
+      expiresAt: stored.expiresAt,
+      ...(txSignature && { txSignature }),
+    });
+    return;
+  }
+  console.log();
+  console.log(chalk.yellow("Payment is still being confirmed."));
+  console.log(`\n  Payment URL: ${chalk.cyan(stored.paymentUrl)}`);
+  if (txSignature) {
+    console.log(`  Transaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
+  }
+  console.log(chalk.gray(`\nRun \`helius signup --resume\` again in a moment.`));
+}
+
+function emitExpired(stored: PendingSignup, options: SignupOptions): void {
+  if (options.json) {
+    outputJson({ status: "EXPIRED", paymentIntentId: stored.paymentIntentId });
+    return;
+  }
+  console.error("\n" + chalk.red("Payment intent expired."));
+  console.error(chalk.gray("Run `helius signup` to start a fresh signup."));
+  process.exit(ExitCode.GENERAL_ERROR);
+}
+
+function emitFailed(
+  stored: PendingSignup,
+  reason: string | undefined,
+  options: SignupOptions,
+): void {
+  if (options.json) {
+    outputJson({
+      status: "FAILED",
+      paymentIntentId: stored.paymentIntentId,
+      ...(reason && { reason }),
+    });
+    return;
+  }
+  console.error("\n" + chalk.red("Payment failed."));
+  if (reason) console.error(chalk.gray(reason));
+  process.exit(ExitCode.GENERAL_ERROR);
+}
+
+async function loadSecretKey(options: SignupOptions): Promise<Uint8Array> {
+  if (!keypairExists(options.keypair)) {
+    exitWithError(
+      "KEYPAIR_NOT_FOUND",
+      `Keypair not found at ${options.keypair}`,
+      undefined,
+      !!options.json,
+    );
+  }
+  const keypair = await loadKeypairFromFile(options.keypair);
+  return keypair.secretKey;
 }

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -4,6 +4,7 @@ import {
   signup as sdkSignup,
   payPaymentLink,
   getPaymentStatus,
+  getPaymentIntent,
   listProjects,
   getProject,
   createApiKey,
@@ -493,6 +494,21 @@ async function provisionAndEmit(
   setApiKey(apiKey);
   setSharedApiKey(apiKey);
   setProjectId(projectId);
+
+  // Backfill txSignature from the backend for browser-pay flows where the
+  // SDK never saw the on-chain signature (the user paid via wallet-connect
+  // in the hosted page). The backend persists txSignature on the intent
+  // when payment-service confirms the memo'd transfer.
+  let resolvedTxSignature = txSignature ?? undefined;
+  if (!resolvedTxSignature) {
+    try {
+      const intent = await getPaymentIntent(stored.jwt, stored.paymentIntentId);
+      resolvedTxSignature = intent.txSignature;
+    } catch {
+      // Best-effort — don't block SUCCESS on this lookup.
+    }
+  }
+
   clearPendingSignup();
 
   const endpoints = buildEndpoints(apiKey);
@@ -505,7 +521,7 @@ async function provisionAndEmit(
       apiKey,
       endpoints,
       paymentIntentId: stored.paymentIntentId,
-      txSignature: txSignature ?? null,
+      txSignature: resolvedTxSignature ?? null,
     });
     return;
   }

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -31,7 +31,7 @@ import {
   createSpinner,
   type OutputOptions,
 } from "../lib/output.js";
-import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
+import { checkSolBalance, checkUsdcBalance, checkBackendForRefresh } from "../lib/payment.js";
 import { sendDiscoveryEvent } from "../lib/feedback.js";
 import {
   validateSignupPlan,
@@ -316,7 +316,37 @@ async function runPayWithStored(
   }
 
   // 3. status === "pending" → send USDC.
-  const secretKey = freshSecretKey ?? (await loadSecretKey(options));
+  // Load the full keypair (not just secretKey) so we can verify the local
+  // wallet still matches the wallet that created the intent. If the user
+  // rotated `id.json` between `helius signup` (link) and `helius signup --pay`,
+  // the new keypair would send USDC from a wallet the backend doesn't
+  // associate with this intent and memo binding would fail server-side.
+  let secretKey: Uint8Array;
+  let payerAddress: string;
+  if (freshSecretKey) {
+    secretKey = freshSecretKey;
+    payerAddress = stored.walletAddress;
+  } else {
+    if (!keypairExists(options.keypair)) {
+      exitWithError(
+        "KEYPAIR_NOT_FOUND",
+        `Keypair not found at ${options.keypair}`,
+        undefined,
+        !!options.json,
+      );
+    }
+    const keypair = await loadKeypairFromFile(options.keypair);
+    secretKey = keypair.secretKey;
+    payerAddress = await getAddress(keypair);
+  }
+  if (payerAddress !== stored.walletAddress) {
+    exitWithError(
+      "INVALID_INPUT",
+      `Local keypair wallet (${payerAddress}) does not match the wallet that created this payment intent (${stored.walletAddress}). Run \`helius signup --restart\` to start over.`,
+      undefined,
+      !!options.json,
+    );
+  }
   const walletAddress = stored.walletAddress;
 
   spinner?.start("Checking wallet balance...");
@@ -441,25 +471,16 @@ async function refreshStoredFromBackend(
   spinner: ReturnType<typeof createSpinner>,
   options: SignupOptions,
 ): Promise<"cleared" | "provisioned" | "still_payable"> {
-  spinner?.start("Stored payment link is past its local expiry — checking backend...");
-  let status;
-  try {
-    status = await getPaymentStatus(stored.jwt, stored.paymentIntentId);
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("410")) {
-      clearPendingSignup();
-      spinner?.succeed("Stored intent expired on the backend; starting fresh");
-      return "cleared";
-    }
-    throw error;
-  }
-  spinner?.succeed(`Backend status: ${status.phase}`);
-
-  if (status.phase === "expired" || status.phase === "failed") {
+  const { verdict } = await checkBackendForRefresh(
+    stored.jwt,
+    stored.paymentIntentId,
+    spinner,
+  );
+  if (verdict === "cleared") {
     clearPendingSignup();
     return "cleared";
   }
-  if (status.status === "completed" || status.readyToRedirect) {
+  if (verdict === "completed") {
     await pollAndProvision(stored, stored.txSignature, options, spinner);
     return "provisioned";
   }

--- a/helius-cli/src/commands/signup.ts
+++ b/helius-cli/src/commands/signup.ts
@@ -696,16 +696,3 @@ function emitFailed(
   if (reason) console.error(chalk.gray(reason));
   process.exit(ExitCode.GENERAL_ERROR);
 }
-
-async function loadSecretKey(options: SignupOptions): Promise<Uint8Array> {
-  if (!keypairExists(options.keypair)) {
-    exitWithError(
-      "KEYPAIR_NOT_FOUND",
-      `Keypair not found at ${options.keypair}`,
-      undefined,
-      !!options.json,
-    );
-  }
-  const keypair = await loadKeypairFromFile(options.keypair);
-  return keypair.secretKey;
-}

--- a/helius-cli/src/commands/upgrade.test.ts
+++ b/helius-cli/src/commands/upgrade.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUpgradePlan = vi.fn();
+const mockPayPaymentLink = vi.fn();
+const mockGetPaymentStatus = vi.fn();
+const mockListProjects = vi.fn();
+const mockWalletSignup = vi.fn();
+
+vi.mock("../lib/api.js", () => ({
+  walletSignup: (...args: unknown[]) => mockWalletSignup(...args),
+  listProjects: (...args: unknown[]) => mockListProjects(...args),
+  getPaymentStatus: (...args: unknown[]) => mockGetPaymentStatus(...args),
+  payPaymentLink: (...args: unknown[]) => mockPayPaymentLink(...args),
+  upgradePlan: (...args: unknown[]) => mockUpgradePlan(...args),
+}));
+
+const mockSetJwt = vi.fn();
+const mockGetPendingUpgrade = vi.fn();
+const mockSetPendingUpgrade = vi.fn();
+const mockUpdatePendingUpgrade = vi.fn();
+const mockClearPendingUpgrade = vi.fn();
+
+vi.mock("../lib/config.js", () => ({
+  setJwt: (...args: unknown[]) => mockSetJwt(...args),
+  getPendingUpgrade: () => mockGetPendingUpgrade(),
+  setPendingUpgrade: (...args: unknown[]) => mockSetPendingUpgrade(...args),
+  updatePendingUpgrade: (...args: unknown[]) => mockUpdatePendingUpgrade(...args),
+  clearPendingUpgrade: () => mockClearPendingUpgrade(),
+  SHARED_CONFIG_PATH: "/tmp/test-config.json",
+}));
+
+const mockKeypairExists = vi.fn();
+vi.mock("./keygen.js", () => ({
+  keypairExists: (...args: unknown[]) => mockKeypairExists(...args),
+  getDefaultKeypairPath: () => "/tmp/keypair.json",
+}));
+
+const mockLoadKeypair = vi.fn();
+const mockGetAddress = vi.fn();
+const mockSignAuthMessage = vi.fn();
+vi.mock("../lib/wallet.js", () => ({
+  loadKeypairFromFile: (...args: unknown[]) => mockLoadKeypair(...args),
+  getAddress: (...args: unknown[]) => mockGetAddress(...args),
+  signAuthMessage: (...args: unknown[]) => mockSignAuthMessage(...args),
+}));
+
+const mockCheckSolBalance = vi.fn();
+const mockCheckUsdcBalance = vi.fn();
+vi.mock("../lib/payment.js", () => ({
+  checkSolBalance: (...args: unknown[]) => mockCheckSolBalance(...args),
+  checkUsdcBalance: (...args: unknown[]) => mockCheckUsdcBalance(...args),
+}));
+
+vi.mock("../lib/feedback.js", () => ({
+  sendDiscoveryEvent: vi.fn(),
+  sendCommandEvent: vi.fn(),
+  getCurrentCommand: () => "upgrade",
+}));
+
+import { upgradeCommand } from "./upgrade.js";
+
+interface CapturedJson {
+  ok: boolean;
+  v?: number;
+  data?: any;
+  error?: any;
+}
+
+function captureStdout(fn: () => Promise<void>) {
+  const chunks: string[] = [];
+  let exitCode: number | null = null;
+
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    chunks.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n");
+  });
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code: any) => {
+    exitCode = typeof code === "number" ? code : 0;
+    throw new Error("__test_exit__");
+  }) as never);
+
+  return fn()
+    .catch((e) => {
+      if (e instanceof Error && e.message === "__test_exit__") return;
+      throw e;
+    })
+    .finally(() => {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    })
+    .then(() => {
+      const raw = chunks.join("");
+      const trimmed = raw.trim();
+      let json: CapturedJson | null = null;
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed && "ok" in parsed) json = parsed;
+      } catch {
+        let depth = 0;
+        let start = -1;
+        for (let i = 0; i < trimmed.length; i++) {
+          if (trimmed[i] === "{") {
+            if (depth === 0) start = i;
+            depth++;
+          } else if (trimmed[i] === "}") {
+            depth--;
+            if (depth === 0 && start >= 0) {
+              try {
+                const parsed = JSON.parse(trimmed.slice(start, i + 1));
+                if (parsed && "ok" in parsed) {
+                  json = parsed;
+                  break;
+                }
+              } catch {
+                /* ignore */
+              }
+              start = -1;
+            }
+          }
+        }
+      }
+      return { json, raw, exitCode };
+    });
+}
+
+const baseOpts = {
+  keypair: "/tmp/keypair.json",
+  json: true,
+  plan: "developer",
+};
+
+const samplePending = {
+  paymentIntentId: "pi_up",
+  paymentUrl: "https://dashboard.helius.dev/pay/pi_up",
+  planName: "Developer (Monthly)",
+  amountCents: 4900,
+  destinationWallet: "Treasury",
+  solanaPayUrl: "solana:Treasury?amount=49",
+  memo: "pi_up",
+  expiresAt: new Date(Date.now() + 1_800_000).toISOString(),
+  jwt: "jwt-1",
+  projectId: "proj-1",
+  targetPlan: "developer",
+  period: "monthly",
+  createdAt: new Date().toISOString(),
+};
+
+describe("upgrade command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKeypairExists.mockReturnValue(true);
+    mockLoadKeypair.mockResolvedValue({ secretKey: new Uint8Array(64) });
+    mockGetAddress.mockResolvedValue("Wallet111");
+    mockSignAuthMessage.mockResolvedValue({ message: "m", signature: "s" });
+    mockWalletSignup.mockResolvedValue({ token: "jwt-1", refId: "r", newUser: false });
+    mockListProjects.mockResolvedValue([{ id: "proj-1" }]);
+    mockCheckSolBalance.mockResolvedValue(2_000_000n);
+    mockCheckUsdcBalance.mockResolvedValue(99_900_000_000n);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("PAYMENT_REQUIRED on fresh upgrade", async () => {
+    mockGetPendingUpgrade.mockReturnValue(undefined);
+    mockUpgradePlan.mockResolvedValue({
+      kind: "payment_required",
+      paymentLink: {
+        kind: "payment_required",
+        paymentIntentId: samplePending.paymentIntentId,
+        amountCents: samplePending.amountCents,
+        destinationWallet: samplePending.destinationWallet,
+        memo: samplePending.memo,
+        expiresAt: samplePending.expiresAt,
+        paymentUrl: samplePending.paymentUrl,
+        solanaPayUrl: samplePending.solanaPayUrl,
+        planName: samplePending.planName,
+      },
+    });
+
+    const { json } = await captureStdout(() => upgradeCommand({ ...baseOpts }));
+    expect(json?.data.status).toBe("PAYMENT_REQUIRED");
+    expect(json?.data.targetPlan).toBe("developer");
+    expect(json?.data.destinationWallet).toBe("Treasury");
+    expect(mockSetPendingUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("PAYMENT_REQUIRED with reused:true on second invocation", async () => {
+    mockGetPendingUpgrade.mockReturnValue(samplePending);
+    const { json } = await captureStdout(() => upgradeCommand({ ...baseOpts, plan: undefined } as any));
+    expect(json?.data.status).toBe("PAYMENT_REQUIRED");
+    expect(json?.data.reused).toBe(true);
+    expect(mockUpgradePlan).not.toHaveBeenCalled();
+    expect(mockSetPendingUpgrade).not.toHaveBeenCalled();
+  });
+
+  it("--restart clears stored pendingUpgrade", async () => {
+    let cleared = false;
+    mockClearPendingUpgrade.mockImplementation(() => {
+      cleared = true;
+    });
+    mockGetPendingUpgrade.mockImplementation(() => (cleared ? undefined : samplePending));
+    mockUpgradePlan.mockResolvedValue({
+      kind: "payment_required",
+      paymentLink: {
+        ...samplePending,
+        kind: "payment_required" as const,
+        paymentIntentId: "pi_new",
+      },
+    });
+    await captureStdout(() => upgradeCommand({ ...baseOpts, restart: true } as any));
+    expect(mockClearPendingUpgrade).toHaveBeenCalled();
+    expect(mockUpgradePlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("--pay reuses stored pendingUpgrade and skips USDC send when txSignature exists", async () => {
+    mockGetPendingUpgrade.mockReturnValue({ ...samplePending, txSignature: "tx-old" });
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    await captureStdout(() => upgradeCommand({ ...baseOpts, plan: undefined, pay: true } as any));
+    expect(mockPayPaymentLink).not.toHaveBeenCalled();
+    expect(mockClearPendingUpgrade).toHaveBeenCalled();
+  });
+
+  it("--resume returns SUCCESS when activation is ready", async () => {
+    mockGetPendingUpgrade.mockReturnValue({ ...samplePending, txSignature: "tx-sent" });
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "completed",
+      phase: "complete",
+      subscriptionActive: true,
+      readyToRedirect: true,
+      message: "ok",
+    });
+    const { json } = await captureStdout(() =>
+      upgradeCommand({ ...baseOpts, plan: undefined, resume: true } as any),
+    );
+    expect(json?.data.status).toBe("SUCCESS");
+    expect(json?.data.txSignature).toBe("tx-sent");
+    expect(mockClearPendingUpgrade).toHaveBeenCalled();
+  });
+
+  it("--resume returns MISSING_PENDING_UPGRADE when no stored intent", async () => {
+    mockGetPendingUpgrade.mockReturnValue(undefined);
+    const { json } = await captureStdout(() =>
+      upgradeCommand({ ...baseOpts, plan: undefined, resume: true } as any),
+    );
+    expect(json?.data.status).toBe("MISSING_PENDING_UPGRADE");
+    expect(mockLoadKeypair).not.toHaveBeenCalled();
+  });
+
+  it("--resume returns FAILED when backend reports failed", async () => {
+    mockGetPendingUpgrade.mockReturnValue(samplePending);
+    mockGetPaymentStatus.mockResolvedValue({
+      status: "failed",
+      phase: "failed",
+      subscriptionActive: false,
+      readyToRedirect: false,
+      message: "boom",
+    });
+    const { json } = await captureStdout(() =>
+      upgradeCommand({ ...baseOpts, plan: undefined, resume: true } as any),
+    );
+    expect(json?.data.status).toBe("FAILED");
+    expect(mockClearPendingUpgrade).toHaveBeenCalled();
+  });
+});

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
-import { signup, listProjects, getProject } from "../lib/api.js";
+import { walletSignup, listProjects, getProject } from "../lib/api.js";
 import { getCheckoutPreview, executeCheckout, PLAN_CATALOG } from "../lib/checkout.js";
 import { setJwt } from "../lib/config.js";
 import { keypairExists, getDefaultKeypairPath } from "./keygen.js";
@@ -59,7 +59,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
 
     spinner?.start("Authenticating...");
     const { message, signature } = await signAuthMessage(keypair.secretKey);
-    const authResult = await signup(message, signature, walletAddress);
+    const authResult = await walletSignup(message, signature, walletAddress);
     setJwt(authResult.token);
     spinner?.succeed("Authenticated");
 

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -8,6 +8,7 @@ import {
   walletSignup,
   listProjects,
   getPaymentStatus,
+  getPaymentIntent,
   payPaymentLink,
   upgradePlan as sdkUpgradePlan,
   type PaymentLink,
@@ -216,7 +217,7 @@ async function runPayWithStored(
 
   if (status.readyToRedirect) {
     clearPendingUpgrade();
-    emitSuccess(stored, undefined, options);
+    await emitSuccess(stored, undefined, options);
     return;
   }
   if (status.phase === "expired") {
@@ -295,7 +296,7 @@ async function pollAndEmit(
     if (status.readyToRedirect) {
       spinner?.succeed("Upgraded");
       clearPendingUpgrade();
-      emitSuccess(stored, txSignature, options);
+      await emitSuccess(stored, txSignature, options);
       return;
     }
     if (status.phase === "failed") {
@@ -382,11 +383,23 @@ function emitPaymentRequired(
   console.log(chalk.gray("Once paid, run `helius upgrade --resume` to confirm locally."));
 }
 
-function emitSuccess(
+async function emitSuccess(
   stored: PendingUpgrade,
   txSignature: string | undefined,
   options: UpgradeOptions,
-): void {
+): Promise<void> {
+  // Backfill txSignature from the backend for browser-pay flows where the
+  // SDK never saw the on-chain signature.
+  let resolvedTxSignature = txSignature;
+  if (!resolvedTxSignature) {
+    try {
+      const intent = await getPaymentIntent(stored.jwt, stored.paymentIntentId);
+      resolvedTxSignature = intent.txSignature;
+    } catch {
+      // Best-effort.
+    }
+  }
+
   if (options.json) {
     outputJson({
       status: "SUCCESS",
@@ -394,14 +407,14 @@ function emitSuccess(
       newPlan: stored.targetPlan,
       period: stored.period,
       paymentIntentId: stored.paymentIntentId,
-      txSignature: txSignature ?? null,
+      txSignature: resolvedTxSignature ?? null,
     });
     return;
   }
   console.log("\n" + chalk.green(`Upgraded to ${stored.planName}!`));
   console.log(`\nProject ID: ${chalk.cyan(stored.projectId)}`);
-  if (txSignature) {
-    console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${txSignature}`)}`);
+  if (resolvedTxSignature) {
+    console.log(`Transaction: ${chalk.blue(`${TX_EXPLORER}/${resolvedTxSignature}`)}`);
   }
 }
 

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -235,13 +235,10 @@ async function runPayWithStored(
   }
 
   const secretKey = freshSecretKey ?? (await loadSecretKey(options));
-
-  spinner?.start("Checking wallet balance...");
-  const sol = await checkSolBalance(stored.destinationWallet);
-  void sol; // The destinationWallet is the treasury, not the payer; check payer instead.
-  // (Keypair-derived wallet pays; just sanity-check fees are present on it.)
   const keypair = await loadKeypairFromFile(options.keypair);
   const payerAddress = await getAddress(keypair);
+
+  spinner?.start("Checking wallet balance...");
   const payerSol = await checkSolBalance(payerAddress);
   const payerUsdc = await checkUsdcBalance(payerAddress);
   const required = BigInt(stored.amountCents) * CENTS_TO_USDC_RAW;

--- a/helius-cli/src/commands/upgrade.ts
+++ b/helius-cli/src/commands/upgrade.ts
@@ -30,7 +30,7 @@ import {
   createSpinner,
   type OutputOptions,
 } from "../lib/output.js";
-import { checkSolBalance, checkUsdcBalance } from "../lib/payment.js";
+import { checkSolBalance, checkUsdcBalance, checkBackendForRefresh } from "../lib/payment.js";
 import { validateUpgradePlan, validatePeriod, validateEmail } from "../lib/validation.js";
 
 interface UpgradeOptions extends OutputOptions {
@@ -84,10 +84,34 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     if (stored && !options.restart) {
       if (options.pay) {
         await runPayWithStored(stored, options, spinner);
+        return;
+      }
+
+      // Local expiry past → query backend (source of truth) before
+      // reprinting a stale URL. See `checkBackendForRefresh`.
+      const localExpired = Date.parse(stored.expiresAt) <= Date.now();
+      if (localExpired) {
+        const { verdict } = await checkBackendForRefresh(
+          stored.jwt,
+          stored.paymentIntentId,
+          spinner,
+        );
+        if (verdict === "completed") {
+          await pollAndEmit(stored, stored.txSignature, options, spinner);
+          return;
+        }
+        if (verdict === "cleared") {
+          clearPendingUpgrade();
+          // Fall through to fresh upgrade path. Requires --plan; the existing
+          // INVALID_INPUT check below handles the missing-flag case.
+        } else {
+          emitPaymentRequired(stored, true, options);
+          return;
+        }
       } else {
         emitPaymentRequired(stored, true, options);
+        return;
       }
-      return;
     }
 
     if (!options.plan) {
@@ -159,6 +183,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
       projectId: project.id,
       targetPlan,
       period,
+      payerWallet: walletAddress,
       createdAt: new Date().toISOString(),
     };
     setPendingUpgrade(pending);
@@ -238,6 +263,18 @@ async function runPayWithStored(
   const secretKey = freshSecretKey ?? (await loadSecretKey(options));
   const keypair = await loadKeypairFromFile(options.keypair);
   const payerAddress = await getAddress(keypair);
+
+  // Guard against keypair rotation between intent creation and --pay.
+  // `payerWallet` is undefined for intents stored before this field was
+  // introduced; skip the check in that case (one-version migration window).
+  if (stored.payerWallet && payerAddress !== stored.payerWallet) {
+    exitWithError(
+      "INVALID_INPUT",
+      `Local keypair wallet (${payerAddress}) does not match the wallet that created this upgrade intent (${stored.payerWallet}). Run \`helius upgrade --restart\` to start over.`,
+      undefined,
+      !!options.json,
+    );
+  }
 
   spinner?.start("Checking wallet balance...");
   const payerSol = await checkSolBalance(payerAddress);

--- a/helius-cli/src/lib/api.ts
+++ b/helius-cli/src/lib/api.ts
@@ -10,6 +10,18 @@ import { signup as sdkSignup } from "helius-sdk/auth/signup";
 import { signupAndPay as sdkSignupAndPay } from "helius-sdk/auth/signupAndPay";
 import { payPaymentLink as sdkPayPaymentLink } from "helius-sdk/auth/payPaymentLink";
 import { getPaymentStatus as sdkGetPaymentStatus } from "helius-sdk/auth/checkout";
+import {
+  upgradePlan as sdkUpgradePlan,
+  upgradePlanAndPay as sdkUpgradePlanAndPay,
+} from "helius-sdk/auth/upgradePlan";
+import {
+  purchaseCredits as sdkPurchaseCredits,
+  purchaseCreditsAndPay as sdkPurchaseCreditsAndPay,
+} from "helius-sdk/auth/purchaseCredits";
+import {
+  payRenewal as sdkPayRenewal,
+  payRenewalAndPay as sdkPayRenewalAndPay,
+} from "helius-sdk/auth/payRenewal";
 import type {
   SignupResponse,
   Project,
@@ -24,6 +36,16 @@ import type {
   SignupAndPayResult,
   PaymentLink,
   CheckoutStatusResponse,
+  UpgradePlanOptions,
+  UpgradePlanResult,
+  UpgradePlanAndPayOptions,
+  UpgradePlanAndPayResult,
+  PurchaseCreditsLinkOptions,
+  PurchaseCreditsLinkResult,
+  PurchaseCreditsAndPayOptions,
+  PurchaseCreditsAndPayResult,
+  PayRenewalResult,
+  PayRenewalAndPayResult,
 } from "helius-sdk/auth/types";
 
 // Wrap SDK functions to pass CLI user agent.
@@ -91,6 +113,43 @@ export async function getPaymentStatus(
   return sdkGetPaymentStatus(jwt, paymentIntentId, CLI_USER_AGENT);
 }
 
+// Phase 2 helpers — pass-through to the SDK.
+export async function upgradePlan(
+  options: UpgradePlanOptions,
+): Promise<UpgradePlanResult> {
+  return sdkUpgradePlan(options);
+}
+export async function upgradePlanAndPay(
+  options: UpgradePlanAndPayOptions,
+): Promise<UpgradePlanAndPayResult> {
+  return sdkUpgradePlanAndPay(options);
+}
+export async function purchaseCredits(
+  options: PurchaseCreditsLinkOptions,
+): Promise<PurchaseCreditsLinkResult> {
+  return sdkPurchaseCredits(options);
+}
+export async function purchaseCreditsAndPay(
+  options: PurchaseCreditsAndPayOptions,
+): Promise<PurchaseCreditsAndPayResult> {
+  return sdkPurchaseCreditsAndPay(options);
+}
+export async function payRenewal(
+  jwt: string,
+  paymentIntentId: string,
+  options: { paymentHost?: string } = {},
+): Promise<PayRenewalResult> {
+  return sdkPayRenewal(jwt, paymentIntentId, options);
+}
+export async function payRenewalAndPay(
+  secretKey: Uint8Array,
+  jwt: string,
+  paymentIntentId: string,
+  options: { paymentHost?: string } = {},
+): Promise<PayRenewalAndPayResult> {
+  return sdkPayRenewalAndPay(secretKey, jwt, paymentIntentId, options);
+}
+
 export type {
   Project,
   ProjectListItem,
@@ -108,4 +167,14 @@ export type {
   SignupAndPayResult,
   PaymentLink,
   CheckoutStatusResponse,
+  UpgradePlanOptions,
+  UpgradePlanResult,
+  UpgradePlanAndPayOptions,
+  UpgradePlanAndPayResult,
+  PurchaseCreditsLinkOptions,
+  PurchaseCreditsLinkResult,
+  PurchaseCreditsAndPayOptions,
+  PurchaseCreditsAndPayResult,
+  PayRenewalResult,
+  PayRenewalAndPayResult,
 } from "helius-sdk/auth/types";

--- a/helius-cli/src/lib/api.ts
+++ b/helius-cli/src/lib/api.ts
@@ -8,7 +8,10 @@ import { createApiKey as sdkCreateApiKey } from "helius-sdk/auth/createApiKey";
 import { signup as sdkSignup } from "helius-sdk/auth/signup";
 import { signupAndPay as sdkSignupAndPay } from "helius-sdk/auth/signupAndPay";
 import { payPaymentLink as sdkPayPaymentLink } from "helius-sdk/auth/payPaymentLink";
-import { getPaymentStatus as sdkGetPaymentStatus } from "helius-sdk/auth/checkout";
+import {
+  getPaymentStatus as sdkGetPaymentStatus,
+  getPaymentIntent as sdkGetPaymentIntent,
+} from "helius-sdk/auth/checkout";
 import {
   upgradePlan as sdkUpgradePlan,
   upgradePlanAndPay as sdkUpgradePlanAndPay,
@@ -32,6 +35,7 @@ import type {
   SignupAndPayOptions,
   SignupAndPayResult,
   PaymentLink,
+  CheckoutInitializeResponse,
   CheckoutStatusResponse,
   UpgradePlanOptions,
   UpgradePlanResult,
@@ -100,6 +104,13 @@ export async function getPaymentStatus(
   paymentIntentId: string,
 ): Promise<CheckoutStatusResponse> {
   return sdkGetPaymentStatus(jwt, paymentIntentId, CLI_USER_AGENT);
+}
+
+export async function getPaymentIntent(
+  jwt: string,
+  paymentIntentId: string,
+): Promise<CheckoutInitializeResponse> {
+  return sdkGetPaymentIntent(jwt, paymentIntentId, CLI_USER_AGENT);
 }
 
 // Phase 2 helpers — pass-through to the SDK.

--- a/helius-cli/src/lib/api.ts
+++ b/helius-cli/src/lib/api.ts
@@ -5,7 +5,6 @@ import { createProject as sdkCreateProject } from "helius-sdk/auth/createProject
 import { listProjects as sdkListProjects } from "helius-sdk/auth/listProjects";
 import { getProject as sdkGetProject } from "helius-sdk/auth/getProject";
 import { createApiKey as sdkCreateApiKey } from "helius-sdk/auth/createApiKey";
-import { agenticSignup as sdkAgenticSignup } from "helius-sdk/auth/agenticSignup";
 import { signup as sdkSignup } from "helius-sdk/auth/signup";
 import { signupAndPay as sdkSignupAndPay } from "helius-sdk/auth/signupAndPay";
 import { payPaymentLink as sdkPayPaymentLink } from "helius-sdk/auth/payPaymentLink";
@@ -28,8 +27,6 @@ import type {
   ProjectListItem,
   ProjectDetails,
   ApiKey,
-  AgenticSignupOptions,
-  AgenticSignupResult,
   SignupOptions,
   SignupResult,
   SignupAndPayOptions,
@@ -81,14 +78,6 @@ export async function createApiKey(
   return sdkCreateApiKey(jwt, projectId, walletAddress, CLI_USER_AGENT);
 }
 
-export async function agenticSignup(
-  options: Omit<AgenticSignupOptions, "userAgent">,
-): Promise<AgenticSignupResult> {
-  return sdkAgenticSignup({ ...options, userAgent: CLI_USER_AGENT });
-}
-
-// New Phase 1 signup surface — pass-through with no userAgent (the SDK doesn't
-// thread one through these helpers yet; that's a Phase 2 cleanup).
 export async function signup(options: SignupOptions): Promise<SignupResult> {
   return sdkSignup(options);
 }

--- a/helius-cli/src/lib/api.ts
+++ b/helius-cli/src/lib/api.ts
@@ -1,11 +1,15 @@
 // Re-export auth functions and types from helius-sdk
 import { CLI_USER_AGENT } from "../constants.js";
-import { walletSignup } from "helius-sdk/auth/walletSignup";
+import { walletSignup as sdkWalletSignup } from "helius-sdk/auth/walletSignup";
 import { createProject as sdkCreateProject } from "helius-sdk/auth/createProject";
 import { listProjects as sdkListProjects } from "helius-sdk/auth/listProjects";
 import { getProject as sdkGetProject } from "helius-sdk/auth/getProject";
 import { createApiKey as sdkCreateApiKey } from "helius-sdk/auth/createApiKey";
 import { agenticSignup as sdkAgenticSignup } from "helius-sdk/auth/agenticSignup";
+import { signup as sdkSignup } from "helius-sdk/auth/signup";
+import { signupAndPay as sdkSignupAndPay } from "helius-sdk/auth/signupAndPay";
+import { payPaymentLink as sdkPayPaymentLink } from "helius-sdk/auth/payPaymentLink";
+import { getPaymentStatus as sdkGetPaymentStatus } from "helius-sdk/auth/checkout";
 import type {
   SignupResponse,
   Project,
@@ -14,15 +18,25 @@ import type {
   ApiKey,
   AgenticSignupOptions,
   AgenticSignupResult,
+  SignupOptions,
+  SignupResult,
+  SignupAndPayOptions,
+  SignupAndPayResult,
+  PaymentLink,
+  CheckoutStatusResponse,
 } from "helius-sdk/auth/types";
 
-// Wrap SDK functions to pass CLI user agent
-export async function signup(
+// Wrap SDK functions to pass CLI user agent.
+//
+// Renamed from `signup` → `walletSignup` to free the `signup` name for the new
+// SDK signup flow (Phase 1). Existing callers in commands/login.ts, pay.ts,
+// upgrade.ts use this for low-level wallet authentication only.
+export async function walletSignup(
   message: string,
   signature: string,
   userID: string,
 ): Promise<SignupResponse> {
-  return walletSignup(message, signature, userID, CLI_USER_AGENT);
+  return sdkWalletSignup(message, signature, userID, CLI_USER_AGENT);
 }
 
 export async function createProject(jwt: string): Promise<Project> {
@@ -51,6 +65,32 @@ export async function agenticSignup(
   return sdkAgenticSignup({ ...options, userAgent: CLI_USER_AGENT });
 }
 
+// New Phase 1 signup surface — pass-through with no userAgent (the SDK doesn't
+// thread one through these helpers yet; that's a Phase 2 cleanup).
+export async function signup(options: SignupOptions): Promise<SignupResult> {
+  return sdkSignup(options);
+}
+
+export async function signupAndPay(
+  options: SignupAndPayOptions,
+): Promise<SignupAndPayResult> {
+  return sdkSignupAndPay(options);
+}
+
+export async function payPaymentLink(
+  secretKey: Uint8Array,
+  paymentLink: PaymentLink,
+): Promise<{ txSignature: string }> {
+  return sdkPayPaymentLink(secretKey, paymentLink);
+}
+
+export async function getPaymentStatus(
+  jwt: string,
+  paymentIntentId: string,
+): Promise<CheckoutStatusResponse> {
+  return sdkGetPaymentStatus(jwt, paymentIntentId, CLI_USER_AGENT);
+}
+
 export type {
   Project,
   ProjectListItem,
@@ -62,4 +102,10 @@ export type {
   Subscription,
   User,
   BillingCycle,
+  SignupOptions,
+  SignupResult,
+  SignupAndPayOptions,
+  SignupAndPayResult,
+  PaymentLink,
+  CheckoutStatusResponse,
 } from "helius-sdk/auth/types";

--- a/helius-cli/src/lib/api.ts
+++ b/helius-cli/src/lib/api.ts
@@ -8,10 +8,8 @@ import { createApiKey as sdkCreateApiKey } from "helius-sdk/auth/createApiKey";
 import { signup as sdkSignup } from "helius-sdk/auth/signup";
 import { signupAndPay as sdkSignupAndPay } from "helius-sdk/auth/signupAndPay";
 import { payPaymentLink as sdkPayPaymentLink } from "helius-sdk/auth/payPaymentLink";
-import {
-  getPaymentStatus as sdkGetPaymentStatus,
-  getPaymentIntent as sdkGetPaymentIntent,
-} from "helius-sdk/auth/checkout";
+import { getPaymentStatus as sdkGetPaymentStatus } from "helius-sdk/auth/getPaymentStatus";
+import { getPaymentIntent as sdkGetPaymentIntent } from "helius-sdk/auth/checkout";
 import {
   upgradePlan as sdkUpgradePlan,
   upgradePlanAndPay as sdkUpgradePlanAndPay,

--- a/helius-cli/src/lib/api.ts
+++ b/helius-cli/src/lib/api.ts
@@ -155,7 +155,6 @@ export type {
   ProjectListItem,
   ProjectDetails,
   ApiKey,
-  AgenticSignupResult,
   CreditsUsage,
   DnsRecord,
   Subscription,

--- a/helius-cli/src/lib/checkout.ts
+++ b/helius-cli/src/lib/checkout.ts
@@ -2,17 +2,13 @@
 import { CLI_USER_AGENT } from "../constants.js";
 import { initializeCheckout as sdkInitializeCheckout } from "helius-sdk/auth/checkout";
 import { pollCheckoutCompletion as sdkPollCheckoutCompletion } from "helius-sdk/auth/checkout";
-import { executeCheckout as sdkExecuteCheckout } from "helius-sdk/auth/checkout";
 import { getCheckoutPreview as sdkGetCheckoutPreview } from "helius-sdk/auth/checkout";
 import { getPaymentIntent as sdkGetPaymentIntent } from "helius-sdk/auth/checkout";
-import { executeRenewal as sdkExecuteRenewal } from "helius-sdk/auth/checkout";
 import type {
   CheckoutInitializeRequest,
   CheckoutInitializeResponse,
   CheckoutStatusResponse,
   CheckoutPreviewResponse,
-  CheckoutResult,
-  CheckoutRequest,
 } from "helius-sdk/auth/types";
 
 export async function initializeCheckout(
@@ -28,15 +24,6 @@ export async function pollCheckoutCompletion(
   options?: { timeoutMs?: number; intervalMs?: number },
 ): Promise<CheckoutStatusResponse> {
   return sdkPollCheckoutCompletion(jwt, paymentIntentId, CLI_USER_AGENT, options);
-}
-
-export async function executeCheckout(
-  secretKey: Uint8Array,
-  jwt: string,
-  request: CheckoutRequest,
-  options?: { skipProjectPolling?: boolean },
-): Promise<CheckoutResult> {
-  return sdkExecuteCheckout(secretKey, jwt, request, CLI_USER_AGENT, options);
 }
 
 export async function getCheckoutPreview(
@@ -56,16 +43,7 @@ export async function getPaymentIntent(
   return sdkGetPaymentIntent(jwt, paymentIntentId, CLI_USER_AGENT);
 }
 
-export async function executeRenewal(
-  secretKey: Uint8Array,
-  jwt: string,
-  paymentIntentId: string,
-): Promise<CheckoutResult> {
-  return sdkExecuteRenewal(secretKey, jwt, paymentIntentId, CLI_USER_AGENT);
-}
-
 export { payWithMemo } from "helius-sdk/auth/payWithMemo";
-export { payPaymentIntent } from "helius-sdk/auth/checkout";
 export { PLAN_CATALOG } from "helius-sdk/auth/planCatalog";
 
 export type {
@@ -73,6 +51,4 @@ export type {
   CheckoutInitializeResponse,
   CheckoutStatusResponse,
   CheckoutPreviewResponse,
-  CheckoutResult,
-  CheckoutRequest,
 } from "helius-sdk/auth/types";

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -8,12 +8,55 @@ const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
 // Alias for backwards compatibility (used by signup.ts)
 export const SHARED_CONFIG_PATH = CONFIG_FILE;
 
+/**
+ * Stored state for an in-flight signup that returned a payment link. Lets
+ * subsequent invocations of `helius signup` (default link mode), `signup
+ * --resume`, and `signup --pay` operate against the existing intent without
+ * a backend roundtrip and without re-deriving the wallet from the keypair
+ * (`--resume` is forbidden from loading the keypair).
+ *
+ * Carries the full PaymentLink so `--pay` can pay it, plus the JWT used to
+ * create it (kept here, not at the top level, so a later `helius login` that
+ * rotates the top-level JWT does not corrupt the resume path).
+ *
+ * Cleanup rules — DO NOT auto-clear on local `expiresAt`:
+ *   - Backend reports `expired` / `failed` → cleared
+ *   - Provisioning succeeds (SUCCESS) → cleared
+ *   - User passes `--restart` → cleared
+ * The user can pay just before expiry but return to the terminal after, and
+ * we must not delete a still-valid resume state.
+ */
+export interface PendingSignup {
+  // PaymentLink fields
+  paymentIntentId: string;
+  paymentUrl: string;
+  planName: string;
+  amountCents: number;
+  destinationWallet: string;
+  solanaPayUrl: string;
+  /** Always equal to `paymentIntentId`. */
+  memo: string;
+  expiresAt: string;
+
+  // Auth + identity for --resume
+  walletAddress: string;
+  refId: string;
+  jwt: string;
+
+  /** Set by `--pay` after USDC has been sent but before activation polling lands. */
+  txSignature?: string;
+
+  /** ISO timestamp of when the pending intent was first stored. */
+  createdAt: string;
+}
+
 interface Config {
   jwt?: string;
   apiKey?: string;
   network?: "mainnet" | "devnet";
   projectId?: string;
   owsWallet?: string;
+  pendingSignup?: PendingSignup;
 }
 
 function ensureDir(): void {
@@ -139,6 +182,29 @@ export function clearOwsWallet(): void {
 
 export function clearConfig(): void {
   save({});
+}
+
+export function getPendingSignup(): PendingSignup | undefined {
+  return load().pendingSignup;
+}
+
+export function setPendingSignup(pending: PendingSignup): void {
+  const config = load();
+  config.pendingSignup = pending;
+  save(config);
+}
+
+export function updatePendingSignup(patch: Partial<PendingSignup>): void {
+  const config = load();
+  if (!config.pendingSignup) return;
+  config.pendingSignup = { ...config.pendingSignup, ...patch };
+  save(config);
+}
+
+export function clearPendingSignup(): void {
+  const config = load();
+  delete config.pendingSignup;
+  save(config);
 }
 
 // Delegates to main config (shared and main are now the same)

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -50,14 +50,19 @@ export interface PendingUpgrade extends PendingPaymentBase {
   period?: "monthly" | "yearly";
   /** Wallet that authenticated and created the intent. Optional for backwards
    * compatibility with intents stored before this field was introduced —
-   * when undefined, the wallet-mismatch check is skipped. */
+   * when undefined, the wallet-mismatch check is skipped.
+   * TODO(payerWallet-migration): once enough release cycles have passed that
+   * any in-flight intent has either been resumed or expired, flip this to
+   * required and have the runPayWithStored guard treat absence as an error
+   * pointing at --restart. Same for `PendingCredits.payerWallet`. */
   payerWallet?: string;
 }
 
 export interface PendingCredits extends PendingPaymentBase {
   projectId: string;
   qty: number;
-  /** Wallet that authenticated and created the intent. See `PendingUpgrade.payerWallet`. */
+  /** Wallet that authenticated and created the intent. See `PendingUpgrade.payerWallet`
+   * (including the migration TODO). */
   payerWallet?: string;
 }
 

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -9,25 +9,20 @@ const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
 export const SHARED_CONFIG_PATH = CONFIG_FILE;
 
 /**
- * Stored state for an in-flight signup that returned a payment link. Lets
- * subsequent invocations of `helius signup` (default link mode), `signup
- * --resume`, and `signup --pay` operate against the existing intent without
- * a backend roundtrip and without re-deriving the wallet from the keypair
- * (`--resume` is forbidden from loading the keypair).
+ * Shared shape for any in-flight checkout pending local resume. Each
+ * caller (signup / upgrade / credits) extends with flow-specific identity
+ * fields (wallet address, project id, qty, etc.).
  *
  * Carries the full PaymentLink so `--pay` can pay it, plus the JWT used to
- * create it (kept here, not at the top level, so a later `helius login` that
- * rotates the top-level JWT does not corrupt the resume path).
+ * create it (kept here, not at the top level, so a later `helius login`
+ * rotating top-level JWT can't corrupt --resume).
  *
  * Cleanup rules — DO NOT auto-clear on local `expiresAt`:
  *   - Backend reports `expired` / `failed` → cleared
  *   - Provisioning succeeds (SUCCESS) → cleared
  *   - User passes `--restart` → cleared
- * The user can pay just before expiry but return to the terminal after, and
- * we must not delete a still-valid resume state.
  */
-export interface PendingSignup {
-  // PaymentLink fields
+export interface PendingPaymentBase {
   paymentIntentId: string;
   paymentUrl: string;
   planName: string;
@@ -37,17 +32,27 @@ export interface PendingSignup {
   /** Always equal to `paymentIntentId`. */
   memo: string;
   expiresAt: string;
-
-  // Auth + identity for --resume
-  walletAddress: string;
-  refId: string;
   jwt: string;
-
   /** Set by `--pay` after USDC has been sent but before activation polling lands. */
   txSignature?: string;
-
   /** ISO timestamp of when the pending intent was first stored. */
   createdAt: string;
+}
+
+export interface PendingSignup extends PendingPaymentBase {
+  walletAddress: string;
+  refId: string;
+}
+
+export interface PendingUpgrade extends PendingPaymentBase {
+  projectId: string;
+  targetPlan: string;
+  period?: "monthly" | "yearly";
+}
+
+export interface PendingCredits extends PendingPaymentBase {
+  projectId: string;
+  qty: number;
 }
 
 interface Config {
@@ -57,6 +62,8 @@ interface Config {
   projectId?: string;
   owsWallet?: string;
   pendingSignup?: PendingSignup;
+  pendingUpgrade?: PendingUpgrade;
+  pendingCredits?: PendingCredits;
 }
 
 function ensureDir(): void {
@@ -204,6 +211,52 @@ export function updatePendingSignup(patch: Partial<PendingSignup>): void {
 export function clearPendingSignup(): void {
   const config = load();
   delete config.pendingSignup;
+  save(config);
+}
+
+export function getPendingUpgrade(): PendingUpgrade | undefined {
+  return load().pendingUpgrade;
+}
+
+export function setPendingUpgrade(pending: PendingUpgrade): void {
+  const config = load();
+  config.pendingUpgrade = pending;
+  save(config);
+}
+
+export function updatePendingUpgrade(patch: Partial<PendingUpgrade>): void {
+  const config = load();
+  if (!config.pendingUpgrade) return;
+  config.pendingUpgrade = { ...config.pendingUpgrade, ...patch };
+  save(config);
+}
+
+export function clearPendingUpgrade(): void {
+  const config = load();
+  delete config.pendingUpgrade;
+  save(config);
+}
+
+export function getPendingCredits(): PendingCredits | undefined {
+  return load().pendingCredits;
+}
+
+export function setPendingCredits(pending: PendingCredits): void {
+  const config = load();
+  config.pendingCredits = pending;
+  save(config);
+}
+
+export function updatePendingCredits(patch: Partial<PendingCredits>): void {
+  const config = load();
+  if (!config.pendingCredits) return;
+  config.pendingCredits = { ...config.pendingCredits, ...patch };
+  save(config);
+}
+
+export function clearPendingCredits(): void {
+  const config = load();
+  delete config.pendingCredits;
   save(config);
 }
 

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -48,11 +48,17 @@ export interface PendingUpgrade extends PendingPaymentBase {
   projectId: string;
   targetPlan: string;
   period?: "monthly" | "yearly";
+  /** Wallet that authenticated and created the intent. Optional for backwards
+   * compatibility with intents stored before this field was introduced —
+   * when undefined, the wallet-mismatch check is skipped. */
+  payerWallet?: string;
 }
 
 export interface PendingCredits extends PendingPaymentBase {
   projectId: string;
   qty: number;
+  /** Wallet that authenticated and created the intent. See `PendingUpgrade.payerWallet`. */
+  payerWallet?: string;
 }
 
 interface Config {

--- a/helius-cli/src/lib/payment.ts
+++ b/helius-cli/src/lib/payment.ts
@@ -1,3 +1,52 @@
 // Re-export payment and balance functions from helius-sdk
 export { checkSolBalance, checkUsdcBalance } from "helius-sdk/auth/checkBalances";
 export { MIN_SOL_FOR_TX } from "helius-sdk/auth/constants";
+
+import { getPaymentStatus, type CheckoutStatusResponse } from "./api.js";
+import type ora from "ora";
+
+type Spinner = ReturnType<typeof ora> | null | undefined;
+
+export type RefreshVerdict = "cleared" | "completed" | "still_payable";
+
+/**
+ * Shared backend-status check used by signup/upgrade/credits when a stored
+ * payment intent's local `expiresAt` has passed. The backend is the source
+ * of truth — local clocks lie, and a user could pay just before backend
+ * expiry yet return after.
+ *
+ * - `cleared`     — backend reports expired/failed/410-Gone; caller should
+ *                   clear the stored intent and decide whether to fall
+ *                   through to a fresh-intent path.
+ * - `completed`   — backend reports the payment has settled (regardless of
+ *                   `readyToRedirect`); caller should drive its own
+ *                   poll-and-emit / poll-and-provision flow.
+ * - `still_payable` — backend reports `pending`; caller should re-print the
+ *                   existing payment link.
+ */
+export async function checkBackendForRefresh(
+  jwt: string,
+  paymentIntentId: string,
+  spinner?: Spinner,
+): Promise<{ verdict: RefreshVerdict; status?: CheckoutStatusResponse }> {
+  spinner?.start("Stored payment link is past its local expiry — checking backend...");
+  let status: CheckoutStatusResponse;
+  try {
+    status = await getPaymentStatus(jwt, paymentIntentId);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("410")) {
+      spinner?.succeed("Stored intent expired on the backend");
+      return { verdict: "cleared" };
+    }
+    throw error;
+  }
+  spinner?.succeed(`Backend status: ${status.phase}`);
+
+  if (status.phase === "expired" || status.phase === "failed") {
+    return { verdict: "cleared", status };
+  }
+  if (status.status === "completed" || status.readyToRedirect) {
+    return { verdict: "completed", status };
+  }
+  return { verdict: "still_payable", status };
+}

--- a/helius-cli/src/lib/validation.ts
+++ b/helius-cli/src/lib/validation.ts
@@ -1,7 +1,12 @@
 import { PLAN_CATALOG } from "../lib/checkout.js";
 
-// Valid plans for signup (includes "basic" which isn't in PLAN_CATALOG)
-const SIGNUP_PLANS = new Set(["basic", ...Object.keys(PLAN_CATALOG)]);
+// Valid plans for signup. "basic" was the legacy $1 entry plan; Phase 1 of the
+// crypto-checkout revamp replaces it with "agent" ($10 one-time, 1M credits).
+// `--plan basic` is explicitly rejected with a hint to use `--plan agent`.
+//
+// `agent` lives outside PLAN_CATALOG (which only models monthly/yearly
+// subscription tiers); we list it here explicitly.
+const SIGNUP_PLANS = new Set(["agent", ...Object.keys(PLAN_CATALOG)]);
 const UPGRADE_PLANS = new Set(Object.keys(PLAN_CATALOG));
 const VALID_PERIODS = new Set(["monthly", "yearly"]);
 
@@ -15,7 +20,11 @@ const DOMAIN_RE = /^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]+)+$/;
 const DOMAIN_MAX_LEN = 255;
 
 export function validateSignupPlan(plan: string): string | null {
-  if (!SIGNUP_PLANS.has(plan.toLowerCase())) {
+  const normalized = plan.toLowerCase();
+  if (normalized === "basic") {
+    return "The 'basic' plan was retired. Use --plan agent ($10 USDC one-time, 1,000,000 starting credits).";
+  }
+  if (!SIGNUP_PLANS.has(normalized)) {
     const available = [...SIGNUP_PLANS].join(", ");
     return `Unknown plan: ${plan}. Available: ${available}`;
   }

--- a/helius-cli/vitest.config.ts
+++ b/helius-cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/helius-cursor/README.md
+++ b/helius-cursor/README.md
@@ -42,7 +42,7 @@ The agent picks the right tools and reads the right reference files automaticall
 The plugin auto-starts the MCP server, but you still need a Helius API key. On first use, the agent will guide you through one of these paths:
 
 - **Existing key**: Use the `setHeliusApiKey` tool with your key from https://dashboard.helius.dev
-- **New account**: Autonomous signup via `generateKeypair` → fund wallet → `agenticSignup`
+- **New account**: `generateKeypair` → `signup` with `mode: "link"` (browser pay) or `mode: "autopay"` (pay USDC from local keypair) → after browser payment, `signup` with `mode: "resume"`
 - **CLI**: `npx helius-cli@latest keygen` → fund → `npx helius-cli@latest signup`
 
 ## Links

--- a/helius-cursor/agents/helius-integration-specialist.md
+++ b/helius-cursor/agents/helius-integration-specialist.md
@@ -31,7 +31,7 @@ When helping with a Helius integration:
 
 2. **Check MCP availability** — Verify Helius MCP tools are available before proceeding. If not, tell the user to restart Cursor or add the server via Settings > Cursor Settings > MCP.
 
-3. **Check API key** — If any Helius MCP tool returns "API key not configured", guide through setup: `setHeliusApiKey` for existing keys, or `generateKeypair` → fund → `agenticSignup` for new accounts.
+3. **Check API key** — If any Helius MCP tool returns "API key not configured", guide through setup: `setHeliusApiKey` for existing keys, or `generateKeypair` → `signup` (link or autopay) → optional `signup` with `mode: "resume"` for new accounts.
 
 4. **Read references before writing code** — Always read the relevant reference file(s) before implementing. Never write code based on assumptions about API shapes.
 

--- a/helius-cursor/skills/build/SKILL.md
+++ b/helius-cursor/skills/build/SKILL.md
@@ -25,7 +25,7 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
 **Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
 
@@ -92,7 +92,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting

--- a/helius-cursor/skills/build/references/onboarding.md
+++ b/helius-cursor/skills/build/references/onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-cursor/skills/dflow/SKILL.md
+++ b/helius-cursor/skills/dflow/SKILL.md
@@ -168,7 +168,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`, `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-cursor/skills/dflow/references/helius-onboarding.md
+++ b/helius-cursor/skills/dflow/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-cursor/skills/jupiter/SKILL.md
+++ b/helius-cursor/skills/jupiter/SKILL.md
@@ -180,7 +180,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`, `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-cursor/skills/jupiter/references/helius-onboarding.md
+++ b/helius-cursor/skills/jupiter/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -114,18 +137,16 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **RPC RPS** | 10 | 50 | 200 | 500 |
 | **sendTransaction** | 1/s | 5/s | 50/s | 100/s |
 | **DAS** | 2/s | 10/s | 50/s | 100/s |
-| **WS connections** | 5 | 150 | 250 | 250 |
-| **Enhanced WS** | No | No | 100 conn | 100 conn |
-| **LaserStream** | No | Devnet | Devnet | Full (mainnet + devnet) |
+| **WS connections** | 5 | 150 | 250 | 1,000 |
+| **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
+| **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
 - **0 credits**: Helius Sender (sendSmartTransaction, sendJitoBundle)
 - **1 credit**: Standard RPC calls, sendTransaction, Priority Fee API, webhook events
-- **3 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets)
+- **2 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets, Standard WebSockets)
 - **10 credits**: getProgramAccounts, DAS API, historical data
 - **100 credits**: Enhanced Transactions API, Wallet API, webhook management
 
@@ -133,12 +154,12 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
-| Enhanced WebSockets | Business |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
+| Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
-| LaserStream (mainnet) | Professional |
-| LaserStream data add-ons | Professional ($500+/mo) |
+| LaserStream (mainnet) | Business |
+| LaserStream data add-ons | Business+ ($400+/mo) |
 
 Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current details.
 
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-cursor/skills/phantom/SKILL.md
+++ b/helius-cursor/skills/phantom/SKILL.md
@@ -186,7 +186,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-cursor/skills/phantom/references/helius-onboarding.md
+++ b/helius-cursor/skills/phantom/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-mcp/README.md
+++ b/helius-mcp/README.md
@@ -41,21 +41,24 @@ Or set it from your AI assistant by calling the `setHeliusApiKey` tool.
 
 **If you need a new account:**
 
-The MCP includes a fully autonomous signup flow — no browser needed:
+The MCP includes a `signup` tool with three modes:
 
 1. Call the `generateKeypair` tool — it creates a Solana wallet and returns the address
-2. Fund the wallet with **~0.001 SOL** (transaction fees) + **1 USDC** (basic plan costs $1)
-3. Call `checkSignupBalance` to verify funds arrived
-4. Call `agenticSignup` to create your account — API key is configured automatically
+2. Call `signup` with `mode: "link"` — returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) you open in any browser to pay with any wallet
+3. After paying in the browser, call `signup` with `mode: "resume"` — finalizes provisioning and configures the API key automatically
+4. Or skip the browser: call `signup` with `mode: "autopay"` to pay USDC from the local keypair (wallet must hold ~0.001 SOL + the plan amount in USDC)
 
-> **Paid plans (developer/business/professional):** `agenticSignup` and `upgradePlan` require `email`, `firstName`, and `lastName`. Basic plan does not.
+> **All paid plans:** `signup` and `upgradePlan` require `email`, `firstName`, and `lastName` for new signups (every plan, including Agent).
 
 Or do the same from the terminal:
 
 ```bash
-npx helius-cli@latest keygen     # Generate keypair
-# Fund the wallet address shown above with ~0.001 SOL + 1 USDC
-npx helius-cli@latest signup      # Verify balance + create account
+npx helius-cli@latest keygen                  # Generate keypair
+npx helius-cli@latest signup --plan agent     # Print hosted payment link
+# (pay in browser, then:)
+npx helius-cli@latest signup --resume         # Finalize account
+# Or autopay USDC from the local keypair:
+npx helius-cli@latest signup --plan agent --pay
 ```
 
 ### 3. Start using tools

--- a/helius-mcp/package.json
+++ b/helius-mcp/package.json
@@ -45,7 +45,7 @@
     "@solana-program/token": "^0.9.0",
     "@solana/kit": "^5.0.0",
     "bs58": "^6.0.0",
-    "helius-sdk": "^2.2.2",
+    "helius-sdk": "^3.0.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/helius-mcp/pnpm-lock.yaml
+++ b/helius-mcp/pnpm-lock.yaml
@@ -236,66 +236,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}

--- a/helius-mcp/pnpm-lock.yaml
+++ b/helius-mcp/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       helius-sdk:
-        specifier: ^2.2.2
-        version: 2.2.2(typescript@5.9.3)
+        specifier: ^3.0.0
+        version: 3.0.0(@solana-program/compute-budget@0.11.0(@solana/kit@5.4.0(typescript@5.9.3)))(@solana-program/stake@0.5.0(@solana/kit@5.4.0(typescript@5.9.3)))(@solana-program/system@0.10.0(@solana/kit@5.4.0(typescript@5.9.3)))(@solana-program/token@0.9.0(@solana/kit@5.4.0(typescript@5.9.3)))(@solana/kit@5.4.0(typescript@5.9.3))
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -975,8 +975,15 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  helius-sdk@2.2.2:
-    resolution: {integrity: sha512-T7H9fJOYAB9HUZomDQ47EnKYPE//SgweZz4PbWF6q0Y1/jA0J+7xY15kFpZLJHyAGd4AXXxDCSISRdABmpCjfQ==}
+  helius-sdk@3.0.0:
+    resolution: {integrity: sha512-fd6s8jtgs85qBRxRveEjnfsb8JjkJPydtM2Na5F5UdT9PKjrbcTkqKe9isr9Kh8rYW5sQ1WbZzGapgersTbrMg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@solana-program/compute-budget': ^0.15.0
+      '@solana-program/stake': ^0.6.1
+      '@solana-program/system': ^0.12.0
+      '@solana-program/token': ^0.13.0
+      '@solana/kit': ^6.9.0
 
   hono@4.11.4:
     resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
@@ -2302,7 +2309,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  helius-sdk@2.2.2(typescript@5.9.3):
+  helius-sdk@3.0.0(@solana-program/compute-budget@0.11.0(@solana/kit@5.4.0(typescript@5.9.3)))(@solana-program/stake@0.5.0(@solana/kit@5.4.0(typescript@5.9.3)))(@solana-program/system@0.10.0(@solana/kit@5.4.0(typescript@5.9.3)))(@solana-program/token@0.9.0(@solana/kit@5.4.0(typescript@5.9.3)))(@solana/kit@5.4.0(typescript@5.9.3)):
     dependencies:
       '@solana-program/compute-budget': 0.11.0(@solana/kit@5.4.0(typescript@5.9.3))
       '@solana-program/stake': 0.5.0(@solana/kit@5.4.0(typescript@5.9.3))
@@ -2311,11 +2318,6 @@ snapshots:
       '@solana/kit': 5.4.0(typescript@5.9.3)
       bs58: 6.0.0
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
 
   hono@4.11.4: {}
 

--- a/helius-mcp/src/router/actions.ts
+++ b/helius-mcp/src/router/actions.ts
@@ -2,8 +2,7 @@ export const HELIUS_ACCOUNT_ACTIONS = [
   'getStarted',
   'setHeliusApiKey',
   'generateKeypair',
-  'checkSignupBalance',
-  'agenticSignup',
+  'signup',
   'getAccountStatus',
   'getAccountPlan',
   'getHeliusPlanInfo',
@@ -11,6 +10,7 @@ export const HELIUS_ACCOUNT_ACTIONS = [
   'previewUpgrade',
   'upgradePlan',
   'payRenewal',
+  'purchaseCredits',
 ] as const;
 
 export const HELIUS_WALLET_ACTIONS = [

--- a/helius-mcp/src/router/catalog.ts
+++ b/helius-mcp/src/router/catalog.ts
@@ -59,7 +59,7 @@ function makeEntry(
     publicTool,
     aliases: overrides.aliases ?? [],
     authRequirement: overrides.authRequirement ?? 'apiKey',
-    capabilityGate: overrides.capabilityGate ?? gate('free', 'Available on free plan'),
+    capabilityGate: overrides.capabilityGate ?? gate('agent', 'Available on every plan'),
     mutability: overrides.mutability ?? (publicTool === 'heliusWrite' ? 'write' : 'read'),
     responseFamily,
     defaultDetail,
@@ -83,50 +83,50 @@ const catalog: Partial<Record<ActionName, ActionCatalogEntry>> = {};
 
 addEntries(catalog, HELIUS_ACCOUNT_ACTIONS, {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'Account setup and plan metadata'),
+  capabilityGate: gate('agent', 'Account setup and plan metadata'),
   responseFamily: 'record',
 });
 
 addEntries(catalog, HELIUS_WALLET_ACTIONS, {
-  capabilityGate: gate('free', 'Wallet data'),
+  capabilityGate: gate('agent', 'Wallet data'),
   responseFamily: 'record',
 });
 
 addEntries(catalog, HELIUS_ASSET_ACTIONS, {
-  capabilityGate: gate('free', 'Asset and DAS queries'),
+  capabilityGate: gate('agent', 'Asset and DAS queries'),
   responseFamily: 'record',
 });
 
 addEntries(catalog, HELIUS_TRANSACTION_ACTIONS, {
-  capabilityGate: gate('free', 'Transaction parsing and history'),
+  capabilityGate: gate('agent', 'Transaction parsing and history'),
   responseFamily: 'history',
 });
 
 addEntries(catalog, HELIUS_CHAIN_ACTIONS, {
-  capabilityGate: gate('free', 'Core chain state'),
+  capabilityGate: gate('agent', 'Core chain state'),
   responseFamily: 'record',
 });
 
 addEntries(catalog, HELIUS_STREAMING_ACTIONS, {
-  capabilityGate: gate('free', 'Streaming and webhook operations'),
+  capabilityGate: gate('agent', 'Streaming and webhook operations'),
   responseFamily: 'record',
 });
 
 addEntries(catalog, HELIUS_KNOWLEDGE_ACTIONS, {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'Documentation and knowledge'),
+  capabilityGate: gate('agent', 'Documentation and knowledge'),
   responseFamily: 'document',
 });
 
 addEntries(catalog, HELIUS_WRITE_ACTIONS, {
   authRequirement: 'signer',
-  capabilityGate: gate('free', 'Transaction sending and staking'),
+  capabilityGate: gate('agent', 'Transaction sending and staking'),
   mutability: 'write',
   responseFamily: 'mutationReceipt',
 });
 
 addEntries(catalog, HELIUS_COMPRESSION_ACTIONS, {
-  capabilityGate: gate('free', 'Compression state queries'),
+  capabilityGate: gate('agent', 'Compression state queries'),
   responseFamily: 'record',
 });
 
@@ -279,7 +279,7 @@ for (const action of ['transactionSubscribe', 'accountSubscribe', 'laserstreamSu
 
 catalog.setHeliusApiKey = makeEntry('setHeliusApiKey', {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'API key configuration'),
+  capabilityGate: gate('agent', 'API key configuration'),
   responseFamily: 'record',
   defaultDetail: 'standard',
   handleEligibility: false,
@@ -287,7 +287,7 @@ catalog.setHeliusApiKey = makeEntry('setHeliusApiKey', {
 
 catalog.generateKeypair = makeEntry('generateKeypair', {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'Local keypair generation'),
+  capabilityGate: gate('agent', 'Local keypair generation'),
   responseFamily: 'record',
   defaultDetail: 'standard',
   handleEligibility: false,
@@ -295,7 +295,7 @@ catalog.generateKeypair = makeEntry('generateKeypair', {
 
 catalog.getStarted = makeEntry('getStarted', {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'Setup instructions'),
+  capabilityGate: gate('agent', 'Setup instructions'),
   responseFamily: 'record',
   defaultDetail: 'standard',
   handleEligibility: false,
@@ -303,7 +303,7 @@ catalog.getStarted = makeEntry('getStarted', {
 
 catalog.signup = makeEntry('signup', {
   authRequirement: 'signer',
-  capabilityGate: gate('free', 'Signup flow'),
+  capabilityGate: gate('agent', 'Signup flow'),
   responseFamily: 'record',
   defaultDetail: 'standard',
   handleEligibility: false,
@@ -311,7 +311,7 @@ catalog.signup = makeEntry('signup', {
 
 catalog.purchaseCredits = makeEntry('purchaseCredits', {
   authRequirement: 'jwt',
-  capabilityGate: gate('free', 'Prepaid credits top-up'),
+  capabilityGate: gate('agent', 'Prepaid credits top-up'),
   responseFamily: 'record',
   defaultDetail: 'standard',
   handleEligibility: false,
@@ -319,20 +319,20 @@ catalog.purchaseCredits = makeEntry('purchaseCredits', {
 
 catalog.getAccountStatus = makeEntry('getAccountStatus', {
   authRequirement: 'jwt',
-  capabilityGate: gate('free', 'Authenticated account status'),
+  capabilityGate: gate('agent', 'Authenticated account status'),
   responseFamily: 'record',
 });
 
 catalog.previewUpgrade = makeEntry('previewUpgrade', {
   authRequirement: 'jwt',
-  capabilityGate: gate('free', 'Upgrade preview'),
+  capabilityGate: gate('agent', 'Upgrade preview'),
   responseFamily: 'record',
   handleEligibility: false,
 });
 
 catalog.upgradePlan = makeEntry('upgradePlan', {
   authRequirement: 'jwtAndSigner',
-  capabilityGate: gate('free', 'Upgrade checkout'),
+  capabilityGate: gate('agent', 'Upgrade checkout'),
   mutability: 'write',
   responseFamily: 'mutationReceipt',
   handleEligibility: false,
@@ -340,7 +340,7 @@ catalog.upgradePlan = makeEntry('upgradePlan', {
 
 catalog.payRenewal = makeEntry('payRenewal', {
   authRequirement: 'jwtAndSigner',
-  capabilityGate: gate('free', 'Renewal checkout'),
+  capabilityGate: gate('agent', 'Renewal checkout'),
   mutability: 'write',
   responseFamily: 'mutationReceipt',
   handleEligibility: false,
@@ -348,14 +348,14 @@ catalog.payRenewal = makeEntry('payRenewal', {
 
 catalog.compareHeliusPlans = makeEntry('compareHeliusPlans', {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'Plan comparison'),
+  capabilityGate: gate('agent', 'Plan comparison'),
   responseFamily: 'catalog',
   defaultDetail: 'summary',
 });
 
 catalog.getHeliusPlanInfo = makeEntry('getHeliusPlanInfo', {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'Plan details'),
+  capabilityGate: gate('agent', 'Plan details'),
   responseFamily: 'catalog',
   defaultDetail: 'summary',
 });
@@ -418,7 +418,7 @@ catalog.laserstreamSubscribe = makeEntry('laserstreamSubscribe', {
 
 catalog.getEnhancedWebSocketInfo = makeEntry('getEnhancedWebSocketInfo', {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'Enhanced WebSocket info', [
+  capabilityGate: gate('agent', 'Enhanced WebSocket info', [
     {
       id: 'business:enhanced-websockets',
       minimumPlan: 'business',
@@ -432,7 +432,7 @@ catalog.getEnhancedWebSocketInfo = makeEntry('getEnhancedWebSocketInfo', {
 
 catalog.getLaserstreamInfo = makeEntry('getLaserstreamInfo', {
   authRequirement: 'none',
-  capabilityGate: gate('free', 'Laserstream info', [
+  capabilityGate: gate('agent', 'Laserstream info', [
     {
       id: 'developer:laserstream-devnet',
       minimumPlan: 'developer',

--- a/helius-mcp/src/router/catalog.ts
+++ b/helius-mcp/src/router/catalog.ts
@@ -147,7 +147,6 @@ const professionalLaserstreamGate = gate(
 
 const scalarActions: ActionName[] = [
   'getBalance',
-  'checkSignupBalance',
   'getAccountPlan',
   'getNetworkStatus',
   'getPriorityFeeEstimate',
@@ -302,9 +301,17 @@ catalog.getStarted = makeEntry('getStarted', {
   handleEligibility: false,
 });
 
-catalog.agenticSignup = makeEntry('agenticSignup', {
+catalog.signup = makeEntry('signup', {
   authRequirement: 'signer',
-  capabilityGate: gate('free', 'Agentic signup flow'),
+  capabilityGate: gate('free', 'Signup flow'),
+  responseFamily: 'record',
+  defaultDetail: 'standard',
+  handleEligibility: false,
+});
+
+catalog.purchaseCredits = makeEntry('purchaseCredits', {
+  authRequirement: 'jwt',
+  capabilityGate: gate('free', 'Prepaid credits top-up'),
   responseFamily: 'record',
   defaultDetail: 'standard',
   handleEligibility: false,

--- a/helius-mcp/src/router/types.ts
+++ b/helius-mcp/src/router/types.ts
@@ -25,7 +25,7 @@ export type GatePredicate =
 
 export type CapabilityVariant = {
   id: string;
-  minimumPlan: 'free' | 'developer' | 'business' | 'professional';
+  minimumPlan: 'agent' | 'developer' | 'business' | 'professional';
   predicate: GatePredicate;
   label: string;
 };

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -118,16 +118,17 @@ export function registerAuthTools(server: McpServer) {
         '',
         '## Path B — Create a new account via crypto checkout',
         '',
-        '1. Call `signup` with your email/name. By default it returns a hosted-checkout link the user can open in a browser to pay.',
-        '2. After the user pays, call `signup` again with `mode: "resume"` (or just `signup` again — it picks up the pending intent) to provision the API key.',
+        '1. Call `generateKeypair` to create (or load) a Solana wallet — required for every signup mode, including link mode (the wallet address is bound to the payment intent).',
+        '2. Call `signup` with your email/name. By default (`mode: "link"`) it returns a hosted-checkout URL the user can open in a browser to pay with any wallet.',
+        '3. After the user pays, call `signup` again with `mode: "resume"` to poll the intent and provision the API key.',
         '',
-        'For an autopay flow that pays directly from a local Solana keypair, pass `mode: "autopay"` to `signup`. The MCP will generate a keypair for you (`generateKeypair`), and you must ensure the wallet has ~0.001 SOL for fees and the plan amount in USDC.',
+        'For an autopay flow that pays USDC directly from the local keypair, pass `mode: "autopay"` to `signup`. The wallet must hold ~0.001 SOL for fees and the plan amount in USDC.',
         '',
       );
 
       if (hasKeypair) {
         lines.push(
-          `_(A keypair already exists at \`${KEYPAIR_PATH}\` — autopay mode will reuse it.)_`,
+          `_(A keypair already exists at \`${KEYPAIR_PATH}\` — \`signup\` will reuse it; you can skip step 1.)_`,
           '',
         );
       }
@@ -140,7 +141,7 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'generateKeypair',
-    'Generate a new Solana keypair (or load the existing one from disk). Returns the wallet address. Used by the `signup` autopay path; not needed for default link mode.',
+    'Generate a new Solana keypair (or load the existing one from disk). Returns the wallet address. Required before any `signup` call — the wallet address is bound to the payment intent in both link and autopay modes.',
     {},
     async () => {
       try {
@@ -182,7 +183,7 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'signup',
-    'Create a Helius account via crypto checkout. Default `mode: "link"` returns a hosted-checkout URL the user opens in a browser to pay USDC. `mode: "autopay"` sends USDC + memo directly from the local keypair (the MCP will load/generate one if needed). `mode: "resume"` polls a pending payment intent and provisions the API key after the user has paid in a browser.',
+    'Create a Helius account via crypto checkout. Requires `generateKeypair` to have been called first (the wallet address is bound to the payment intent in every mode). Default `mode: "link"` returns a hosted-checkout URL the user opens in a browser to pay USDC. `mode: "autopay"` sends USDC + memo directly from the local keypair. `mode: "resume"` polls a pending payment intent and provisions the API key after the user has paid in a browser.',
     {
       mode: z
         .enum(['link', 'autopay', 'resume'])

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -530,10 +530,10 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'purchaseCredits',
-    'Top up prepaid credits on an agent-plan project. Default `mode: "link"` returns a hosted-checkout URL. `mode: "autopay"` pays USDC from the local keypair and polls. Each unit of `qty` grants 1,000,000 credits.',
+    'Buy prepaid credits as a one-time USDC top-up. AGENT PLAN ONLY: each unit of `qty` is 1,000,000 credits at $10 USDC, no recurring sub. Subscription plans (Developer / Business / Professional) get monthly allotments and overage is auto-billed at $5/M on the next invoice — they can NOT use this tool; this tool will reject the call with UNSUPPORTED_PLAN. Default `mode: "link"` returns a hosted-checkout URL; `mode: "autopay"` pays USDC from the local keypair and polls.',
     {
       mode: z.enum(['link', 'autopay']).default('link').describe('link (default) or autopay'),
-      qty: z.number().int().min(1).default(1).describe('Quantity multiplier (each unit = 1M credits)'),
+      qty: z.number().int().min(1).default(1).describe('Quantity multiplier (each unit = 1M credits at $10 USDC)'),
       couponCode: z.string().optional().describe('Optional coupon code'),
     },
     async ({ mode, qty, couponCode }) => {
@@ -558,6 +558,26 @@ export function registerAuthTools(server: McpServer) {
           });
         }
         const projectId = projects[0].id;
+
+        // Pre-flight plan check. SDK will reject non-Agent plans, but its
+        // error path surfaces as a generic SDK_ERROR; intercepting here gives
+        // the agent a clean, structured error with the correct semantics.
+        const projectPlan = projects[0].subscription?.plan;
+        const normalizedPlan = projectPlan?.replace(/_v\d+$/, '');
+        if (normalizedPlan && normalizedPlan !== 'agent') {
+          return mcpError(
+            `Prepaid credits via \`purchaseCredits\` are only available on the Agent plan. ` +
+              `Project ${projectId} is on the ${normalizedPlan} plan, where credit overage ` +
+              `is auto-billed at $5 per 1,000,000 credits on the next invoice — there's no ` +
+              `manual top-up flow. To preview your usage, call \`getAccountStatus\`.`,
+            {
+              type: 'UNSUPPORTED',
+              code: 'UNSUPPORTED_PLAN',
+              retryable: false,
+              recovery: 'Use the dashboard to manage subscription overage, or call `getAccountStatus` to inspect usage.',
+            },
+          );
+        }
 
         if (mode === 'autopay') {
           let signerData: { secretKey: Uint8Array; walletAddress: string };

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -183,7 +183,7 @@ export function registerAuthTools(server: McpServer) {
 
   server.tool(
     'signup',
-    'Create a Helius account via crypto checkout. Requires `generateKeypair` to have been called first (the wallet address is bound to the payment intent in every mode). Default `mode: "link"` returns a hosted-checkout URL the user opens in a browser to pay USDC. `mode: "autopay"` sends USDC + memo directly from the local keypair. `mode: "resume"` polls a pending payment intent and provisions the API key after the user has paid in a browser.',
+    'Create a Helius account via crypto checkout. Requires `generateKeypair` to have been called first (the wallet address is bound to the payment intent in every mode). Default `mode: "link"` returns a hosted-checkout URL the user opens in a browser to pay USDC. `mode: "autopay"` sends USDC + memo directly from the local keypair. `mode: "resume"` polls a pending payment intent and provisions the API key after the user has paid in a browser. NOTE: resume strictly polls the JWT-bound project list and cannot distinguish "pending signup awaiting browser pay" from "stale JWT left over from a long-completed signup" — if the wallet already has an API key, prefer `setHeliusApiKey` over re-resuming.',
     {
       mode: z
         .enum(['link', 'autopay', 'resume'])

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -3,35 +3,67 @@ import { z } from 'zod';
 import { generateKeypair } from 'helius-sdk/auth/generateKeypair';
 import { loadKeypair } from 'helius-sdk/auth/loadKeypair';
 import { getAddress } from 'helius-sdk/auth/getAddress';
-import { checkSolBalance, checkUsdcBalance } from 'helius-sdk/auth/checkBalances';
-import { agenticSignup } from 'helius-sdk/auth/agenticSignup';
-import { getCheckoutPreview, executeCheckout, executeRenewal } from 'helius-sdk/auth/checkout';
 import { listProjects } from 'helius-sdk/auth/listProjects';
 import { getProject } from 'helius-sdk/auth/getProject';
-import { PLAN_CATALOG } from 'helius-sdk/auth/planCatalog';
+import { getCheckoutPreview } from 'helius-sdk/auth/checkout';
+import { signup } from 'helius-sdk/auth/signup';
+import { signupAndPay } from 'helius-sdk/auth/signupAndPay';
+import { upgradePlan, upgradePlanAndPay } from 'helius-sdk/auth/upgradePlan';
+import {
+  purchaseCredits as sdkPurchaseCredits,
+  purchaseCreditsAndPay,
+} from 'helius-sdk/auth/purchaseCredits';
+import { payRenewal, payRenewalAndPay } from 'helius-sdk/auth/payRenewal';
 import { MCP_USER_AGENT } from '../http.js';
 import {
   setApiKey,
   hasApiKey,
   setSessionSecretKey,
   setSessionWalletAddress,
-  getSessionWalletAddress,
   loadSignerOrFail,
 } from '../utils/helius.js';
 import { mcpText, mcpError, handleToolError } from '../utils/errors.js';
 import { fetchDoc, extractSections } from '../utils/docs.js';
 import { sendFeedbackEvent, captureWalletAddress } from '../utils/feedback.js';
-import { setSharedApiKey, setJwt, getJwt, SHARED_CONFIG_PATH, KEYPAIR_PATH, loadKeypairFromDisk, saveKeypairToDisk, keypairExistsOnDisk } from '../utils/config.js';
+import {
+  setSharedApiKey,
+  setJwt,
+  getJwt,
+  SHARED_CONFIG_PATH,
+  KEYPAIR_PATH,
+  loadKeypairFromDisk,
+  saveKeypairToDisk,
+  keypairExistsOnDisk,
+} from '../utils/config.js';
 import { HELIUS_PLANS } from './plans.js';
 
-const PAID_PLAN_ORDER = ['developer', 'business', 'professional'] as const;
+type SupportedPlan = 'agent' | 'developer' | 'business' | 'professional';
 
-/** Tracks consecutive insufficient-balance checks to prevent agent polling loops. */
-let insufficientBalanceChecks = 0;
-const MAX_BALANCE_CHECKS_BEFORE_STOP = 3;
+const renderPaymentLink = (
+  paymentLink: {
+    paymentUrl: string;
+    paymentIntentId: string;
+    amountCents: number;
+    destinationWallet: string;
+    memo: string;
+    planName: string;
+    expiresAt: string;
+  },
+  flowName: string,
+  resumeCmd: string,
+): string =>
+  `**${flowName}: payment required**\n\n` +
+  `Open this link in a browser to pay:\n\n` +
+  `\`${paymentLink.paymentUrl}\`\n\n` +
+  `Or send USDC + memo manually:\n` +
+  `- **Amount:** ${paymentLink.amountCents / 100} USDC\n` +
+  `- **Treasury:** \`${paymentLink.destinationWallet}\`\n` +
+  `- **Memo:** \`${paymentLink.memo}\`\n` +
+  `- **Plan:** ${paymentLink.planName}\n\n` +
+  `After paying, call \`${resumeCmd}\` to confirm activation locally.`;
 
 export function registerAuthTools(server: McpServer) {
-  // ── Getting Started Guide ──
+  // ── Getting Started ──
 
   server.tool(
     'getStarted',
@@ -44,7 +76,7 @@ export function registerAuthTools(server: McpServer) {
       const hasKeypair = keypairExistsOnDisk();
       const jwt = getJwt();
 
-      // ── Already fully set up ──
+      // Already fully set up
       if (apiKeyConfigured && jwt) {
         lines.push(
           '',
@@ -59,141 +91,73 @@ export function registerAuthTools(server: McpServer) {
           '',
           'Just ask a question in plain English and the right tool will be used automatically.',
           '',
-          '**IMPORTANT — if the user described a project they want to build, call `recommendStack` now** with their project description. It returns architecture recommendations with Helius products, MCP tools, credit costs, and reference files tailored to their plan.',
+          '**IMPORTANT — if the user described a project they want to build, call `recommendStack` now.** It returns architecture recommendations with Helius products, MCP tools, credit costs, and reference files.',
         );
         return mcpText(lines.join('\n'));
       }
 
-      // ── API key set but no JWT (e.g., set via env or setHeliusApiKey) ──
+      // API key set but no JWT
       if (apiKeyConfigured) {
         lines.push(
           '',
           'Your API key is configured — all Helius tools are ready to use.',
           '',
-          '**What you can do:**',
-          '- Query NFTs and tokens: `getAssetsByOwner`, `searchAssets`',
-          '- Check balances: `getBalance`, `getTokenAccounts`',
-          '- Parse transactions: `parseTransactions`',
-          '- Manage webhooks: `createWebhook`, `getAllWebhooks`',
-          '',
-          'Just ask a question in plain English and the right tool will be used automatically.',
-          '',
-          '**IMPORTANT — if the user described a project they want to build, call `recommendStack` now** with their project description. It returns architecture recommendations with Helius products, MCP tools, credit costs, and reference files.',
-          '',
-          '**Optional:** To see your plan, credits, and rate limits, call `agenticSignup` — it will detect your existing account (no payment needed) and enable `getAccountStatus`.',
+          'To enable account-status info (plan, credits, rate limits), call `signup`. It will detect your existing account, no payment required.',
         );
         return mcpText(lines.join('\n'));
       }
 
-      // ── No API key — need to set up ──
+      // No API key — need to set up
       lines.push(
         '',
-        'You need a Helius API key to use these tools. Choose one of these paths:',
-        '',
-        '---',
+        'You need a Helius API key to use these tools. Two paths:',
         '',
         '## Path A — I already have an API key',
         '',
-        'If you have a key from https://dashboard.helius.dev:',
-        '1. Call the `setHeliusApiKey` tool with your key',
-        '2. Done — all tools are immediately available',
+        'Call `setHeliusApiKey` with your key from https://dashboard.helius.dev. All tools immediately available.',
         '',
-        '---',
+        '## Path B — Create a new account via crypto checkout',
         '',
-        '## Path B — Create a new account',
+        '1. Call `signup` with your email/name. By default it returns a hosted-checkout link the user can open in a browser to pay.',
+        '2. After the user pays, call `signup` again with `mode: "resume"` (or just `signup` again — it picks up the pending intent) to provision the API key.',
         '',
-        'The signup is fully autonomous — no browser needed. It takes ~2 minutes:',
+        'For an autopay flow that pays directly from a local Solana keypair, pass `mode: "autopay"` to `signup`. The MCP will generate a keypair for you (`generateKeypair`), and you must ensure the wallet has ~0.001 SOL for fees and the plan amount in USDC.',
         '',
       );
 
-      // Adapt steps based on whether a keypair already exists
       if (hasKeypair) {
         lines.push(
-          '### Step 1: Keypair ✓',
-          `You already have a keypair saved at \`${KEYPAIR_PATH}\`.`,
-          'Call `generateKeypair` to load it and see the wallet address.',
-          '',
-        );
-      } else {
-        lines.push(
-          '### Step 1: Generate a keypair',
-          'Call the `generateKeypair` tool. It creates a Solana wallet and returns the address.',
+          `_(A keypair already exists at \`${KEYPAIR_PATH}\` — autopay mode will reuse it.)_`,
           '',
         );
       }
 
-      lines.push(
-        '### Step 2: Fund the wallet',
-        'Send the following to the wallet address from Step 1:',
-        '- **~0.001 SOL** — covers transaction fees',
-        '- **1 USDC** — pays for the basic plan ($1)',
-        '',
-        'You can send from any Solana wallet, exchange, or on-ramp.',
-        'The USDC token mint on Solana is: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`',
-        '',
-        `For paid plans, send more USDC instead: ${PAID_PLAN_ORDER.filter(k => k in PLAN_CATALOG).map(k => `$${PLAN_CATALOG[k].monthlyPrice / 100} (${PLAN_CATALOG[k].name})`).join(', ')}.`,
-        '',
-        '### Step 3: Verify funding',
-        'Call `checkSignupBalance` to confirm your SOL and USDC balances are sufficient.',
-        '',
-        '### Step 4: Create the account',
-        'Call `agenticSignup` to process the payment and create your Helius account.',
-        'Your API key will be configured automatically — no extra steps needed.',
-        '',
-        '> **Paid plans only:** `agenticSignup` requires `email`, `firstName`, and `lastName` for developer/business/professional plans. Basic plan ($1) does not require them.',
-        '',
-        '---',
-        '',
-        '## Path C — Use the Helius CLI',
-        '',
-        'Same flow from the terminal:',
-        '```',
-        'npx helius-cli@latest keygen     # Generate keypair',
-        '# Fund the wallet address shown above',
-        'npx helius-cli@latest signup      # Verify balance + create account',
-        '```',
-        '',
-        '---',
-        '',
-        '**After setup:** Use `recommendStack` to plan your project — describe what you\'re building and get architecture recommendations at different cost and complexity levels.',
-      );
-
       return mcpText(lines.join('\n'));
-    }
+    },
   );
 
   // ── Keypair Generation ──
 
   server.tool(
     'generateKeypair',
-    'Generate a new Solana keypair for Helius account signup. Returns the wallet address. The user must fund this wallet with ~0.001 SOL + 1 USDC (basic plan) or more USDC (for paid plans) before calling agenticSignup.',
+    'Generate a new Solana keypair (or load the existing one from disk). Returns the wallet address. Used by the `signup` autopay path; not needed for default link mode.',
     {},
     async () => {
       try {
-        // Reset balance-check counter for fresh signup flow
-        insufficientBalanceChecks = 0;
-
-        // Check disk first — reuse existing keypair if available
         const existingKey = loadKeypairFromDisk();
         if (existingKey) {
           const walletKeypair = loadKeypair(existingKey);
           const address = await getAddress(walletKeypair);
-
           setSessionSecretKey(existingKey);
           setSessionWalletAddress(address);
           captureWalletAddress(address);
 
           return mcpText(
             `**Existing Keypair Loaded** from \`${KEYPAIR_PATH}\`\n\n` +
-            `**Wallet Address:** \`${address}\`\n\n` +
-            `To create a Helius account, fund this wallet with:\n` +
-            `- **~0.001 SOL** for transaction fees\n` +
-            `- **1 USDC** for basic plan (or more for paid plans)\n\n` +
-            `Then call \`agenticSignup\` to complete account creation.`
+              `**Wallet Address:** \`${address}\``,
           );
         }
 
-        // Generate new keypair and persist to disk
         const keypair = await generateKeypair();
         const walletKeypair = loadKeypair(keypair.secretKey);
         const address = await getAddress(walletKeypair);
@@ -205,121 +169,43 @@ export function registerAuthTools(server: McpServer) {
 
         return mcpText(
           `**Keypair Generated**\n\n` +
-          `**Wallet Address:** \`${address}\`\n` +
-          `**Saved to:** \`${KEYPAIR_PATH}\`\n\n` +
-          `To create a Helius account, fund this wallet with:\n` +
-          `- **~0.001 SOL** for transaction fees\n` +
-          `- **1 USDC** for basic plan (or more for paid plans)\n\n` +
-          `Then call \`agenticSignup\` to complete account creation.`
+            `**Wallet Address:** \`${address}\`\n` +
+            `**Saved to:** \`${KEYPAIR_PATH}\``,
         );
       } catch (err) {
         return handleToolError(err, 'Error generating keypair');
       }
-    }
-  );
-
-  server.tool(
-    'checkSignupBalance',
-    'Check if the signup wallet has sufficient SOL and USDC balance for Helius basic plan ($1 USDC). Paid plans (developer/business/professional) require more USDC — the exact amount depends on the plan and is checked during checkout.',
-    {},
-    async () => {
-      try {
-        let address = getSessionWalletAddress();
-
-        // Fall back to disk keypair if no session wallet
-        if (!address) {
-          const diskKey = loadKeypairFromDisk();
-          if (diskKey) {
-            const walletKeypair = loadKeypair(diskKey);
-            address = await getAddress(walletKeypair);
-            setSessionSecretKey(diskKey);
-            setSessionWalletAddress(address);
-          }
-        }
-
-        if (!address) {
-          return mcpError(
-            'No signup wallet found. Call `generateKeypair` first to create a wallet.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
-          );
-        }
-
-        const solBalance = await checkSolBalance(address);
-        const usdcBalance = await checkUsdcBalance(address);
-
-        const solAmount = Number(solBalance) / 1_000_000_000;
-        const usdcAmount = Number(usdcBalance) / 1_000_000;
-
-        const solOk = solBalance >= 1_000_000n;
-        const usdcOk = usdcBalance >= 1_000_000n; // 1 USDC for basic plan
-
-        const funded = solOk && usdcOk;
-
-        // Reset counter when balance is sufficient
-        if (funded) {
-          insufficientBalanceChecks = 0;
-          return mcpText(
-            `**Signup Wallet Balance** (\`${address}\`)\n\n` +
-            `- **SOL:** ${solAmount.toFixed(6)} (sufficient)\n` +
-            `- **USDC:** ${usdcAmount.toFixed(2)} (sufficient for basic)\n\n` +
-            `**Status:** Ready for signup (basic plan). For paid plans, ensure sufficient USDC for the plan price.\n\n` +
-            `Call \`agenticSignup\` to proceed.`
-          );
-        }
-
-        // Insufficient — increment counter and escalate guidance
-        insufficientBalanceChecks++;
-
-        const missing: string[] = [];
-        if (!solOk) missing.push(`~0.001 SOL (have ${solAmount.toFixed(6)})`);
-        if (!usdcOk) missing.push(`1 USDC (have ${usdcAmount.toFixed(2)})`);
-
-        let balanceBlock =
-          `**Signup Wallet Balance** (\`${address}\`)\n\n` +
-          `- **SOL:** ${solAmount.toFixed(6)} ${solOk ? '(sufficient)' : '(insufficient)'}\n` +
-          `- **USDC:** ${usdcAmount.toFixed(2)} ${usdcOk ? '(sufficient for basic)' : '(insufficient)'}\n\n` +
-          `**Status:** Need more funds: ${missing.join(', ')}`;
-
-        if (insufficientBalanceChecks === 1) {
-          // First check — normal guidance
-          balanceBlock +=
-            `\n\n**Action required:** Ask the user to send the missing funds to \`${address}\`. ` +
-            `Do **not** call \`checkSignupBalance\` again until the user confirms they have sent the funds.`;
-        } else if (insufficientBalanceChecks < MAX_BALANCE_CHECKS_BEFORE_STOP) {
-          // Second check — firmer nudge
-          balanceBlock +=
-            `\n\n**⚠ Balance still insufficient (check ${insufficientBalanceChecks}/${MAX_BALANCE_CHECKS_BEFORE_STOP}).** ` +
-            `The wallet has not been funded yet. Ask the user to confirm they have sent funds to \`${address}\` before calling this tool again.`;
-        } else {
-          // Third+ check — hard stop
-          balanceBlock +=
-            `\n\n**🛑 Balance checked ${insufficientBalanceChecks} times — still insufficient. Stop polling.** ` +
-            `The wallet \`${address}\` has not received funds. ` +
-            `Tell the user the exact amounts needed and the wallet address, then **wait for the user to explicitly confirm** they have sent funds before calling \`checkSignupBalance\` again. ` +
-            `Do not retry automatically.`;
-        }
-
-        return mcpText(balanceBlock);
-      } catch (err) {
-        return handleToolError(err, 'Error checking balances');
-      }
-    }
-  );
-
-  server.tool(
-    'agenticSignup',
-    'Create a Helius account using the generated keypair. Default: basic plan ($1 USDC). For paid plans (developer/business/professional), email, firstName, and lastName are required. On success, automatically configures the API key for this session.',
-    {
-      plan: z.string().optional().describe('Plan to sign up for: "basic" ($1, default), "developer", "business", or "professional"'),
-      period: z.enum(["monthly", "yearly"]).optional().describe('Billing period for paid plans (default: monthly)'),
-      email: z.string().email().optional().describe('Email address (required for paid plans)'),
-      firstName: z.string().optional().describe('First name (required for paid plans)'),
-      lastName: z.string().optional().describe('Last name (required for paid plans)'),
-      couponCode: z.string().optional().describe('Coupon code for paid plans'),
-      discoveryPath: z.string().optional().describe('How did you discover Helius? Helps us improve agent onboarding'),
-      frictionPoints: z.string().optional().describe('What friction did you hit finding or setting up Helius? Free-form feedback'),
     },
-    async ({ plan, period, email, firstName, lastName, couponCode, discoveryPath, frictionPoints }) => {
+  );
+
+  // ── Signup ──
+
+  server.tool(
+    'signup',
+    'Create a Helius account via crypto checkout. Default `mode: "link"` returns a hosted-checkout URL the user opens in a browser to pay USDC. `mode: "autopay"` sends USDC + memo directly from the local keypair (the MCP will load/generate one if needed). `mode: "resume"` polls a pending payment intent and provisions the API key after the user has paid in a browser.',
+    {
+      mode: z
+        .enum(['link', 'autopay', 'resume'])
+        .default('link')
+        .describe(
+          'link (default): print payment URL and exit. autopay: send USDC + memo from local keypair. resume: poll an in-flight payment intent.',
+        ),
+      plan: z
+        .enum(['agent', 'developer', 'business', 'professional'])
+        .default('agent')
+        .describe('Plan: agent ($10 one-time, default), developer, business, professional'),
+      period: z
+        .enum(['monthly', 'yearly'])
+        .optional()
+        .describe('Billing period for subscription plans (default: monthly). Ignored for agent.'),
+      email: z.string().email().optional().describe('Email (required for fresh signup; not needed for resume)'),
+      firstName: z.string().optional().describe('First name (required for fresh signup)'),
+      lastName: z.string().optional().describe('Last name (required for fresh signup)'),
+      couponCode: z.string().optional().describe('Coupon code'),
+      discoveryPath: z.string().optional().describe('How did you discover Helius?'),
+      frictionPoints: z.string().optional().describe('What friction did you hit?'),
+    },
+    async ({ mode, plan, period, email, firstName, lastName, couponCode, discoveryPath, frictionPoints }) => {
       if (discoveryPath || frictionPoints) {
         sendFeedbackEvent({
           type: 'discovery',
@@ -327,21 +213,42 @@ export function registerAuthTools(server: McpServer) {
           frictionPoints,
         });
       }
+
       try {
+        // Resume mode: just poll the existing JWT/intent. Caller must have
+        // already gone through link mode in a previous invocation; the JWT
+        // from that invocation is on disk.
+        if (mode === 'resume') {
+          return await handleResumeSignup();
+        }
+
         let signerData: { secretKey: Uint8Array; walletAddress: string };
         try {
           signerData = await loadSignerOrFail();
         } catch {
           return mcpError(
-            'No signup keypair found. Call `generateKeypair` first to create a wallet, fund it, then call this tool.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet, fund it, then retry.' }
+            'No signup keypair found. Call `generateKeypair` first to create a wallet, then retry.',
+            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair`.' },
           );
         }
 
-        const result = await agenticSignup({
+        if (mode === 'autopay') {
+          const result = await signupAndPay({
+            secretKey: signerData.secretKey,
+            plan: plan as SupportedPlan,
+            period,
+            email,
+            firstName,
+            lastName,
+            couponCode,
+          });
+          return renderSignupAndPayResult(result);
+        }
+
+        // mode === "link" (default)
+        const result = await signup({
           secretKey: signerData.secretKey,
-          userAgent: MCP_USER_AGENT,
-          plan,
+          plan: plan as SupportedPlan,
           period,
           email,
           firstName,
@@ -349,260 +256,73 @@ export function registerAuthTools(server: McpServer) {
           couponCode,
         });
 
-        // Configure API key for this session and persist to shared config
-        if (result.apiKey) {
+        if (result.kind === 'already_subscribed') {
           setApiKey(result.apiKey);
           setSharedApiKey(result.apiKey);
-        }
-
-        // Persist JWT to disk
-        if (result.jwt) {
           setJwt(result.jwt);
-        }
-
-        const saveNote = result.apiKey
-          ? `\nAPI key configured for this session and saved to \`${SHARED_CONFIG_PATH}\`. All Helius tools are now ready to use.`
-          : '';
-
-        if (result.status === 'existing_project') {
           return mcpText(
             `**Helius Account Found**\n\n` +
-            `You already have a Helius account. No payment was needed.\n\n` +
-            `- **Wallet:** \`${result.walletAddress}\`\n` +
-            `- **Project ID:** \`${result.projectId}\`\n` +
-            (result.apiKey ? `- **API Key:** \`${result.apiKey}\`\n` : '') +
-            (result.endpoints ? `- **Mainnet RPC:** \`${result.endpoints.mainnet}\`\n` : '') +
-            (result.endpoints ? `- **Devnet RPC:** \`${result.endpoints.devnet}\`\n` : '') +
-            (result.credits !== null ? `- **Credits:** ${result.credits.toLocaleString()}\n` : '') +
-            saveNote
+              `You already have a Helius account on this plan. No payment was needed.\n\n` +
+              `- **Project ID:** \`${result.projectId}\`\n` +
+              `- **API Key:** \`${result.apiKey}\`\n` +
+              `- **Mainnet RPC:** \`${result.endpoints.mainnet}\`\n` +
+              `- **Devnet RPC:** \`${result.endpoints.devnet}\`\n\n` +
+              `API key configured for this session and saved to \`${SHARED_CONFIG_PATH}\`.`,
           );
         }
 
-        if (result.status === 'upgraded') {
+        if (result.kind === 'upgrade_required') {
           return mcpText(
-            `**Plan Upgraded to ${plan || 'paid plan'}**\n\n` +
-            `- **Wallet:** \`${result.walletAddress}\`\n` +
-            `- **Project ID:** \`${result.projectId}\`\n` +
-            (result.apiKey ? `- **API Key:** \`${result.apiKey}\`\n` : '') +
-            (result.txSignature ? `- **Payment TX:** \`${result.txSignature}\`\n` : '') +
-            saveNote
+            `**Plan change required**\n\n` +
+              `Your wallet is already on plan \`${result.currentPlan}\`. ` +
+              `Use the \`upgradePlan\` tool to switch to \`${result.requestedPlan}\`.`,
           );
         }
 
+        // payment_required — store JWT so resume mode can use it.
+        setJwt(result.jwt);
         return mcpText(
-          `**Helius Account Created**\n\n` +
-          `- **Wallet:** \`${result.walletAddress}\`\n` +
-          `- **Project ID:** \`${result.projectId}\`\n` +
-          (result.apiKey ? `- **API Key:** \`${result.apiKey}\`\n` : '') +
-          (result.endpoints ? `- **Mainnet RPC:** \`${result.endpoints.mainnet}\`\n` : '') +
-          (result.endpoints ? `- **Devnet RPC:** \`${result.endpoints.devnet}\`\n` : '') +
-          (result.credits !== null ? `- **Credits:** ${result.credits.toLocaleString()}\n` : '') +
-          (result.txSignature ? `- **Payment TX:** \`${result.txSignature}\`\n` : '') +
-          saveNote
+          renderPaymentLink(result.paymentLink, 'Sign up', 'signup with mode: "resume"'),
         );
       } catch (err) {
         return handleToolError(err, 'Error during signup');
       }
-    }
-  );
-
-  // ── Upgrade, Preview, Renewal Tools ──
-
-  server.tool(
-    'previewUpgrade',
-    'Preview pricing for a plan upgrade with proration details. Shows current plan, new plan cost, prorated credits, and amount due today.',
-    {
-      plan: z.enum(['developer', 'business', 'professional']).describe('Target plan name'),
-      period: z.enum(['monthly', 'yearly']).default('monthly').describe('Billing period'),
-      couponCode: z.string().optional().describe('Optional coupon code'),
     },
-    async ({ plan, period, couponCode }) => {
-      try {
-        const jwt = getJwt();
-        if (!jwt) {
-          return mcpError(
-            'Not authenticated. Call `agenticSignup` or authenticate first.',
-            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
-          );
-        }
-
-        const projects = await listProjects(jwt, MCP_USER_AGENT);
-        if (projects.length === 0) {
-          return mcpError(
-            'No projects found. Call `agenticSignup` to create an account first.',
-            { type: 'AUTH', code: 'NO_PROJECT', retryable: false, recovery: 'Call `agenticSignup` to create an account first.' }
-          );
-        }
-
-        const projectId = projects[0].id;
-        const projectDetails = await getProject(jwt, projectId, MCP_USER_AGENT);
-        const currentPlan = projectDetails.subscriptionPlanDetails?.currentPlan || 'unknown';
-
-        const preview = await getCheckoutPreview(jwt, plan, period, projectId, couponCode, MCP_USER_AGENT);
-
-        let text =
-          `**Upgrade Preview**\n\n` +
-          `- **Current Plan:** ${currentPlan}\n` +
-          `- **Target Plan:** ${preview.planName} (${preview.period})\n\n` +
-          `**Pricing Breakdown:**\n` +
-          `- Subtotal: $${(preview.subtotal / 100).toFixed(2)}\n`;
-
-        if (preview.proratedCredits > 0) {
-          text += `- Prorated credit: -$${(preview.proratedCredits / 100).toFixed(2)}\n`;
-        }
-        if (preview.appliedCredits > 0) {
-          text += `- Applied credits: -$${(preview.appliedCredits / 100).toFixed(2)}\n`;
-        }
-        if (preview.discounts > 0) {
-          text += `- Discounts: -$${(preview.discounts / 100).toFixed(2)}\n`;
-        }
-        if (preview.coupon?.valid) {
-          text += `- Coupon (${preview.coupon.code}): ${preview.coupon.description || 'Applied'}\n`;
-        } else if (preview.coupon && !preview.coupon.valid) {
-          text += `- Coupon (${preview.coupon.code}): **Invalid** — ${preview.coupon.invalidReason || 'not applicable'}\n`;
-        }
-
-        text += `\n**Due Today: $${(preview.dueToday / 100).toFixed(2)}**\n`;
-
-        if (preview.note) {
-          text += `\n_${preview.note}_\n`;
-        }
-
-        text += `\nTo proceed, use the \`upgradePlan\` tool with plan: '${plan}'.`;
-
-        return mcpText(text);
-      } catch (err) {
-        return handleToolError(err, 'Error previewing upgrade');
-      }
-    }
   );
 
-  server.tool(
-    'upgradePlan',
-    'Upgrade your Helius plan. Processes USDC payment with proration. Call previewUpgrade first to see pricing. Requires email, firstName, and lastName for first-time upgrades — all three must be provided together.',
-    {
-      plan: z.enum(['developer', 'business', 'professional']).describe('Target plan name'),
-      period: z.enum(['monthly', 'yearly']).default('monthly').describe('Billing period'),
-      couponCode: z.string().optional().describe('Optional coupon code'),
-      email: z.string().email().optional().describe('Email address (required for first-time upgrades)'),
-      firstName: z.string().optional().describe('First name (required for first-time upgrades)'),
-      lastName: z.string().optional().describe('Last name (required for first-time upgrades)'),
-    },
-    async ({ plan, period, couponCode, email, firstName, lastName }) => {
-      try {
-        // All-or-none customer info validation
-        const hasAny = email || firstName || lastName;
-        if (hasAny && (!email || !firstName || !lastName)) {
-          const missing = [
-            !email && 'email',
-            !firstName && 'firstName',
-            !lastName && 'lastName',
-          ].filter(Boolean);
-          return mcpError(
-            `Partial customer info provided. If any of email/firstName/lastName is given, all three are required. Missing: ${missing.join(', ')}`,
-            { type: 'VALIDATION', code: 'MISSING_PARAM', retryable: false, recovery: `Provide all three: email, firstName, and lastName. Missing: ${missing.join(', ')}` }
-          );
-        }
-
-        let signerData: { secretKey: Uint8Array; walletAddress: string };
-        try {
-          signerData = await loadSignerOrFail();
-        } catch {
-          return mcpError(
-            'No keypair found. Call `generateKeypair` first.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
-          );
-        }
-
-        const jwt = getJwt();
-        if (!jwt) {
-          return mcpError(
-            'Not authenticated. Call `agenticSignup` or authenticate first.',
-            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
-          );
-        }
-
-        const projects = await listProjects(jwt, MCP_USER_AGENT);
-        if (projects.length === 0) {
-          return mcpError(
-            'No projects found. Call `agenticSignup` to create an account first.',
-            { type: 'AUTH', code: 'NO_PROJECT', retryable: false, recovery: 'Call `agenticSignup` to create an account first.' }
-          );
-        }
-
-        const projectId = projects[0].id;
-        const result = await executeCheckout(signerData.secretKey, jwt, {
-          plan,
-          period,
-          refId: projectId,
-          couponCode,
-          email,
-          firstName,
-          lastName,
-        }, MCP_USER_AGENT, { skipProjectPolling: true });
-
-        if (result.status !== 'completed') {
-          return mcpError(
-            `**Upgrade ${result.status}**\n\n` +
-            (result.error ? `Error: ${result.error}\n` : '') +
-            (result.txSignature ? `TX: \`${result.txSignature}\`\n` : '') +
-            `\nIf you need help, contact support with the payment intent ID: \`${result.paymentIntentId}\``,
-            { type: 'API', code: 'OPERATION_FAILED', retryable: false, recovery: `Upgrade ${result.status}. Contact support with payment intent ID: ${result.paymentIntentId}` }
-          );
-        }
-
-        const planInfo = PLAN_CATALOG[plan];
-        return mcpText(
-          `**Plan Upgraded Successfully**\n\n` +
-          `- **New Plan:** ${planInfo.name} (${period})\n` +
-          `- **Project ID:** \`${projectId}\`\n` +
-          (result.txSignature ? `- **Payment TX:** \`${result.txSignature}\`\n` : '') +
-          `\nYour new plan is now active with ${(planInfo.credits / 1_000_000).toFixed(0)}M credits and ${planInfo.requestsPerSecond} RPS.`
-        );
-      } catch (err) {
-        return handleToolError(err, 'Error upgrading plan');
-      }
-    }
-  );
+  // ── Account Status ──
 
   server.tool(
     'getAccountStatus',
-    'Check your Helius account status: current plan, remaining credits, rate limits, and billing cycle. ' +
-    'Call this before bulk operations to verify you have sufficient credits. ' +
-    'Requires a JWT session (i.e., you signed up via agenticSignup). ' +
-    'If you only have an API key configured, auth status is confirmed but credit data is unavailable — call agenticSignup to enable full status.',
+    'Check your Helius account status: current plan, remaining credits, rate limits, and billing cycle. Requires a JWT session (i.e., you signed up via `signup`). If you only have an API key configured, auth status is confirmed but credit data is unavailable — call `signup` to enable full status.',
     {},
     async () => {
       try {
-        // ── Tier 1: not authenticated at all ──
         if (!hasApiKey()) {
           return mcpText(
             `## Account Status\n\n` +
-            `**Auth:** Not authenticated\n\n` +
-            `No API key or session found. To get started:\n` +
-            `- If you have a key: use the \`setHeliusApiKey\` tool\n` +
-            `- If you need an account: use \`generateKeypair\` → fund wallet → \`agenticSignup\``
+              `**Auth:** Not authenticated\n\n` +
+              `No API key or session found. To get started:\n` +
+              `- If you have a key: use the \`setHeliusApiKey\` tool\n` +
+              `- If you need an account: use \`signup\``,
           );
         }
 
-        // ── Tier 2: API key present but no JWT — can't reach dashboard API ──
         const jwt = getJwt();
         if (!jwt) {
           return mcpText(
             `## Account Status\n\n` +
-            `**Auth:** Authenticated (API key configured)\n` +
-            `**Credit usage:** Not available — no JWT session found\n\n` +
-            `To see your plan, rate limits, and credit balance, call \`agenticSignup\`.\n` +
-            `Your existing account will be detected automatically — no payment needed.`
+              `**Auth:** Authenticated (API key configured)\n` +
+              `**Credit usage:** Not available — no JWT session found\n\n` +
+              `To see your plan, rate limits, and credit balance, call \`signup\`. Your existing account will be detected automatically — no payment needed.`,
           );
         }
 
-        // ── Tier 3: full status via JWT ──
         const projects = await listProjects(jwt, MCP_USER_AGENT);
         if (projects.length === 0) {
           return mcpError(
-            'No projects found. Call `agenticSignup` to create an account first.',
-            { type: 'AUTH', code: 'NO_PROJECT', retryable: false, recovery: 'Call `agenticSignup` to create an account first.' }
+            'No projects found. Call `signup` to create an account first.',
+            { type: 'AUTH', code: 'NO_PROJECT', retryable: false, recovery: 'Call `signup`.' },
           );
         }
 
@@ -618,133 +338,429 @@ export function registerAuthTools(server: McpServer) {
         const cycle = details.billingCycle;
 
         const lines: string[] = [`## Account Status`, ''];
-
-        // ── Auth + plan ──
         lines.push(`**Auth:** Authenticated`);
         lines.push(`**Plan:** ${planInfo ? planInfo.name : planKey}  |  **Project:** \`${projectId}\``);
         if (isUpgrading && upcomingPlan && upcomingPlan !== planKey) {
           lines.push(`**Upcoming plan:** ${upcomingPlan} (takes effect at next billing cycle)`);
         }
 
-        // ── Rate limits (fetched live from billing docs) ──
         try {
           const billingDoc = await fetchDoc('billing');
-          const rateLimits = extractSections(billingDoc, ['standard rate limits', 'rate limits'], { includeLooseMatches: false });
+          const rateLimits = extractSections(billingDoc, ['standard rate limits', 'rate limits'], {
+            includeLooseMatches: false,
+          });
           if (rateLimits) {
             lines.push('', '### Rate Limits (live)', '', rateLimits);
-          } else {
-            lines.push('', '_Rate limit details: use `getRateLimitInfo` or visit https://www.helius.dev/docs/billing_');
           }
         } catch {
-          lines.push('', '_Rate limit details: use `getRateLimitInfo` or visit https://www.helius.dev/docs/billing_');
+          // best-effort
         }
 
-        // ── Credits ──
         if (usage) {
           const total = usage.remainingCredits + usage.totalCreditsUsed;
           const pctUsed = total > 0 ? ((usage.totalCreditsUsed / total) * 100).toFixed(1) : '0.0';
           const pctRemaining = total > 0 ? (100 - parseFloat(pctUsed)).toFixed(1) : '100.0';
 
-          // Billing cycle + days remaining
           let cycleStr = '';
-          let daysNote = '';
           if (cycle) {
             const end = new Date(cycle.end);
             const now = new Date();
             const daysLeft = Math.ceil((end.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
             cycleStr = ` (${cycle.start} - ${cycle.end}, ${daysLeft} day${daysLeft !== 1 ? 's' : ''} remaining)`;
-
-            // Burn-rate warning: project usage over elapsed days to end of cycle
-            const start = new Date(cycle.start);
-            const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
-            const elapsedDays = totalDays - daysLeft;
-            if (elapsedDays > 0 && daysLeft > 0) {
-              const projectedTotal = Math.round((usage.totalCreditsUsed / elapsedDays) * totalDays);
-              if (projectedTotal > total) {
-                const overageM = ((projectedTotal - total) / 1_000_000).toFixed(1);
-                daysNote = `\n> At current burn rate you're projected to use ~${(projectedTotal / 1_000_000).toFixed(1)}M credits this cycle — ${overageM}M over your ${(total / 1_000_000).toFixed(0)}M limit. Consider upgrading or reducing usage.`;
-              }
-            }
           }
 
           lines.push('', `### Credits — Billing Cycle${cycleStr}`);
           lines.push(`- **Remaining:** ${usage.remainingCredits.toLocaleString()} / ${total.toLocaleString()}  (${pctRemaining}%)`);
           lines.push(`- **Used:** ${usage.totalCreditsUsed.toLocaleString()}  (${pctUsed}%)`);
-          lines.push(`  - API: ${usage.apiUsage.toLocaleString()}`);
-          lines.push(`  - RPC: ${usage.rpcUsage.toLocaleString()}  |  RPC GPA: ${usage.rpcGPAUsage.toLocaleString()}  |  Webhooks: ${usage.webhookUsage.toLocaleString()}`);
-
-          if (usage.overageCreditsUsed > 0) {
-            lines.push(`- **Overage:** ${usage.overageCreditsUsed.toLocaleString()} credits  ($${usage.overageCost.toFixed(2)})`);
-          } else {
-            lines.push(`- **Overage:** none`);
-          }
-
-          if (usage.remainingPrepaidCredits > 0 || usage.prepaidCreditsUsed > 0) {
-            lines.push(`- **Prepaid:** ${usage.remainingPrepaidCredits.toLocaleString()} remaining  (${usage.prepaidCreditsUsed.toLocaleString()} used)`);
-          }
-
-          if (daysNote) lines.push(daysNote);
-
-          // Low-credit warning
-          if (parseFloat(pctRemaining) < 20) {
-            lines.push(`\n> Less than 20% of credits remaining. Use \`previewUpgrade\` to see upgrade pricing, or \`getHeliusPlanInfo\` to compare plans.`);
-          }
         }
 
         return mcpText(lines.join('\n'));
       } catch (err) {
         return handleToolError(err, 'Error fetching account status');
       }
-    }
+    },
+  );
+
+  // ── Upgrade ──
+
+  server.tool(
+    'previewUpgrade',
+    'Preview pricing for a plan upgrade with proration details. Shows current plan, new plan cost, prorated credits, and amount due today.',
+    {
+      plan: z.enum(['developer', 'business', 'professional']).describe('Target plan name'),
+      period: z.enum(['monthly', 'yearly']).default('monthly').describe('Billing period'),
+      couponCode: z.string().optional().describe('Optional coupon code'),
+    },
+    async ({ plan, period, couponCode }) => {
+      try {
+        const jwt = getJwt();
+        if (!jwt) {
+          return mcpError('Not authenticated. Call `signup` first.', {
+            type: 'AUTH',
+            code: 'NOT_AUTHENTICATED',
+            retryable: false,
+            recovery: 'Call `signup`.',
+          });
+        }
+
+        const projects = await listProjects(jwt, MCP_USER_AGENT);
+        if (projects.length === 0) {
+          return mcpError('No projects found. Call `signup` to create an account first.', {
+            type: 'AUTH',
+            code: 'NO_PROJECT',
+            retryable: false,
+            recovery: 'Call `signup`.',
+          });
+        }
+
+        const projectId = projects[0].id;
+        const projectDetails = await getProject(jwt, projectId, MCP_USER_AGENT);
+        const currentPlan = projectDetails.subscriptionPlanDetails?.currentPlan || 'unknown';
+
+        const preview = await getCheckoutPreview(jwt, plan, period, projectId, couponCode, MCP_USER_AGENT);
+
+        let text =
+          `**Upgrade Preview**\n\n` +
+          `- **Current Plan:** ${currentPlan}\n` +
+          `- **Target Plan:** ${preview.planName} (${preview.period})\n\n` +
+          `**Pricing Breakdown:**\n` +
+          `- Subtotal: $${(preview.subtotal / 100).toFixed(2)}\n`;
+        if (preview.proratedCredits > 0) {
+          text += `- Prorated credit: -$${(preview.proratedCredits / 100).toFixed(2)}\n`;
+        }
+        if (preview.appliedCredits > 0) {
+          text += `- Applied credits: -$${(preview.appliedCredits / 100).toFixed(2)}\n`;
+        }
+        if (preview.discounts > 0) {
+          text += `- Discounts: -$${(preview.discounts / 100).toFixed(2)}\n`;
+        }
+        if (preview.coupon?.valid) {
+          text += `- Coupon (${preview.coupon.code}): ${preview.coupon.description || 'Applied'}\n`;
+        }
+        text += `\n**Due Today: $${(preview.dueToday / 100).toFixed(2)}**\n`;
+        text += `\nTo proceed, use the \`upgradePlan\` tool with plan: '${plan}'.`;
+        return mcpText(text);
+      } catch (err) {
+        return handleToolError(err, 'Error previewing upgrade');
+      }
+    },
   );
 
   server.tool(
-    'payRenewal',
-    'Pay an existing payment intent (e.g., from a renewal notification). Fetches intent details, validates, and processes USDC payment.',
+    'upgradePlan',
+    'Upgrade your Helius plan via crypto checkout. Default `mode: "link"` returns a hosted-checkout URL. `mode: "autopay"` pays USDC from the local keypair and polls. Contact info (email/firstName/lastName) is only needed for first-time upgrades — backend auto-fetches from existing customer otherwise.',
     {
-      paymentIntentId: z.string().describe('Payment intent ID from renewal notification'),
+      mode: z.enum(['link', 'autopay']).default('link').describe('link (default) or autopay'),
+      plan: z.enum(['developer', 'business', 'professional']).describe('Target plan name'),
+      period: z.enum(['monthly', 'yearly']).default('monthly').describe('Billing period'),
+      couponCode: z.string().optional().describe('Optional coupon code'),
+      email: z.string().email().optional().describe('Email (only for first-time upgrades)'),
+      firstName: z.string().optional().describe('First name (only for first-time upgrades)'),
+      lastName: z.string().optional().describe('Last name (only for first-time upgrades)'),
     },
-    async ({ paymentIntentId }) => {
+    async ({ mode, plan, period, couponCode, email, firstName, lastName }) => {
       try {
-        let signerData: { secretKey: Uint8Array; walletAddress: string };
-        try {
-          signerData = await loadSignerOrFail();
-        } catch {
-          return mcpError(
-            'No keypair found. Call `generateKeypair` first.',
-            { type: 'AUTH', code: 'NO_KEYPAIR', retryable: false, recovery: 'Call `generateKeypair` to create a wallet.' }
-          );
-        }
-
         const jwt = getJwt();
         if (!jwt) {
-          return mcpError(
-            'Not authenticated. Call `agenticSignup` or authenticate first.',
-            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
-          );
+          return mcpError('Not authenticated. Call `signup` first.', {
+            type: 'AUTH',
+            code: 'NOT_AUTHENTICATED',
+            retryable: false,
+            recovery: 'Call `signup`.',
+          });
         }
 
-        const result = await executeRenewal(signerData.secretKey, jwt, paymentIntentId, MCP_USER_AGENT);
+        const projects = await listProjects(jwt, MCP_USER_AGENT);
+        if (projects.length === 0) {
+          return mcpError('No projects found. Call `signup` first.', {
+            type: 'AUTH',
+            code: 'NO_PROJECT',
+            retryable: false,
+            recovery: 'Call `signup`.',
+          });
+        }
+        const projectId = projects[0].id;
 
-        if (result.status !== 'completed') {
-          return mcpError(
-            `**Payment ${result.status}**\n\n` +
-            (result.error ? `Error: ${result.error}\n` : '') +
-            (result.txSignature ? `TX: \`${result.txSignature}\`\n` : '') +
-            `\nIf you need help, contact support with the payment intent ID: \`${result.paymentIntentId}\``,
-            { type: 'API', code: 'OPERATION_FAILED', retryable: false, recovery: `Payment ${result.status}. Contact support with payment intent ID: ${result.paymentIntentId}` }
-          );
+        if (mode === 'autopay') {
+          let signerData: { secretKey: Uint8Array; walletAddress: string };
+          try {
+            signerData = await loadSignerOrFail();
+          } catch {
+            return mcpError('No keypair. Autopay needs one — call `generateKeypair` first.', {
+              type: 'AUTH',
+              code: 'NO_KEYPAIR',
+              retryable: false,
+              recovery: 'Call `generateKeypair`.',
+            });
+          }
+          const result = await upgradePlanAndPay({
+            secretKey: signerData.secretKey,
+            jwt,
+            projectId,
+            plan,
+            period,
+            couponCode,
+            email,
+            firstName,
+            lastName,
+          });
+          return renderUpgradeOrCreditsAndPayResult(result, 'Upgrade');
         }
 
-        return mcpText(
-          `**Payment Complete**\n\n` +
-          `- **Payment Intent:** \`${result.paymentIntentId}\`\n` +
-          (result.txSignature ? `- **TX:** \`${result.txSignature}\`\n` : '') +
-          `\nYour subscription has been renewed successfully.`
-        );
+        // mode === "link"
+        const result = await upgradePlan({
+          jwt,
+          projectId,
+          plan,
+          period,
+          couponCode,
+          email,
+          firstName,
+          lastName,
+        });
+        return mcpText(renderPaymentLink(result.paymentLink, 'Upgrade', 'getAccountStatus'));
+      } catch (err) {
+        return handleToolError(err, 'Error upgrading plan');
+      }
+    },
+  );
+
+  // ── Prepaid Credits ──
+
+  server.tool(
+    'purchaseCredits',
+    'Top up prepaid credits on an agent-plan project. Default `mode: "link"` returns a hosted-checkout URL. `mode: "autopay"` pays USDC from the local keypair and polls. Each unit of `qty` grants 1,000,000 credits.',
+    {
+      mode: z.enum(['link', 'autopay']).default('link').describe('link (default) or autopay'),
+      qty: z.number().int().min(1).default(1).describe('Quantity multiplier (each unit = 1M credits)'),
+      couponCode: z.string().optional().describe('Optional coupon code'),
+    },
+    async ({ mode, qty, couponCode }) => {
+      try {
+        const jwt = getJwt();
+        if (!jwt) {
+          return mcpError('Not authenticated. Call `signup` first.', {
+            type: 'AUTH',
+            code: 'NOT_AUTHENTICATED',
+            retryable: false,
+            recovery: 'Call `signup`.',
+          });
+        }
+
+        const projects = await listProjects(jwt, MCP_USER_AGENT);
+        if (projects.length === 0) {
+          return mcpError('No projects found. Call `signup` first.', {
+            type: 'AUTH',
+            code: 'NO_PROJECT',
+            retryable: false,
+            recovery: 'Call `signup`.',
+          });
+        }
+        const projectId = projects[0].id;
+
+        if (mode === 'autopay') {
+          let signerData: { secretKey: Uint8Array; walletAddress: string };
+          try {
+            signerData = await loadSignerOrFail();
+          } catch {
+            return mcpError('No keypair. Autopay needs one — call `generateKeypair` first.', {
+              type: 'AUTH',
+              code: 'NO_KEYPAIR',
+              retryable: false,
+              recovery: 'Call `generateKeypair`.',
+            });
+          }
+          const result = await purchaseCreditsAndPay({
+            secretKey: signerData.secretKey,
+            jwt,
+            projectId,
+            qty,
+            couponCode,
+          });
+          return renderUpgradeOrCreditsAndPayResult(result, 'Credits top-up');
+        }
+
+        const result = await sdkPurchaseCredits({ jwt, projectId, qty, couponCode });
+        return mcpText(renderPaymentLink(result.paymentLink, 'Credits top-up', 'getAccountStatus'));
+      } catch (err) {
+        return handleToolError(err, 'Error purchasing credits');
+      }
+    },
+  );
+
+  // ── Renewal Pay ──
+
+  server.tool(
+    'payRenewal',
+    'Pay an existing renewal payment intent. Default `mode: "link"` returns the hosted-checkout URL for the renewal. `mode: "autopay"` pays USDC from the local keypair.',
+    {
+      mode: z.enum(['link', 'autopay']).default('link').describe('link (default) or autopay'),
+      paymentIntentId: z.string().describe('Payment intent ID from renewal notification'),
+    },
+    async ({ mode, paymentIntentId }) => {
+      try {
+        const jwt = getJwt();
+        if (!jwt) {
+          return mcpError('Not authenticated. Call `signup` first.', {
+            type: 'AUTH',
+            code: 'NOT_AUTHENTICATED',
+            retryable: false,
+            recovery: 'Call `signup`.',
+          });
+        }
+
+        if (mode === 'autopay') {
+          let signerData: { secretKey: Uint8Array; walletAddress: string };
+          try {
+            signerData = await loadSignerOrFail();
+          } catch {
+            return mcpError('No keypair. Autopay needs one — call `generateKeypair` first.', {
+              type: 'AUTH',
+              code: 'NO_KEYPAIR',
+              retryable: false,
+              recovery: 'Call `generateKeypair`.',
+            });
+          }
+          const result = await payRenewalAndPay(signerData.secretKey, jwt, paymentIntentId);
+          return renderUpgradeOrCreditsAndPayResult(result, 'Renewal');
+        }
+
+        const result = await payRenewal(jwt, paymentIntentId);
+        return mcpText(renderPaymentLink(result.paymentLink, 'Renewal', 'payRenewal again with mode: "autopay" or open the link'));
       } catch (err) {
         return handleToolError(err, 'Error processing renewal payment');
       }
-    }
+    },
   );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Resume / result rendering helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+async function handleResumeSignup() {
+  const jwt = getJwt();
+  if (!jwt) {
+    return mcpError('No pending signup. Call `signup` (link mode) first.', {
+      type: 'AUTH',
+      code: 'NOT_AUTHENTICATED',
+      retryable: false,
+      recovery: 'Call `signup`.',
+    });
+  }
+  const projects = await listProjects(jwt, MCP_USER_AGENT);
+  if (projects.length === 0) {
+    return mcpText(
+      'Payment not yet provisioned on the backend. The webhook may still be processing — try again in a moment.',
+    );
+  }
+  const projectId = projects[0].id;
+  const details = await getProject(jwt, projectId, MCP_USER_AGENT);
+  const apiKey = details.apiKeys?.[0]?.keyId;
+  if (!apiKey) {
+    return mcpText(
+      'Project is provisioned but no API key has been generated yet. Try again in a moment.',
+    );
+  }
+  setApiKey(apiKey);
+  setSharedApiKey(apiKey);
+  return mcpText(
+    `**Signup complete!**\n\n` +
+      `- **Project ID:** \`${projectId}\`\n` +
+      `- **API Key:** \`${apiKey}\`\n\n` +
+      `API key configured for this session and saved to \`${SHARED_CONFIG_PATH}\`. All Helius tools are ready to use.`,
+  );
+}
+
+type SignupAndPayResult = import('helius-sdk/auth/types').SignupAndPayResult;
+
+function renderSignupAndPayResult(result: SignupAndPayResult): { content: { type: 'text'; text: string }[] } {
+  switch (result.kind) {
+    case 'completed':
+      setApiKey(result.apiKey);
+      setSharedApiKey(result.apiKey);
+      setJwt(result.jwt);
+      return mcpText(
+        `**Helius Account Created**\n\n` +
+          `- **Project ID:** \`${result.projectId}\`\n` +
+          `- **API Key:** \`${result.apiKey}\`\n` +
+          `- **Mainnet RPC:** \`${result.endpoints.mainnet}\`\n` +
+          (result.txSignature ? `- **Payment TX:** \`${result.txSignature}\`\n` : '') +
+          `\nAPI key configured for this session and saved to \`${SHARED_CONFIG_PATH}\`.`,
+      );
+    case 'already_subscribed':
+      setApiKey(result.apiKey);
+      setSharedApiKey(result.apiKey);
+      setJwt(result.jwt);
+      return mcpText(
+        `**Helius Account Found**\n\n` +
+          `You already have a Helius account on this plan. No payment was needed.\n\n` +
+          `- **Project ID:** \`${result.projectId}\`\n` +
+          `- **API Key:** \`${result.apiKey}\`\n` +
+          `\nAPI key configured for this session.`,
+      );
+    case 'upgrade_required':
+      return mcpText(
+        `**Plan change required**\n\n` +
+          `Your wallet is already on plan \`${result.currentPlan}\`. ` +
+          `Use the \`upgradePlan\` tool to switch to \`${result.requestedPlan}\`.`,
+      );
+    case 'pending':
+      setJwt(result.jwt);
+      return mcpText(
+        `**Payment sent — activation pending**\n\n` +
+          `USDC was sent (tx: \`${result.txSignature ?? 'unknown'}\`) but the backend hasn't finished provisioning yet.\n\n` +
+          `Call \`signup\` with \`mode: "resume"\` to try again.`,
+      );
+    case 'expired':
+      return mcpError(
+        `Payment intent expired (\`${result.paymentIntentId}\`). Run \`signup\` again to start a fresh one.`,
+        { type: 'API', code: 'EXPIRED', retryable: false, recovery: 'Run `signup` again.' },
+      );
+    case 'failed':
+      return mcpError(
+        `Payment failed: ${result.reason ?? 'unknown reason'} (intent \`${result.paymentIntentId}\`).`,
+        { type: 'API', code: 'OPERATION_FAILED', retryable: false, recovery: 'Contact support if this persists.' },
+      );
+    default: {
+      const _exhaustive: never = result;
+      throw new Error(`Unhandled result kind: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}
+
+type UpgradeAndPayResult = import('helius-sdk/auth/types').UpgradePlanAndPayResult;
+
+function renderUpgradeOrCreditsAndPayResult(
+  result: UpgradeAndPayResult,
+  flowName: string,
+): { content: { type: 'text'; text: string }[] } {
+  switch (result.kind) {
+    case 'completed':
+      return mcpText(
+        `**${flowName} complete!**\n\n` +
+          (result.txSignature ? `- **TX:** \`${result.txSignature}\`\n` : '') +
+          `- **Payment Intent:** \`${result.paymentIntentId}\``,
+      );
+    case 'pending':
+      return mcpText(
+        `**Payment sent — activation pending**\n\n` +
+          `USDC was sent (tx: \`${result.txSignature ?? 'unknown'}\`). The backend is still processing.\n\n` +
+          `Call this tool again or check \`getAccountStatus\` shortly.`,
+      );
+    case 'expired':
+      return mcpError(
+        `Payment intent expired (\`${result.paymentIntentId}\`). Run the tool again to start fresh.`,
+        { type: 'API', code: 'EXPIRED', retryable: false, recovery: 'Retry from scratch.' },
+      );
+    case 'failed':
+      return mcpError(
+        `Payment failed: ${result.reason ?? 'unknown reason'} (intent \`${result.paymentIntentId}\`).`,
+        { type: 'API', code: 'OPERATION_FAILED', retryable: false, recovery: 'Contact support if this persists.' },
+      );
+    default: {
+      const _exhaustive: never = result;
+      throw new Error(`Unhandled result kind: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
 }

--- a/helius-mcp/src/tools/config.ts
+++ b/helius-mcp/src/tools/config.ts
@@ -11,7 +11,7 @@ export function registerConfigTools(server: McpServer) {
     'setHeliusApiKey',
     keyFromEnv
       ? 'API key is already configured via environment. You do NOT need to call this tool - just use the other Helius tools directly.'
-      : 'Set an existing Helius API key for the current session. If the user does not have a key, use the agentic signup flow instead: generateKeypair → fund wallet → agenticSignup. Get a key at https://dashboard.helius.dev/api-keys',
+      : 'Set an existing Helius API key for the current session. If the user does not have a key, use the signup flow instead: generateKeypair → fund wallet → signup. Get a key at https://dashboard.helius.dev/api-keys',
     {
       apiKey: z.string().describe('Your Helius API key from https://dashboard.helius.dev/api-keys'),
       network: z.string().optional().default('mainnet-beta').describe('Network to use (default: mainnet-beta)')

--- a/helius-mcp/src/tools/config.ts
+++ b/helius-mcp/src/tools/config.ts
@@ -11,7 +11,7 @@ export function registerConfigTools(server: McpServer) {
     'setHeliusApiKey',
     keyFromEnv
       ? 'API key is already configured via environment. You do NOT need to call this tool - just use the other Helius tools directly.'
-      : 'Set an existing Helius API key for the current session. If the user does not have a key, use the signup flow instead: generateKeypair → fund wallet → signup. Get a key at https://dashboard.helius.dev/api-keys',
+      : 'Set an existing Helius API key for the current session. If the user does not have a key, use the signup flow instead: generateKeypair → signup (link mode prints a payment URL). Get a key at https://dashboard.helius.dev/api-keys',
     {
       apiKey: z.string().describe('Your Helius API key from https://dashboard.helius.dev/api-keys'),
       network: z.string().optional().default('mainnet-beta').describe('Network to use (default: mainnet-beta)')

--- a/helius-mcp/src/tools/plans.ts
+++ b/helius-mcp/src/tools/plans.ts
@@ -191,7 +191,7 @@ export function registerPlanTools(server: McpServer) {
           `**Auth:** Not authenticated\n\n` +
           `No API key or session found. To get started:\n` +
           `- If you have a key: use the \`setHeliusApiKey\` tool\n` +
-          `- If you need an account: use \`generateKeypair\` → fund wallet → \`agenticSignup\``
+          `- If you need an account: use \`generateKeypair\` → fund wallet → \`signup\``
         );
       }
 
@@ -201,7 +201,7 @@ export function registerPlanTools(server: McpServer) {
         return mcpText(
           `## Account Plan\n\n` +
           `**Auth:** API key configured, plan unknown\n\n` +
-          `To see your plan and tool eligibility, call \`agenticSignup\`.\n` +
+          `To see your plan and tool eligibility, call \`signup\`.\n` +
           `Your existing account will be detected automatically — no payment needed.`
         );
       }
@@ -210,7 +210,7 @@ export function registerPlanTools(server: McpServer) {
       try {
         const projects = await listProjects(jwt, MCP_USER_AGENT);
         if (projects.length === 0) {
-          return mcpError('No projects found. Call `agenticSignup` to create an account first.');
+          return mcpError('No projects found. Call `signup` to create an account first.');
         }
 
         const projectId = projects[0].id;

--- a/helius-mcp/src/tools/plans.ts
+++ b/helius-mcp/src/tools/plans.ts
@@ -205,7 +205,7 @@ export function registerPlanTools(server: McpServer) {
           `**Auth:** Not authenticated\n\n` +
           `No API key or session found. To get started:\n` +
           `- If you have a key: use the \`setHeliusApiKey\` tool\n` +
-          `- If you need an account: use \`generateKeypair\` → fund wallet → \`signup\``
+          `- If you need an account: use \`generateKeypair\` → \`signup\` (link mode prints a payment URL)`
         );
       }
 

--- a/helius-mcp/src/tools/plans.ts
+++ b/helius-mcp/src/tools/plans.ts
@@ -25,8 +25,8 @@ export const HELIUS_PLANS: Record<string, {
   name: string;
   features: Record<string, boolean | string>;
 }> = {
-  free: {
-    name: 'Free',
+  agent: {
+    name: 'Agent',
     features: { webhooks: true, standardWebSockets: true, enhancedWebSockets: false, laserstream: false, stakedConnections: true, archivalData: true },
   },
   developer: {
@@ -60,6 +60,19 @@ const BILLING_FETCH_META: ErrorMeta = {
  * Returns the plan key (e.g. "developer") or undefined if unavailable.
  * Best-effort — never throws.
  */
+/**
+ * Normalize backend plan keys (e.g. `agent_v4`, `developer_v4`) to the
+ * canonical short keys used in HELIUS_PLANS / PLAN_RANK / PRODUCT_CATALOG.
+ * Backend appends `_v4` for current-generation plans; the MCP/CLI surface
+ * uses the short form throughout.
+ */
+function normalizePlanKey(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim().toLowerCase();
+  // Strip `_v4` (and any future `_v<N>`) suffix.
+  return trimmed.replace(/_v\d+$/, '');
+}
+
 export async function detectCurrentPlan(): Promise<string | undefined> {
   const jwt = getJwt();
   if (!jwt) return undefined;
@@ -67,8 +80,8 @@ export async function detectCurrentPlan(): Promise<string | undefined> {
     const projects = await listProjects(jwt, MCP_USER_AGENT);
     if (projects.length > 0) {
       const details = await getProject(jwt, projects[0].id, MCP_USER_AGENT);
-      const raw = details.subscriptionPlanDetails?.currentPlan?.trim().toLowerCase();
-      if (raw && raw in HELIUS_PLANS) return raw;
+      const normalized = normalizePlanKey(details.subscriptionPlanDetails?.currentPlan);
+      if (normalized && normalized in HELIUS_PLANS) return normalized;
     }
   } catch {
     // Best-effort — don't block the response
@@ -81,7 +94,7 @@ export function registerPlanTools(server: McpServer) {
     'getHeliusPlanInfo',
     'BEST FOR: pricing and plan questions. PREFER compareHeliusPlans for side-by-side category comparisons, getRateLimitInfo for per-method credit costs. Get Helius plan pricing, credits, rate limits, and feature availability. Fetches live from billing docs.',
     {
-      plan: z.enum(['free', 'developer', 'business', 'professional', 'all']).optional().default('all').describe('Specific plan to show details for, or "all" for comparison'),
+      plan: z.enum(['agent', 'developer', 'business', 'professional', 'all']).optional().default('all').describe('Specific plan to show details for, or "all" for comparison. Note: the MCP/CLI signup flow uses Agent ($10 one-time) as the entry tier; the dashboard\'s Free tier is not available through this path.'),
     },
     async ({ plan }) => {
       let billingDoc: string;
@@ -127,7 +140,8 @@ export function registerPlanTools(server: McpServer) {
         '',
         '## Actions',
         '',
-        '- To upgrade, use the `upgradePlan` tool with a plan name (developer, business, professional)',
+        '- To sign up for the Agent plan ($10 one-time, 1M credits), use the `signup` tool',
+        '- To upgrade an existing account, use the `upgradePlan` tool with a plan name (developer, business, professional)',
         '- To preview pricing before upgrading, use the `previewUpgrade` tool',
         '',
         'Source: https://www.helius.dev/docs/billing (fetched live)',
@@ -216,7 +230,7 @@ export function registerPlanTools(server: McpServer) {
         const projectId = projects[0].id;
         const details = await getProject(jwt, projectId, MCP_USER_AGENT);
 
-        const planKey = (details.subscriptionPlanDetails?.currentPlan?.trim().toLowerCase()) ?? 'unknown';
+        const planKey = normalizePlanKey(details.subscriptionPlanDetails?.currentPlan) ?? 'unknown';
         const planInfo = HELIUS_PLANS[planKey];
         if (!planInfo) {
           console.warn(`[getAccountPlan] Unrecognized plan "${planKey}" — tool eligibility may be inaccurate`);
@@ -241,7 +255,7 @@ export function registerPlanTools(server: McpServer) {
           `- **Remaining:** ${remainingCredits.toLocaleString()} / ${totalCredits.toLocaleString()} (${usedPct}% used)`,
           ``,
           `### Gated Tool Eligibility`,
-          `All Free-tier tools are available on every plan.`,
+          `All Agent-tier tools are available on every plan.`,
           ``,
         ];
 
@@ -290,7 +304,7 @@ function computeToolEligibility(planKey: string): ToolEligibilityEntry[] {
   const toolProducts: Record<string, { productName: string; minimumPlan: string }[]> = {};
 
   for (const product of Object.values(PRODUCT_CATALOG)) {
-    if (product.minimumPlan === 'free') continue;
+    if (product.minimumPlan === 'agent') continue;
     for (const tool of product.mcpTools) {
       if (!toolProducts[tool]) toolProducts[tool] = [];
       toolProducts[tool].push({ productName: product.name, minimumPlan: product.minimumPlan });
@@ -300,9 +314,9 @@ function computeToolEligibility(planKey: string): ToolEligibilityEntry[] {
   const results: ToolEligibilityEntry[] = [];
 
   for (const [tool, products] of Object.entries(toolProducts)) {
-    // Also check if this tool appears in any free product (e.g. transactionSubscribe in standard-websockets)
-    const inFreeToo = Object.values(PRODUCT_CATALOG).some(
-      p => p.minimumPlan === 'free' && p.mcpTools.includes(tool)
+    // Also check if this tool appears in any baseline product (Agent tier)
+    const inBaselineToo = Object.values(PRODUCT_CATALOG).some(
+      p => p.minimumPlan === 'agent' && p.mcpTools.includes(tool)
     );
 
     if (products.length === 1) {
@@ -310,17 +324,17 @@ function computeToolEligibility(planKey: string): ToolEligibilityEntry[] {
       const available = userRank >= (PLAN_RANK[p.minimumPlan] ?? 99);
       const planDisplay = HELIUS_PLANS[p.minimumPlan]?.name ?? p.minimumPlan;
 
-      if (inFreeToo && available) {
-        // Tool is available at free tier AND at this gated tier — show available
+      if (inBaselineToo && available) {
+        // Tool is available at baseline tier AND at this gated tier — show available
         results.push({ tool, status: 'AVAILABLE', requires: planDisplay });
-      } else if (inFreeToo && !available) {
-        // Tool works at free tier but the enhanced version needs upgrade
+      } else if (inBaselineToo && !available) {
+        // Tool works at baseline tier but the enhanced version needs upgrade
         results.push({ tool, status: `AVAILABLE (basic) / UPGRADE REQUIRED (${p.productName})`, requires: planDisplay });
       } else {
         results.push({ tool, status: available ? 'AVAILABLE' : 'UPGRADE REQUIRED', requires: planDisplay });
       }
     } else {
-      // Multiple non-free products (e.g. laserstreamSubscribe in devnet + mainnet)
+      // Multiple gated products (e.g. laserstreamSubscribe in devnet + mainnet)
       const statuses: string[] = [];
       const requires: string[] = [];
 

--- a/helius-mcp/src/tools/product-catalog.ts
+++ b/helius-mcp/src/tools/product-catalog.ts
@@ -17,14 +17,16 @@ export interface CatalogProduct {
 // ─── Plan Ranking ───
 // Pure data constant — lives here (zero imports) to avoid circular dependencies.
 
-export const PLAN_RANK: Record<string, number> = { free: 0, developer: 1, business: 2, professional: 3 };
+// Plan tiers, lowest to highest. The MCP/CLI signup flow uses Agent as the
+// entry tier (the dashboard's Free tier is not reachable through this surface).
+export const PLAN_RANK: Record<string, number> = { agent: 0, developer: 1, business: 2, professional: 3 };
 
 export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
   'das-api': {
     name: 'DAS API',
     mcpTools: ['getAssetsByOwner', 'getAssetsByGroup', 'searchAssets', 'getAsset', 'getTokenBalances', 'getTokenAccounts'],
     creditCostPerCall: '10 credits',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'das',
     referenceFile: 'references/das.md',
     description: 'Query tokens, NFTs, collections, and digital assets. Fetches wallet token holdings with names, symbols, and prices. Browse NFT collections, search assets by creator/authority/owner.',
@@ -33,7 +35,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Standard RPC',
     mcpTools: ['getBalance', 'getAccountInfo', 'getBlock', 'getNetworkStatus'],
     creditCostPerCall: '1-10 credits',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'rpc',
     description: 'Core Solana RPC for native SOL balances, account data, block info, and network status. Foundation for any Solana app.',
   },
@@ -41,7 +43,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Enhanced Transactions API',
     mcpTools: ['parseTransactions', 'getTransactionHistory'],
     creditCostPerCall: '100 credits',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'enhanced-transactions',
     referenceFile: 'references/enhanced-transactions.md',
     description: 'Parse any transaction into human-readable format with types (SWAP, TRANSFER, NFT_SALE), descriptions, token transfers, and fees. Powers transaction history views and trade verification.',
@@ -59,7 +61,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Webhooks',
     mcpTools: ['createWebhook', 'getAllWebhooks', 'getWebhookByID', 'updateWebhook', 'deleteWebhook'],
     creditCostPerCall: '100 credits to create, 1 credit per event',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'webhooks',
     referenceFile: 'references/webhooks.md',
     description: 'HTTP POST notifications when monitored addresses have on-chain activity. Event-driven architecture without polling. Monitor up to 100k addresses per webhook. Filter by 150+ transaction types (SWAP, NFT_SALE, TRANSFER, etc.).',
@@ -77,7 +79,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Helius Sender',
     mcpTools: ['getSenderInfo'],
     creditCostPerCall: '0 credits',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'sender',
     referenceFile: 'references/sender.md',
     description: 'Submit transactions with SWQoS routing, staked connections, and Jito tip integration for optimal landing rates. Essential for trading bots, token launches, and any app that sends transactions.',
@@ -86,7 +88,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Priority Fee API',
     mcpTools: ['getPriorityFeeEstimate'],
     creditCostPerCall: '1 credit',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'priority-fee',
     referenceFile: 'references/priority-fees.md',
     description: 'Real-time fee estimates for transaction prioritization during network congestion. Returns recommended fees at multiple priority levels (Min, Low, Medium, High, VeryHigh).',
@@ -95,7 +97,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Standard WebSockets',
     mcpTools: ['transactionSubscribe'],
     creditCostPerCall: '2 credits per 0.1 MB streamed',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'websocket',
     referenceFile: 'references/websockets.md',
     description: 'Persistent connection for real-time transaction and account updates using standard Solana WebSocket subscriptions. Good for confirmation tracking and basic streaming.',
@@ -122,7 +124,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Token Transfers',
     mcpTools: ['transferSol', 'transferToken'],
     creditCostPerCall: '~3-13 credits + on-chain fees',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'sender',
     referenceFile: 'references/sender.md',
     description: 'Send native SOL or SPL tokens from the MCP keypair to any Solana address. Uses Helius Sender for optimal landing rates. Requires a configured keypair.',
@@ -143,7 +145,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
       'getIndexerHealth', 'getIndexerSlot',
     ],
     creditCostPerCall: '10 credits',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'zk-compression',
     referenceFile: 'references/zk-compression.md',
     description: 'Query compressed accounts, token balances, Merkle proofs, validity proofs, and compression transaction history via the ZK Compression / Light Protocol indexer. Powers state compression for cost-efficient on-chain data storage.',
@@ -152,7 +154,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Native Staking',
     mcpTools: ['stakeSOL', 'unstakeSOL', 'withdrawStake', 'getStakeAccounts', 'getWithdrawableAmount'],
     creditCostPerCall: '~3-10 credits + on-chain fees',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'sender',
     referenceFile: 'references/sender.md',
     description: 'Stake, unstake, and withdraw native SOL via the Helius validator. Earn staking yield with one-click delegation. Query stake accounts and withdrawable amounts.',
@@ -161,7 +163,7 @@ export const PRODUCT_CATALOG: Record<string, CatalogProduct> = {
     name: 'Token Holders',
     mcpTools: ['getTokenHolders'],
     creditCostPerCall: '20 credits',
-    minimumPlan: 'free',
+    minimumPlan: 'agent',
     docKey: 'das',
     referenceFile: 'references/das.md',
     description: 'Top 20 holders of any SPL token. Check token distribution, find whale wallets, verify decentralization. Useful for token launches and analytics.',

--- a/helius-mcp/src/tools/recommend.ts
+++ b/helius-mcp/src/tools/recommend.ts
@@ -57,8 +57,8 @@ const TIER_MAP: Record<string, 'budget' | 'standard' | 'production'> = {
   professional: 'production',
 };
 
-const TIER_DISPLAY: Record<string, string> = { budget: 'Free', standard: 'Developer', production: 'Business / Professional' };
-const TIER_PLANS: Record<string, string> = { budget: 'free', standard: 'developer', production: 'business' };
+const TIER_DISPLAY: Record<string, string> = { budget: 'Agent', standard: 'Developer', production: 'Business / Professional' };
+const TIER_PLANS: Record<string, string> = { budget: 'agent', standard: 'developer', production: 'business' };
 
 function groupCatalogByTier(): CatalogTier[] {
   const groups: Record<string, CatalogProduct[]> = { budget: [], standard: [], production: [] };
@@ -69,7 +69,7 @@ function groupCatalogByTier(): CatalogTier[] {
   }
 
   const tiers: CatalogTier[] = [];
-  if (groups.budget.length > 0) tiers.push({ tier: 'budget', tierPlan: 'free', products: groups.budget });
+  if (groups.budget.length > 0) tiers.push({ tier: 'budget', tierPlan: 'agent', products: groups.budget });
   if (groups.standard.length > 0) tiers.push({ tier: 'standard', tierPlan: 'developer', products: groups.standard });
   if (groups.production.length > 0) tiers.push({ tier: 'production', tierPlan: 'business', products: groups.production });
 
@@ -159,7 +159,7 @@ function formatCatalog(
   lines.push('---', '');
 
   if (complexity) {
-    const label: Record<string, string> = { low: 'free tier only', medium: 'free + developer tiers', high: 'all tiers' };
+    const label: Record<string, string> = { low: 'agent tier only', medium: 'agent + developer tiers', high: 'all tiers' };
     lines.push(`_Showing ${label[complexity]}_`, '', '---', '');
   }
 
@@ -215,7 +215,7 @@ export function registerRecommendTools(server: McpServer) {
     'BEST FOR: project architecture when user describes a Solana app to build. PREFER getHeliusPlanInfo for pricing-only, lookupHeliusDocs for API docs. Get tiered architecture recommendations. Returns Helius products, MCP tools, credit costs, minimum plan, and reference files.',
     {
       description: z.string().describe('What the user wants to build, in their own words'),
-      budget: z.enum(['free', 'developer', 'business', 'professional']).optional(),
+      budget: z.enum(['agent', 'developer', 'business', 'professional']).optional(),
       complexity: z.enum(['low', 'medium', 'high']).optional(),
       scale: z.enum(['budget', 'standard', 'production', 'all']).optional().default('all'),
       remember: z.boolean().optional().describe('Save budget/complexity preferences for future sessions'),

--- a/helius-mcp/src/tools/shared.ts
+++ b/helius-mcp/src/tools/shared.ts
@@ -4,7 +4,7 @@ const NO_API_KEY_META: ErrorMeta = {
   type: 'AUTH',
   code: 'NO_API_KEY',
   retryable: false,
-  recovery: 'Call generateKeypair + agenticSignup, or setHeliusApiKey',
+  recovery: 'Call generateKeypair + signup, or setHeliusApiKey',
 };
 
 const NO_API_KEY_MESSAGE = `**Helius API Key Required**
@@ -14,7 +14,7 @@ I need a Helius API key to query the Solana blockchain.
 **Option 1 — Sign up here (recommended):**
 1. Call \`generateKeypair\` to create a signup wallet
 2. Fund the wallet with ~0.001 SOL + 1 USDC
-3. Call \`agenticSignup\` to create your account — the API key will be configured automatically
+3. Call \`signup\` to create your account — the API key will be configured automatically
 
 **Option 2 — Use an existing key:**
 1. Go to https://dashboard.helius.dev/api-keys

--- a/helius-mcp/src/utils/config.ts
+++ b/helius-mcp/src/utils/config.ts
@@ -12,7 +12,7 @@ interface HeliusConfig {
   network?: string;
   projectId?: string;
   preferences?: {
-    budget?: 'free' | 'developer' | 'business' | 'professional';
+    budget?: 'agent' | 'developer' | 'business' | 'professional';
     complexity?: 'low' | 'medium' | 'high';
   };
 }

--- a/helius-mcp/system-prompts/helius-dflow/claude.system.md
+++ b/helius-mcp/system-prompts/helius-dflow/claude.system.md
@@ -192,7 +192,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md, `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-mcp/system-prompts/helius-dflow/full.md
+++ b/helius-mcp/system-prompts/helius-dflow/full.md
@@ -182,7 +182,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md (inlined below), `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys
@@ -1950,15 +1950,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -1972,37 +1972,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -2016,8 +2029,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -2026,28 +2039,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -2059,8 +2082,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -2074,8 +2095,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -2090,7 +2111,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -2098,13 +2119,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -2112,10 +2133,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -2124,6 +2146,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -2137,19 +2160,22 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes
 
 
 ---

--- a/helius-mcp/system-prompts/helius-dflow/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-dflow/openai.developer.md
@@ -192,7 +192,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md, `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-mcp/system-prompts/helius-jupiter/claude.system.md
+++ b/helius-mcp/system-prompts/helius-jupiter/claude.system.md
@@ -185,7 +185,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md, `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-mcp/system-prompts/helius-jupiter/full.md
+++ b/helius-mcp/system-prompts/helius-jupiter/full.md
@@ -175,7 +175,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md (inlined below), `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys
@@ -940,15 +940,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -962,37 +962,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -1006,8 +1019,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -1016,28 +1029,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -1045,18 +1068,16 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **RPC RPS** | 10 | 50 | 200 | 500 |
 | **sendTransaction** | 1/s | 5/s | 50/s | 100/s |
 | **DAS** | 2/s | 10/s | 50/s | 100/s |
-| **WS connections** | 5 | 150 | 250 | 250 |
-| **Enhanced WS** | No | No | 100 conn | 100 conn |
-| **LaserStream** | No | Devnet | Devnet | Full (mainnet + devnet) |
+| **WS connections** | 5 | 150 | 250 | 1,000 |
+| **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
+| **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
 - **0 credits**: Helius Sender (sendSmartTransaction, sendJitoBundle)
 - **1 credit**: Standard RPC calls, sendTransaction, Priority Fee API, webhook events
-- **3 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets)
+- **2 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets, Standard WebSockets)
 - **10 credits**: getProgramAccounts, DAS API, historical data
 - **100 credits**: Enhanced Transactions API, Wallet API, webhook management
 
@@ -1064,12 +1085,12 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
-| Enhanced WebSockets | Business |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
+| Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
-| LaserStream (mainnet) | Professional |
-| LaserStream data add-ons | Professional ($500+/mo) |
+| LaserStream (mainnet) | Business |
+| LaserStream data add-ons | Business+ ($400+/mo) |
 
 Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current details.
 
@@ -1080,7 +1101,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -1088,13 +1109,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -1102,10 +1123,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -1114,6 +1136,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -1127,19 +1150,22 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes
 
 
 ---

--- a/helius-mcp/system-prompts/helius-jupiter/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-jupiter/openai.developer.md
@@ -185,7 +185,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md, `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-mcp/system-prompts/helius-phantom/claude.system.md
+++ b/helius-mcp/system-prompts/helius-phantom/claude.system.md
@@ -201,7 +201,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-mcp/system-prompts/helius-phantom/full.md
+++ b/helius-mcp/system-prompts/helius-phantom/full.md
@@ -191,7 +191,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md (inlined below)
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys
@@ -1707,15 +1707,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -1729,37 +1729,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -1773,8 +1786,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -1783,28 +1796,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -1816,8 +1839,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -1831,8 +1852,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -1847,7 +1868,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -1855,13 +1876,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -1869,10 +1890,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -1881,6 +1903,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -1894,19 +1917,22 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes
 
 
 ---

--- a/helius-mcp/system-prompts/helius-phantom/openai.developer.md
+++ b/helius-mcp/system-prompts/helius-phantom/openai.developer.md
@@ -201,7 +201,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Reference**: See helius-onboarding.md
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-mcp/system-prompts/helius/claude.system.md
+++ b/helius-mcp/system-prompts/helius/claude.system.md
@@ -41,9 +41,9 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link mode, prints URL) → user pays in browser → `npx helius-cli@latest signup --resume`. Or autopay: `... signup --plan agent --pay`.
 
 ## Routing
 
@@ -108,7 +108,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting

--- a/helius-mcp/system-prompts/helius/full.md
+++ b/helius-mcp/system-prompts/helius/full.md
@@ -31,9 +31,9 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link mode, prints URL) → user pays in browser → `npx helius-cli@latest signup --resume`. Or autopay: `... signup --plan agent --pay`.
 
 ## Routing
 
@@ -98,7 +98,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md (inlined below)
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting
@@ -1172,15 +1172,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -1194,37 +1194,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -1238,8 +1251,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -1248,28 +1261,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -1281,8 +1304,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -1296,8 +1317,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -1312,7 +1333,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -1320,13 +1341,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -1334,10 +1355,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -1346,6 +1368,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -1359,19 +1382,22 @@ npx helius-mcp@latest  # configure in your MCP client
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes
 
 
 ---

--- a/helius-mcp/system-prompts/helius/openai.developer.md
+++ b/helius-mcp/system-prompts/helius/openai.developer.md
@@ -41,9 +41,9 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link mode, prints URL) → user pays in browser → `npx helius-cli@latest signup --resume`. Or autopay: `... signup --plan agent --pay`.
 
 ## Routing
 
@@ -108,7 +108,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Reference**: See onboarding.md
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting

--- a/helius-plugin/README.md
+++ b/helius-plugin/README.md
@@ -48,7 +48,7 @@ Claude picks the right tools and reads the right reference files automatically.
 The plugin auto-starts the MCP server, but you still need a Helius API key. On first use, Claude will guide you through one of these paths:
 
 - **Existing key**: Use the `setHeliusApiKey` tool with your key from https://dashboard.helius.dev
-- **New account**: Autonomous signup via `generateKeypair` → fund wallet → `agenticSignup`
+- **New account**: `generateKeypair` → `signup` with `mode: "link"` (browser pay) or `mode: "autopay"` (pay USDC from local keypair) → after browser payment, `signup` with `mode: "resume"`
 - **CLI**: `npx helius-cli@latest keygen` → fund → `npx helius-cli@latest signup`
 
 ## Not Using Claude Code?

--- a/helius-plugin/skills/build/SKILL.md
+++ b/helius-plugin/skills/build/SKILL.md
@@ -25,7 +25,7 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
 **Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
 
@@ -92,7 +92,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting

--- a/helius-plugin/skills/build/references/onboarding.md
+++ b/helius-plugin/skills/build/references/onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-plugin/skills/dflow/SKILL.md
+++ b/helius-plugin/skills/dflow/SKILL.md
@@ -170,7 +170,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`, `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-plugin/skills/dflow/references/helius-onboarding.md
+++ b/helius-plugin/skills/dflow/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-plugin/skills/jupiter/SKILL.md
+++ b/helius-plugin/skills/jupiter/SKILL.md
@@ -181,7 +181,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`, `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-plugin/skills/jupiter/references/helius-onboarding.md
+++ b/helius-plugin/skills/jupiter/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -114,18 +137,16 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **RPC RPS** | 10 | 50 | 200 | 500 |
 | **sendTransaction** | 1/s | 5/s | 50/s | 100/s |
 | **DAS** | 2/s | 10/s | 50/s | 100/s |
-| **WS connections** | 5 | 150 | 250 | 250 |
-| **Enhanced WS** | No | No | 100 conn | 100 conn |
-| **LaserStream** | No | Devnet | Devnet | Full (mainnet + devnet) |
+| **WS connections** | 5 | 150 | 250 | 1,000 |
+| **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
+| **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
 - **0 credits**: Helius Sender (sendSmartTransaction, sendJitoBundle)
 - **1 credit**: Standard RPC calls, sendTransaction, Priority Fee API, webhook events
-- **3 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets)
+- **2 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets, Standard WebSockets)
 - **10 credits**: getProgramAccounts, DAS API, historical data
 - **100 credits**: Enhanced Transactions API, Wallet API, webhook management
 
@@ -133,12 +154,12 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
-| Enhanced WebSockets | Business |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
+| Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
-| LaserStream (mainnet) | Professional |
-| LaserStream data add-ons | Professional ($500+/mo) |
+| LaserStream (mainnet) | Business |
+| LaserStream data add-ons | Business+ ($400+/mo) |
 
 Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current details.
 
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-plugin/skills/phantom/SKILL.md
+++ b/helius-plugin/skills/phantom/SKILL.md
@@ -187,7 +187,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-plugin/skills/phantom/references/helius-onboarding.md
+++ b/helius-plugin/skills/phantom/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-skills/helius-dflow/SKILL.md
+++ b/helius-skills/helius-dflow/SKILL.md
@@ -197,7 +197,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`, `references/dflow-spot-trading.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-skills/helius-dflow/references/helius-onboarding.md
+++ b/helius-skills/helius-dflow/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-skills/helius-jupiter/SKILL.md
+++ b/helius-skills/helius-jupiter/SKILL.md
@@ -191,7 +191,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`, `references/jupiter-portal.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-skills/helius-jupiter/references/helius-onboarding.md
+++ b/helius-skills/helius-jupiter/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -114,18 +137,16 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **RPC RPS** | 10 | 50 | 200 | 500 |
 | **sendTransaction** | 1/s | 5/s | 50/s | 100/s |
 | **DAS** | 2/s | 10/s | 50/s | 100/s |
-| **WS connections** | 5 | 150 | 250 | 250 |
-| **Enhanced WS** | No | No | 100 conn | 100 conn |
-| **LaserStream** | No | Devnet | Devnet | Full (mainnet + devnet) |
+| **WS connections** | 5 | 150 | 250 | 1,000 |
+| **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
+| **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
 - **0 credits**: Helius Sender (sendSmartTransaction, sendJitoBundle)
 - **1 credit**: Standard RPC calls, sendTransaction, Priority Fee API, webhook events
-- **3 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets)
+- **2 credits**: per 0.1 MB streamed (LaserStream, Enhanced WebSockets, Standard WebSockets)
 - **10 credits**: getProgramAccounts, DAS API, historical data
 - **100 credits**: Enhanced Transactions API, Wallet API, webhook management
 
@@ -133,12 +154,12 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
-| Enhanced WebSockets | Business |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
+| Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
-| LaserStream (mainnet) | Professional |
-| LaserStream data add-ons | Professional ($500+/mo) |
+| LaserStream (mainnet) | Business |
+| LaserStream data add-ons | Business+ ($400+/mo) |
 
 Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current details.
 
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-skills/helius-phantom/SKILL.md
+++ b/helius-skills/helius-phantom/SKILL.md
@@ -206,7 +206,7 @@ These are straightforward data lookups. No reference file needed — just use th
 
 ### Getting Started / Onboarding
 **Read**: `references/helius-onboarding.md`
-**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`)
+**MCP tools**: Helius (`setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`)
 
 Use this when the user wants to:
 - Create a Helius account or set up API keys

--- a/helius-skills/helius-phantom/references/helius-onboarding.md
+++ b/helius-skills/helius-phantom/references/helius-onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes

--- a/helius-skills/helius/SKILL.md
+++ b/helius-skills/helius/SKILL.md
@@ -36,9 +36,9 @@ If using MCP and a tool returns "API key not configured":
 
 **Path A — Existing key:** Use `setHeliusApiKey` with their key from https://dashboard.helius.dev.
 
-**Path B — Agentic signup:** `generateKeypair` → user funds wallet with **~0.001 SOL** for fees + **USDC** (USDC mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) — **1 USDC** basic, **$49** Developer, **$499** Business, **$999** Professional → `checkSignupBalance` → `agenticSignup`. **Do NOT skip steps** — on-chain payment required.
+**Path B — Signup (link or autopay):** `generateKeypair` → `signup` with `mode: "link"` returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`) the user opens in any browser; after payment, `signup` with `mode: "resume"` finalizes provisioning. Or `mode: "autopay"` pays USDC from the local keypair (wallet must hold **~0.001 SOL** + USDC: **$1** Agent, **$49** Developer, **$499** Business, **$999** Professional; USDC mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). Every new signup requires `email`, `firstName`, `lastName`.
 
-**Path C — CLI:** `npx helius-cli@latest keygen` → fund wallet → `npx helius-cli@latest signup`
+**Path C — CLI:** `npx helius-cli@latest keygen` → `npx helius-cli@latest signup --plan agent --email ... --first-name ... --last-name ...` (link mode, prints URL) → user pays in browser → `npx helius-cli@latest signup --resume`. Or autopay: `... signup --plan agent --pay`.
 
 ## Routing
 
@@ -103,7 +103,7 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 ### Getting Started / Onboarding
 **Read**: `references/onboarding.md`
 **APIs**: Account API, CLI (`npx helius-cli@latest`)
-**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `checkSignupBalance`, `agenticSignup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`
+**MCP tools** (if available): `setHeliusApiKey`, `generateKeypair`, `signup`, `getAccountStatus`, `getAccountPlan`, `previewUpgrade`, `upgradePlan`, `payRenewal`, `purchaseCredits`
 **When**: account creation, API key management, plan/credits/usage checks, billing
 
 ### Documentation & Troubleshooting

--- a/helius-skills/helius/references/onboarding.md
+++ b/helius-skills/helius/references/onboarding.md
@@ -9,15 +9,15 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
-| `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
-| `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
+| `generateKeypair` | Generate or load a Solana keypair for signup (persists to `~/.helius-cli/keypair.json`) |
+| `signup` | Create a Helius account via hosted payment link (`mode: "link"`), or pay USDC directly from the local keypair (`mode: "autopay"`), or finalize a previously-created intent (`mode: "resume"`) |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
 | `getHeliusPlanInfo` | View plan details — pricing, credits, rate limits, features |
 | `compareHeliusPlans` | Compare plans side-by-side by category (rates, features, connections, pricing, support) |
 | `previewUpgrade` | Preview upgrade pricing with proration before committing |
-| `upgradePlan` | Execute a plan upgrade (processes USDC payment) |
+| `upgradePlan` | Execute a plan upgrade (returns a hosted payment link or pays USDC directly) |
 | `payRenewal` | Pay a renewal payment intent |
+| `purchaseCredits` | Buy prepaid credits (link or autopay) |
 
 ## Getting an API Key
 
@@ -31,37 +31,50 @@ If the user already has a Helius API key from the dashboard:
 
 If the environment variable `HELIUS_API_KEY` is already set, no action is needed — tools auto-detect it.
 
-### Path B: MCP Agentic Signup (For AI Agents)
+### Path B: MCP Signup (For AI Agents)
 
-The fully autonomous signup flow, no browser needed:
+Two modes — pick based on whether the user wants to pay in a browser or have the agent pay USDC from a local keypair.
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
-2. **User funds the wallet** with:
-   - ~0.001 SOL for transaction fees
-   - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
-3. **`checkSignupBalance`** — verifies SOL and USDC balances are sufficient
-4. **`agenticSignup`** — creates the account, processes USDC payment, returns API key + RPC endpoints + project ID
-   - API key is automatically configured for the session and saved to shared config
-   - If the wallet already has an account, it detects and returns existing credentials (no double payment)
+**Link mode (default — pay in browser):**
 
-**Parameters for `agenticSignup`:**
-- `plan`: `"basic"` (default, $1), `"developer"`, `"business"`, or `"professional"`
+1. **`generateKeypair`** — generates or loads a Solana keypair. Returns the wallet address.
+2. **`signup`** with `mode: "link"` — creates a payment intent and returns a `paymentUrl` (e.g. `https://dashboard.helius.dev/pay/<id>`). The user opens that URL in any browser and pays with any wallet. The pending intent is persisted to shared config.
+3. **`signup`** with `mode: "resume"` — polls the intent, finalizes account provisioning, and configures the API key automatically once payment settles.
+
+**Autopay mode (agent pays USDC from local keypair):**
+
+1. **`generateKeypair`** — same as above.
+2. **User funds the wallet** with ~0.001 SOL (transaction fees) + the plan amount in USDC ($1 Agent, $49 Developer, $499 Business, $999 Professional).
+3. **`signup`** with `mode: "autopay"` — sends USDC + memo from the local keypair, polls until the subscription is provisioned, returns API key + RPC endpoints + project ID.
+
+If the wallet already has an account on the same plan, `signup` detects it and returns existing credentials (no double payment). If it's on a different plan, `signup` returns `kind: "upgrade_required"` — use `upgradePlan` instead.
+
+**Parameters for `signup`:**
+- `mode`: `"link"` (default), `"autopay"`, or `"resume"`
+- `plan`: `"agent"` (default, $1), `"developer"`, `"business"`, or `"professional"`
 - `period`: `"monthly"` (default) or `"yearly"` (paid plans only)
-- `email`, `firstName`, `lastName`: required for paid plans
+- `email`, `firstName`, `lastName`: required for every new signup
 - `couponCode`: optional discount code
-
-Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 
 ### Path C: Helius CLI
 
-The `helius-cli` provides the same autonomous signup from the terminal:
+The `helius-cli` provides the same flow from the terminal:
 
 ```bash
 # Generate keypair (saved to ~/.helius-cli/keypair.json)
 helius keygen
 
-# Fund the wallet, then sign up (pays 1 USDC for basic plan)
-helius signup --json
+# Print a hosted payment link (default)
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --json
+
+# Pay in the browser, then finalize:
+helius signup --resume --json
+
+# Or autopay USDC directly from the local keypair:
+helius signup --plan agent --email me@example.com --first-name Ada --last-name Lovelace --pay --json
+
+# Discard a stuck pending intent and start over:
+helius signup --restart --plan agent ...
 
 # List projects and get API keys
 helius projects --json
@@ -75,8 +88,8 @@ helius rpc <project-id> --json
 - `0`: success
 - `10`: not logged in (run `helius login`)
 - `11`: keypair not found (run `helius keygen`)
-- `20`: insufficient SOL
-- `21`: insufficient USDC
+- `20`: insufficient SOL (autopay only)
+- `21`: insufficient USDC (autopay only)
 
 Always use the `--json` flag for machine-readable output when scripting.
 
@@ -85,28 +98,38 @@ Always use the `--json` flag for machine-readable output when scripting.
 For applications that need to create Helius accounts programmatically:
 
 ```typescript
-const helius = createHelius({ apiKey: '' }); // No key yet — signing up
+import { makeAuthClient } from "helius-sdk/auth/client";
+const auth = makeAuthClient();
 
-const keypair = await helius.auth.generateKeypair();
-const address = await helius.auth.getAddress(keypair);
+const keypair = await auth.generateKeypair();
 
-// Fund the wallet (user action), then sign up
-const result = await helius.auth.agenticSignup({
+// Hosted-link signup (returns a paymentUrl the user opens in a browser):
+const link = await auth.signup({
   secretKey: keypair.secretKey,
-  plan: 'developer',
-  period: 'monthly',
-  email: 'user@example.com',
-  firstName: 'Jane',
-  lastName: 'Doe',
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
 });
-// result.apiKey, result.projectId, result.endpoints, result.jwt
+// link.paymentLink.paymentUrl — open this in a browser
+
+// Or pay USDC directly from the local keypair:
+const result = await auth.signupAndPay({
+  secretKey: keypair.secretKey,
+  plan: "developer",
+  period: "monthly",
+  email: "user@example.com",
+  firstName: "Jane",
+  lastName: "Doe",
+});
+// result.kind: "completed" | "pending" | "expired" | "failed" | "already_subscribed" | "upgrade_required"
+// On "completed": result has { jwt, walletAddress, projectId, apiKey, endpoints, txSignature }
 ```
 
 ## Plans and Pricing
 
-The agentic signup flow uses these plan tiers (all paid in USDC):
-
-| | Basic | Developer | Business | Professional |
+| | Agent | Developer | Business | Professional |
 |---|---|---|---|---|
 | **Price** | $1 USDC | $49/mo | $499/mo | $999/mo |
 | **Credits** | 1M | 10M | 100M | 200M |
@@ -118,8 +141,6 @@ The agentic signup flow uses these plan tiers (all paid in USDC):
 | **Enhanced WS** | No | 150 conn | 250 conn | 1,000 conn |
 | **LaserStream** | No | Devnet | Devnet + Mainnet | Devnet + Mainnet |
 | **Support** | Discord | Chat (24hr) | Priority (12hr) | Slack + Telegram (8hr) |
-
-The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but agentic signup charges $1 USDC to create the account on-chain.
 
 ### Credit Costs
 
@@ -133,8 +154,8 @@ The dashboard shows a "Free" tier at $0 — that is the same plan as Basic, but 
 
 | Feature | Minimum Plan |
 |---|---|
-| Standard RPC, DAS, Webhooks, Sender | Basic |
-| Standard WebSockets | Basic |
+| Standard RPC, DAS, Webhooks, Sender | Agent |
+| Standard WebSockets | Agent |
 | Enhanced WebSockets | Developer |
 | LaserStream (devnet) | Developer |
 | LaserStream (mainnet) | Business |
@@ -149,7 +170,7 @@ Use the `getHeliusPlanInfo` or `compareHeliusPlans` MCP tools for current detail
 The `getAccountStatus` tool provides three tiers of information:
 
 1. **No auth**: Tells the user how to get started (set key or sign up)
-2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `agenticSignup` to detect existing account
+2. **API key only** (no JWT): Confirms auth but can't show credit usage — suggests calling `signup` to detect existing account
 3. **Full JWT session**: Shows plan, rate limits, credit usage breakdown (API/RPC/webhooks/overage), billing cycle with days remaining, and burn-rate projections with warnings
 
 Call `getAccountStatus` before bulk operations to verify sufficient credits.
@@ -157,13 +178,13 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 ### Upgrade Plans
 
 1. **`previewUpgrade`** — shows pricing breakdown: subtotal, prorated credits, discounts, coupon status, amount due today
-2. **`upgradePlan`** — executes the upgrade, processes USDC payment from the signup wallet
+2. **`upgradePlan`** — returns a hosted payment link by default, or pays USDC directly with `mode: "autopay"`
    - Requires `email`, `firstName`, `lastName` for first-time upgrades (all three or none)
    - Supports `couponCode` for discounts
 
 ### Pay Renewals
 
-`payRenewal` takes a `paymentIntentId` from a renewal notification and processes the USDC payment.
+`payRenewal` takes a `paymentIntentId` from a renewal notification and either prints a payment link or pays USDC directly.
 
 ## Environment Configuration
 
@@ -171,10 +192,11 @@ Call `getAccountStatus` before bulk operations to verify sufficient credits.
 # Required — set one of these:
 HELIUS_API_KEY=your-api-key          # Environment variable
 # OR use setHeliusApiKey MCP tool    # Session + shared config
-# OR use agenticSignup               # Auto-configures
+# OR use signup                      # Auto-configures
 
 # Optional
 HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
+HELIUS_PAYMENT_HOST=https://dashboard.helius.dev   # override hosted-link host (e.g. staging)
 ```
 
 ### Shared Config
@@ -183,6 +205,7 @@ The MCP persists API keys and JWTs to shared config files so they survive across
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
 - **Keypair**: saved to `~/.helius-cli/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
+- **Pending payment intent**: link-mode signup persists the pending intent so `mode: "resume"` (or `helius signup --resume`) can finalize after the user pays in the browser
 
 ### Installing the MCP
 
@@ -196,16 +219,19 @@ claude mcp add helius npx helius-mcp@latest
 |---|---|
 | User has a Helius API key | `setHeliusApiKey` (Path A) |
 | User has `HELIUS_API_KEY` env var set | No action needed — auto-detected |
-| AI agent needs to sign up autonomously | `generateKeypair` -> fund -> `agenticSignup` (Path B) |
-| Script/CI needs to sign up | `helius keygen` -> fund -> `helius signup --json` (Path C) |
-| Application needs programmatic signup | SDK `agenticSignup()` function |
-| User wants full account visibility | `agenticSignup` (detects existing accounts) then `getAccountStatus` |
+| AI agent + user wants to pay in browser | `generateKeypair` -> `signup` (link) -> user pays -> `signup` (resume) (Path B) |
+| AI agent + agent pays USDC from local keypair | `generateKeypair` -> fund wallet -> `signup` (autopay) (Path B) |
+| Script/CI link-mode signup | `helius keygen` -> `helius signup --json` -> user pays -> `helius signup --resume --json` (Path C) |
+| Script/CI autopay signup | `helius keygen` -> fund -> `helius signup --pay --json` (Path C) |
+| Application needs programmatic signup | SDK `signup()` / `signupAndPay()` |
+| User wants full account visibility | `signup` (detects existing accounts) then `getAccountStatus` |
 | User needs a higher plan | `previewUpgrade` then `upgradePlan` |
 
 ## Common Mistakes
 
-- Calling `agenticSignup` without first calling `generateKeypair` — there's no wallet to sign with
-- Not funding the wallet before calling `agenticSignup` — the USDC payment will fail
-- Assuming `agenticSignup` charges twice for existing accounts — it detects and returns existing credentials
-- Using `getAccountStatus` without a JWT session — call `agenticSignup` first to establish the session (it detects existing accounts for free)
-- Forgetting that paid plan signup requires `email`, `firstName`, and `lastName` — all three are required together
+- Calling `signup` without first calling `generateKeypair` — there's no wallet to sign with
+- Calling `signup` with `mode: "autopay"` before funding the wallet — the USDC payment will fail
+- Assuming `signup` charges twice for existing accounts — it detects and returns existing credentials
+- Using `getAccountStatus` without a JWT session — call `signup` first to establish the session (it detects existing accounts for free)
+- Forgetting that every new signup requires `email`, `firstName`, and `lastName` — all three are required together
+- After a link-mode signup, forgetting to call `mode: "resume"` (or `helius signup --resume`) — the account isn't provisioned until polling completes


### PR DESCRIPTION
## Summary

Phases 1, 2, and 3 of the SDK signup revamp on the CLI + MCP side. The CLI gains link-mode UX for `signup` / `upgrade` / `pay`, plus a new `helius credits` command. The MCP migrates fully off the legacy `agenticSignup` tool to the new `signup` (with `mode: "link" | "autopay" | "resume"`) tool, and gains parallel `upgradePlan` / `purchaseCredits` / `payRenewal` tools.

Pairs with helius-labs/helius-sdk#312 and helius-labs/monorepo#15009. Don't merge until both upstream PRs are in prod.

## helius-cli — every paid command now has three modes

| Command | Default (link) | `--pay` (autopay) | `--resume` |
|---|---|---|---|
| `helius signup` | print payment URL, save pendingSignup | send USDC + memo, poll, provision | poll stored pending intent |
| `helius upgrade` | print upgrade payment URL, save pendingUpgrade | autopay + poll | poll stored pending upgrade |
| `helius pay <id>` | print renewal payment URL | autopay + poll (no activation gate) | poll the renewal intent |
| `helius credits` (new) | print credits-topup URL, save pendingCredits | autopay + poll | poll stored pending credits |

JSON shapes are uniform across commands: `PAYMENT_REQUIRED` / `SUCCESS` / `PENDING` / `EXPIRED` / `FAILED` / `MISSING_PENDING_*` / `ALREADY_SUBSCRIBED` / `UPGRADE_REQUIRED`. Pending state in `~/.helius/config.json` is per-flow (`pendingSignup`, `pendingUpgrade`, `pendingCredits`) so the three flows don't collide. Local `expiresAt` is informational; cleanup only on backend-reported terminal states or `--restart`.

## helius-mcp — agenticSignup tool retired, full Phase 3 migration

- **`signup` tool** replaces `agenticSignup`. Takes `mode: "link" | "autopay" | "resume"` (default `"link"`). Link mode prints the payment URL, autopay sends USDC + memo from the local keypair, resume polls a pending intent.
- **`upgradePlan`, `purchaseCredits`, `payRenewal`** tools rewritten on the new SDK helpers. Each takes `mode: "link" | "autopay"`.
- **`getStarted`** rewritten around the link flow (drops "fund wallet → check balance" steps).
- **`checkSignupBalance`** tool removed — no longer needed for browser-pay flow.
- Router catalog + action lists updated.

## Other changes

- `lib/api.ts` exposes pass-throughs for the new SDK Phase 2 helpers (`upgradePlan`/`AndPay`, `purchaseCredits`/`AndPay`, `payRenewal`/`AndPay`).
- `lib/config.ts` factored into `PendingPaymentBase` shared shape + flow-specific extensions (`PendingSignup` / `PendingUpgrade` / `PendingCredits`).
- `bin/helius.ts` flag changes for the new modes; new `helius credits` command registration.
- README updated for Phase 1 link mode (Phase 2 docs follow once SDK ships).

## Coordination

- Pairs with helius-labs/helius-sdk#312 and helius-labs/monorepo#15009 and helius-labs/dev-portal-v2#1088.
- After SDK publishes to npm, bump `helius-sdk` dep version on this branch before merging.

## Test plan

- [ ] CLI Phase 1: `pnpm test` — 17 / 17 (pre-existing test for signup flow still green)
- [ ] MCP: `vitest run` — 223 / 223 (existing suite still passes after the auth.ts rewrite)
- [ ] CLI typecheck: `tsc --noEmit` clean (one pre-existing `reclaim.ts` error unrelated)
- [ ] MCP typecheck: clean
- [ ] Phase 1 smoke verified live against dev-api-dev (signup link → browser pay → resume)
- [ ] Phase 2 / Phase 3 live smoke pending the SDK npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)