### PR TITLE
feat(mcp+cli): expose getTransfersByAddress RPC method

### DIFF
--- a/.agents/skills/helius/SKILL.md
+++ b/.agents/skills/helius/SKILL.md
@@ -100,8 +100,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Read**: `references/enhanced-transactions.md`
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -150,6 +150,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -193,3 +194,4 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.

--- a/.agents/skills/helius/prompts/claude.system.md
+++ b/.agents/skills/helius/prompts/claude.system.md
@@ -101,8 +101,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Reference**: See enhanced-transactions.md
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -151,6 +151,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -194,6 +195,7 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.
 
 
 === END SKILL: helius ===

--- a/.agents/skills/helius/prompts/full.md
+++ b/.agents/skills/helius/prompts/full.md
@@ -91,8 +91,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Reference**: See enhanced-transactions.md (inlined below)
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -141,6 +141,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -184,6 +185,7 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.
 
 
 ---
@@ -505,6 +507,7 @@ Use these endpoints for transaction analysis — available via MCP tools, SDK me
 | `parseTransactions` | Parse signatures into human-readable format. Returns type, source program, transfers, fees, description. Use `showRaw: true` for instruction-level data. | 100/call | REST: `POST /v0/transactions/`, SDK: `helius.enhanced.getTransactions()`, MCP: `parseTransactions` |
 | `getTransactionsByAddress` | Get parsed transaction history for a wallet via the Enhanced Transactions API. | ~110 | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | `getTransactionsForAddress` | Get transaction history via RPC with advanced filters. Handles `getSignaturesForAddress` + enrichment internally. | ~10-110 | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| `getTransfersByAddress` | RPC method that returns **one row per token/SOL transfer** (not per transaction) with rich filters: mint, direction (in/out/any), counterparty (`with`), time/slot/amount ranges, SOL/WSOL display mode. | RPC | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
 
 Related endpoint (Wallet API, covered in `wallet-api.md`):
 
@@ -520,6 +523,8 @@ Related endpoint (Wallet API, covered in `wallet-api.md`):
 | Get a wallet's recent activity (human-readable) | `getTransactionsByAddress` | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | Get a lightweight list of signatures for a wallet | `getTransactionsForAddress` (signatures mode) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `signatures`) |
 | Filter by time range, slot range, or status | `getTransactionsForAddress` (with filters) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| List per-transfer rows (mint/amount/from/to) for an address | `getTransfersByAddress` | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
+| Aggregate transfers by mint or counterparty | `getTransfersByAddress` with `mint` / `with` filters | SDK / MCP |
 | See balance changes per transaction | `getWalletHistory` (Wallet API) | REST / MCP |
 | Debug raw instruction data | `parseTransactions` with `showRaw: true` | REST / SDK / MCP |
 
@@ -759,6 +764,54 @@ const history = await helius.getTransactionsForAddress(
 ```
 
 **Pagination**: use `paginationToken` from the previous response.
+
+### Method 3: `helius.getTransfersByAddress()` — per-transfer rows
+
+Returns **one row per token or native SOL transfer** (not per transaction). Each row carries `{ signature, slot, blockTime, type, fromUserAccount, toUserAccount, mint, amount, uiAmount, decimals, transactionIdx, instructionIdx, innerInstructionIdx, … }`. Use this when you want to aggregate by mint, counterparty, or direction — far easier than parsing transactions and re-extracting transfers.
+
+Signature: `helius.getTransfersByAddress([address, config?])` — note the positional tuple.
+
+```typescript
+// Recent transfers
+const recent = await helius.getTransfersByAddress([
+  'WalletAddress',
+  { limit: 25, sortOrder: 'desc' },
+]);
+
+// Inbound USDC only
+const inboundUsdc = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    direction: 'in',
+    limit: 50,
+  },
+]);
+
+// Transfers with a specific counterparty in the last 24h
+const oneDayAgo = Math.floor(Date.now() / 1000) - 86400;
+const withCounterparty = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    with: 'CounterpartyAddress',
+    filters: { blockTime: { gte: oneDayAgo } },
+    limit: 100,
+  },
+]);
+
+// Pagination
+const page1 = await helius.getTransfersByAddress(['WalletAddress', { limit: 50 }]);
+if (page1.paginationToken) {
+  const page2 = await helius.getTransfersByAddress([
+    'WalletAddress',
+    { limit: 50, paginationToken: page1.paginationToken },
+  ]);
+}
+```
+
+**Config options**: `with` (counterparty), `direction` (`in` | `out` | `any`), `mint`, `solMode` (`merged` | `separate`), `filters.amount` / `filters.blockTime` / `filters.slot` (each with `gt`/`gte`/`lt`/`lte`), `limit`, `sortOrder` (`asc` | `desc`), `paginationToken`, `commitment` (`finalized` | `confirmed`).
+
+**MCP**: `heliusTransaction.getTransfersByAddress` with the same fields flattened (e.g., `blockTimeGte`, `amountGte`).
 
 ### Parameter Name Mapping
 

--- a/.agents/skills/helius/prompts/openai.developer.md
+++ b/.agents/skills/helius/prompts/openai.developer.md
@@ -101,8 +101,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Reference**: See enhanced-transactions.md
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -151,6 +151,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -194,6 +195,7 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.
 
 
 === END SKILL: helius ===

--- a/.agents/skills/helius/references/enhanced-transactions.md
+++ b/.agents/skills/helius/references/enhanced-transactions.md
@@ -17,6 +17,7 @@ Use these endpoints for transaction analysis — available via MCP tools, SDK me
 | `parseTransactions` | Parse signatures into human-readable format. Returns type, source program, transfers, fees, description. Use `showRaw: true` for instruction-level data. | 100/call | REST: `POST /v0/transactions/`, SDK: `helius.enhanced.getTransactions()`, MCP: `parseTransactions` |
 | `getTransactionsByAddress` | Get parsed transaction history for a wallet via the Enhanced Transactions API. | ~110 | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | `getTransactionsForAddress` | Get transaction history via RPC with advanced filters. Handles `getSignaturesForAddress` + enrichment internally. | ~10-110 | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| `getTransfersByAddress` | RPC method that returns **one row per token/SOL transfer** (not per transaction) with rich filters: mint, direction (in/out/any), counterparty (`with`), time/slot/amount ranges, SOL/WSOL display mode. | RPC | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
 
 Related endpoint (Wallet API, covered in `wallet-api.md`):
 
@@ -32,6 +33,8 @@ Related endpoint (Wallet API, covered in `wallet-api.md`):
 | Get a wallet's recent activity (human-readable) | `getTransactionsByAddress` | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | Get a lightweight list of signatures for a wallet | `getTransactionsForAddress` (signatures mode) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `signatures`) |
 | Filter by time range, slot range, or status | `getTransactionsForAddress` (with filters) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| List per-transfer rows (mint/amount/from/to) for an address | `getTransfersByAddress` | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
+| Aggregate transfers by mint or counterparty | `getTransfersByAddress` with `mint` / `with` filters | SDK / MCP |
 | See balance changes per transaction | `getWalletHistory` (Wallet API) | REST / MCP |
 | Debug raw instruction data | `parseTransactions` with `showRaw: true` | REST / SDK / MCP |
 
@@ -271,6 +274,54 @@ const history = await helius.getTransactionsForAddress(
 ```
 
 **Pagination**: use `paginationToken` from the previous response.
+
+### Method 3: `helius.getTransfersByAddress()` — per-transfer rows
+
+Returns **one row per token or native SOL transfer** (not per transaction). Each row carries `{ signature, slot, blockTime, type, fromUserAccount, toUserAccount, mint, amount, uiAmount, decimals, transactionIdx, instructionIdx, innerInstructionIdx, … }`. Use this when you want to aggregate by mint, counterparty, or direction — far easier than parsing transactions and re-extracting transfers.
+
+Signature: `helius.getTransfersByAddress([address, config?])` — note the positional tuple.
+
+```typescript
+// Recent transfers
+const recent = await helius.getTransfersByAddress([
+  'WalletAddress',
+  { limit: 25, sortOrder: 'desc' },
+]);
+
+// Inbound USDC only
+const inboundUsdc = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    direction: 'in',
+    limit: 50,
+  },
+]);
+
+// Transfers with a specific counterparty in the last 24h
+const oneDayAgo = Math.floor(Date.now() / 1000) - 86400;
+const withCounterparty = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    with: 'CounterpartyAddress',
+    filters: { blockTime: { gte: oneDayAgo } },
+    limit: 100,
+  },
+]);
+
+// Pagination
+const page1 = await helius.getTransfersByAddress(['WalletAddress', { limit: 50 }]);
+if (page1.paginationToken) {
+  const page2 = await helius.getTransfersByAddress([
+    'WalletAddress',
+    { limit: 50, paginationToken: page1.paginationToken },
+  ]);
+}
+```
+
+**Config options**: `with` (counterparty), `direction` (`in` | `out` | `any`), `mint`, `solMode` (`merged` | `separate`), `filters.amount` / `filters.blockTime` / `filters.slot` (each with `gt`/`gte`/`lt`/`lte`), `limit`, `sortOrder` (`asc` | `desc`), `paginationToken`, `commitment` (`finalized` | `confirmed`).
+
+**MCP**: `heliusTransaction.getTransfersByAddress` with the same fields flattened (e.g., `blockTimeGte`, `amountGte`).
 
 ### Parameter Name Mapping
 

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -394,6 +394,12 @@ txCmd
   .option("--pagination-token <token>", "Cursor from a previous response")
   .option("--block-time-gte <ts>", "Unix seconds lower bound")
   .option("--block-time-lte <ts>", "Unix seconds upper bound")
+  .option("--slot-gte <slot>", "Slot lower bound")
+  .option("--slot-lte <slot>", "Slot upper bound")
+  .option("--amount-gte <raw>", "Raw u64 amount lower bound (not UI amount)")
+  .option("--amount-lte <raw>", "Raw u64 amount upper bound (not UI amount)")
+  .option("--sol-mode <mode>", "merged | separate — treat SOL/WSOL as one asset, or keep distinct")
+  .option("--commitment <level>", "finalized | confirmed")
   .option("--json", "Output JSON envelope")
   .addHelpText('after', `
 Examples:

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -15,7 +15,7 @@ import { rpcCommand } from "../src/commands/rpc.js";
 import { keygenCommand, getDefaultKeypairPath } from "../src/commands/keygen.js";
 import { configShowCommand, configSetApiKeyCommand, configSetNetworkCommand, configSetProjectCommand, configClearCommand } from "../src/commands/config-cmd.js";
 import { balanceCommand, tokensCommand, tokenHoldersCommand } from "../src/commands/balance.js";
-import { txParseCommand, txHistoryCommand, txFeesCommand } from "../src/commands/tx.js";
+import { txParseCommand, txHistoryCommand, txTransfersCommand, txFeesCommand } from "../src/commands/tx.js";
 import {
   assetGetCommand, assetBatchCommand, assetOwnerCommand, assetCreatorCommand,
   assetAuthorityCommand, assetCollectionCommand, assetSearchCommand,
@@ -382,6 +382,25 @@ Examples:
   $ helius tx history 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY
   $ helius tx history 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY --limit 5 --type SWAP --json`)
   .action(function(this: any, address: string) { txHistoryCommand(address, opts(this)); });
+
+txCmd
+  .command("transfers <address>")
+  .description("List parsed token + SOL transfers for an address (RPC, rich filters)")
+  .option("-l, --limit <n>", "Max transfers per page (1-100, default 25)")
+  .option("--sort-order <order>", "asc | desc", "desc")
+  .option("--mint <mint>", "Filter by token mint address")
+  .option("--direction <dir>", "in | out | any", "any")
+  .option("--with <addr>", "Filter by counterparty address")
+  .option("--pagination-token <token>", "Cursor from a previous response")
+  .option("--block-time-gte <ts>", "Unix seconds lower bound")
+  .option("--block-time-lte <ts>", "Unix seconds upper bound")
+  .option("--json", "Output JSON envelope")
+  .addHelpText('after', `
+Examples:
+  $ helius tx transfers 86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY --limit 5
+  $ helius tx transfers <addr> --mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --direction in
+  $ helius tx transfers <addr> --with <counterparty> --block-time-gte 1700000000 --json`)
+  .action(function(this: any, address: string) { txTransfersCommand(address, opts(this)); });
 
 txCmd
   .command("fees")

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -182,8 +182,7 @@ export async function txTransfersCommand(address: string, options: TxTransfersOp
     }
     if (Object.keys(filters).length > 0) config.filters = filters;
 
-    // SDK method shipped in helius-sdk PR #313; cast until npm release catches up.
-    const result: any = await withRetry(() => (helius as any).getTransfersByAddress([address, config]), options, spinner);
+    const result: any = await withRetry(() => (helius as any).getTransfersByAddress(address, config), options, spinner);
     spinner?.stop();
 
     if (options.json) {

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -205,10 +205,10 @@ export async function txTransfersCommand(address: string, options: TxTransfersOp
       const symbol = isSol ? "SOL" : "";
       const from = t.fromUserAccount ? formatAddress(t.fromUserAccount) : (t.type === "mint" ? "mint" : "?");
       const to = t.toUserAccount ? formatAddress(t.toUserAccount) : (t.type === "burn" ? "burn" : "?");
-      const time = t.blockTime ? formatTimestamp(t.blockTime) : "N/A";
+      const time = t.blockTime ? formatTimestamp(Number(t.blockTime)) : "N/A";
       console.log(`  ${chalk.yellow((t.type || "transfer").padEnd(10))} ${amount}${symbol ? " " + symbol : ""}`);
       console.log(`    ${from} ${chalk.gray("→")} ${to}`);
-      console.log(`    ${chalk.gray("sig:")} ${chalk.cyan(formatAddress(t.signature))}  ${chalk.gray("slot:")} ${t.slot}  ${chalk.gray(time)}`);
+      console.log(`    ${chalk.gray("sig:")} ${chalk.cyan(formatAddress(t.signature))}  ${chalk.gray("slot:")} ${t.slot.toString()}  ${chalk.gray(time)}`);
     }
     console.log(chalk.gray(`\n  ${data.length} transfer(s) shown`));
     if (result?.paginationToken) {

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -107,6 +107,12 @@ interface TxTransfersOptions extends TxOptions {
   paginationToken?: string;
   blockTimeGte?: string;
   blockTimeLte?: string;
+  commitment?: string;
+  solMode?: string;
+  amountGte?: string;
+  amountLte?: string;
+  slotGte?: string;
+  slotLte?: string;
 }
 
 export async function txTransfersCommand(address: string, options: TxTransfersOptions = {}): Promise<void> {
@@ -114,6 +120,19 @@ export async function txTransfersCommand(address: string, options: TxTransfersOp
   try {
     const addrErr = validateAddress(address);
     if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
+
+    if (options.commitment && !["finalized", "confirmed"].includes(options.commitment)) {
+      exitWithError("INVALID_INPUT", `--commitment must be "finalized" or "confirmed" (got "${options.commitment}")`, undefined, !!options.json);
+    }
+    if (options.solMode && !["merged", "separate"].includes(options.solMode)) {
+      exitWithError("INVALID_INPUT", `--sol-mode must be "merged" or "separate" (got "${options.solMode}")`, undefined, !!options.json);
+    }
+    if (options.direction && !["in", "out", "any"].includes(options.direction)) {
+      exitWithError("INVALID_INPUT", `--direction must be "in", "out", or "any" (got "${options.direction}")`, undefined, !!options.json);
+    }
+    if (options.sortOrder && !["asc", "desc"].includes(options.sortOrder)) {
+      exitWithError("INVALID_INPUT", `--sort-order must be "asc" or "desc" (got "${options.sortOrder}")`, undefined, !!options.json);
+    }
 
     const helius = await setupClient(spinner, options, "Fetching transfers...");
 
@@ -125,12 +144,41 @@ export async function txTransfersCommand(address: string, options: TxTransfersOp
     if (options.mint) config.mint = options.mint;
     if (options.with) config.with = options.with;
     if (options.paginationToken) config.paginationToken = options.paginationToken;
+    if (options.commitment) config.commitment = options.commitment;
+    if (options.solMode) config.solMode = options.solMode;
+
+    // SDK's TransferComparisonFilter types amount as `number`, so raw u64 values outside JS safe-integer
+    // range (>2^53) can't be passed without precision loss. Mirror the MCP handler: surface a clear error
+    // rather than silently dropping the filter.
+    const parseAmountBound = (raw: string | undefined, label: string): number | undefined => {
+      if (raw === undefined) return undefined;
+      const n = Number(raw);
+      if (!Number.isFinite(n)) {
+        exitWithError("INVALID_INPUT", `${label} must be a numeric raw u64 amount (got "${raw}")`, undefined, !!options.json);
+      }
+      if (!Number.isSafeInteger(n) || n < 0) {
+        exitWithError("INVALID_INPUT", `${label}="${raw}" is outside JS safe integer range (>2^53) or negative. Pass a smaller raw amount or filter client-side.`, undefined, !!options.json);
+      }
+      return n;
+    };
 
     const filters: Record<string, { gte?: number; lte?: number }> = {};
     if (options.blockTimeGte || options.blockTimeLte) {
       filters.blockTime = {};
       if (options.blockTimeGte) filters.blockTime.gte = parseInt(options.blockTimeGte, 10);
       if (options.blockTimeLte) filters.blockTime.lte = parseInt(options.blockTimeLte, 10);
+    }
+    if (options.slotGte || options.slotLte) {
+      filters.slot = {};
+      if (options.slotGte) filters.slot.gte = parseInt(options.slotGte, 10);
+      if (options.slotLte) filters.slot.lte = parseInt(options.slotLte, 10);
+    }
+    const aGte = parseAmountBound(options.amountGte, "--amount-gte");
+    const aLte = parseAmountBound(options.amountLte, "--amount-lte");
+    if (aGte !== undefined || aLte !== undefined) {
+      filters.amount = {};
+      if (aGte !== undefined) filters.amount.gte = aGte;
+      if (aLte !== undefined) filters.amount.lte = aLte;
     }
     if (Object.keys(filters).length > 0) config.filters = filters;
 

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -98,6 +98,79 @@ export async function txHistoryCommand(address: string, options: TxOptions & { l
   }
 }
 
+interface TxTransfersOptions extends TxOptions {
+  limit?: string;
+  sortOrder?: string;
+  mint?: string;
+  direction?: string;
+  with?: string;
+  paginationToken?: string;
+  blockTimeGte?: string;
+  blockTimeLte?: string;
+}
+
+export async function txTransfersCommand(address: string, options: TxTransfersOptions = {}): Promise<void> {
+  const spinner = createSpinner(options);
+  try {
+    const addrErr = validateAddress(address);
+    if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
+
+    const helius = await setupClient(spinner, options, "Fetching transfers...");
+
+    const limit = options.limit ? Math.min(Math.max(parseInt(options.limit, 10), 1), 100) : 25;
+    const sortOrder = options.sortOrder || "desc";
+    const direction = options.direction || "any";
+
+    const config: Record<string, unknown> = { direction, limit, sortOrder };
+    if (options.mint) config.mint = options.mint;
+    if (options.with) config.with = options.with;
+    if (options.paginationToken) config.paginationToken = options.paginationToken;
+
+    const filters: Record<string, { gte?: number; lte?: number }> = {};
+    if (options.blockTimeGte || options.blockTimeLte) {
+      filters.blockTime = {};
+      if (options.blockTimeGte) filters.blockTime.gte = parseInt(options.blockTimeGte, 10);
+      if (options.blockTimeLte) filters.blockTime.lte = parseInt(options.blockTimeLte, 10);
+    }
+    if (Object.keys(filters).length > 0) config.filters = filters;
+
+    // SDK method shipped in helius-sdk PR #313; cast until npm release catches up.
+    const result: any = await withRetry(() => (helius as any).getTransfersByAddress([address, config]), options, spinner);
+    spinner?.stop();
+
+    if (options.json) {
+      outputJson(result);
+      return;
+    }
+
+    const data = result?.data || [];
+    if (!Array.isArray(data) || data.length === 0) {
+      console.log(chalk.yellow("\nNo transfers found."));
+      return;
+    }
+
+    const WSOL = "So11111111111111111111111111111111111111112";
+    console.log(chalk.bold(`\nTransfers for ${chalk.cyan(address)}:\n`));
+    for (const t of data) {
+      const isSol = t.mint === WSOL && t.fromTokenAccount === undefined && t.toTokenAccount === undefined;
+      const amount = isSol ? formatSol(Number(t.amount)) : `${t.uiAmount} ${formatAddress(t.mint)}`;
+      const symbol = isSol ? "SOL" : "";
+      const from = t.fromUserAccount ? formatAddress(t.fromUserAccount) : (t.type === "mint" ? "mint" : "?");
+      const to = t.toUserAccount ? formatAddress(t.toUserAccount) : (t.type === "burn" ? "burn" : "?");
+      const time = t.blockTime ? formatTimestamp(t.blockTime) : "N/A";
+      console.log(`  ${chalk.yellow((t.type || "transfer").padEnd(10))} ${amount}${symbol ? " " + symbol : ""}`);
+      console.log(`    ${from} ${chalk.gray("→")} ${to}`);
+      console.log(`    ${chalk.gray("sig:")} ${chalk.cyan(formatAddress(t.signature))}  ${chalk.gray("slot:")} ${t.slot}  ${chalk.gray(time)}`);
+    }
+    console.log(chalk.gray(`\n  ${data.length} transfer(s) shown`));
+    if (result?.paginationToken) {
+      console.log(chalk.gray(`  Next: --pagination-token ${result.paginationToken}`));
+    }
+  } catch (error) {
+    handleCommandError(error, options, spinner);
+  }
+}
+
 export async function txFeesCommand(options: TxOptions & { accounts?: string } = {}): Promise<void> {
   const spinner = createSpinner(options);
   try {

--- a/helius-cli/src/commands/tx.ts
+++ b/helius-cli/src/commands/tx.ts
@@ -152,7 +152,8 @@ export async function txTransfersCommand(address: string, options: TxTransfersOp
     const WSOL = "So11111111111111111111111111111111111111112";
     console.log(chalk.bold(`\nTransfers for ${chalk.cyan(address)}:\n`));
     for (const t of data) {
-      const isSol = t.mint === WSOL && t.fromTokenAccount === undefined && t.toTokenAccount === undefined;
+      // SDK omits from/toTokenAccount for native SOL transfers; accept null or undefined from JSON.
+      const isSol = t.mint === WSOL && t.fromTokenAccount == null && t.toTokenAccount == null;
       const amount = isSol ? formatSol(Number(t.amount)) : `${t.uiAmount} ${formatAddress(t.mint)}`;
       const symbol = isSol ? "SOL" : "";
       const from = t.fromUserAccount ? formatAddress(t.fromUserAccount) : (t.type === "mint" ? "mint" : "?");

--- a/helius-cursor/skills/build/SKILL.md
+++ b/helius-cursor/skills/build/SKILL.md
@@ -85,8 +85,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Read**: `references/enhanced-transactions.md`
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -135,6 +135,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -178,3 +179,4 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.

--- a/helius-cursor/skills/build/references/enhanced-transactions.md
+++ b/helius-cursor/skills/build/references/enhanced-transactions.md
@@ -17,6 +17,7 @@ Use these endpoints for transaction analysis — available via MCP tools, SDK me
 | `parseTransactions` | Parse signatures into human-readable format. Returns type, source program, transfers, fees, description. Use `showRaw: true` for instruction-level data. | 100/call | REST: `POST /v0/transactions/`, SDK: `helius.enhanced.getTransactions()`, MCP: `parseTransactions` |
 | `getTransactionsByAddress` | Get parsed transaction history for a wallet via the Enhanced Transactions API. | ~110 | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | `getTransactionsForAddress` | Get transaction history via RPC with advanced filters. Handles `getSignaturesForAddress` + enrichment internally. | ~10-110 | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| `getTransfersByAddress` | RPC method that returns **one row per token/SOL transfer** (not per transaction) with rich filters: mint, direction (in/out/any), counterparty (`with`), time/slot/amount ranges, SOL/WSOL display mode. | RPC | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
 
 Related endpoint (Wallet API, covered in `wallet-api.md`):
 
@@ -32,6 +33,8 @@ Related endpoint (Wallet API, covered in `wallet-api.md`):
 | Get a wallet's recent activity (human-readable) | `getTransactionsByAddress` | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | Get a lightweight list of signatures for a wallet | `getTransactionsForAddress` (signatures mode) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `signatures`) |
 | Filter by time range, slot range, or status | `getTransactionsForAddress` (with filters) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| List per-transfer rows (mint/amount/from/to) for an address | `getTransfersByAddress` | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
+| Aggregate transfers by mint or counterparty | `getTransfersByAddress` with `mint` / `with` filters | SDK / MCP |
 | See balance changes per transaction | `getWalletHistory` (Wallet API) | REST / MCP |
 | Debug raw instruction data | `parseTransactions` with `showRaw: true` | REST / SDK / MCP |
 
@@ -271,6 +274,54 @@ const history = await helius.getTransactionsForAddress(
 ```
 
 **Pagination**: use `paginationToken` from the previous response.
+
+### Method 3: `helius.getTransfersByAddress()` — per-transfer rows
+
+Returns **one row per token or native SOL transfer** (not per transaction). Each row carries `{ signature, slot, blockTime, type, fromUserAccount, toUserAccount, mint, amount, uiAmount, decimals, transactionIdx, instructionIdx, innerInstructionIdx, … }`. Use this when you want to aggregate by mint, counterparty, or direction — far easier than parsing transactions and re-extracting transfers.
+
+Signature: `helius.getTransfersByAddress([address, config?])` — note the positional tuple.
+
+```typescript
+// Recent transfers
+const recent = await helius.getTransfersByAddress([
+  'WalletAddress',
+  { limit: 25, sortOrder: 'desc' },
+]);
+
+// Inbound USDC only
+const inboundUsdc = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    direction: 'in',
+    limit: 50,
+  },
+]);
+
+// Transfers with a specific counterparty in the last 24h
+const oneDayAgo = Math.floor(Date.now() / 1000) - 86400;
+const withCounterparty = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    with: 'CounterpartyAddress',
+    filters: { blockTime: { gte: oneDayAgo } },
+    limit: 100,
+  },
+]);
+
+// Pagination
+const page1 = await helius.getTransfersByAddress(['WalletAddress', { limit: 50 }]);
+if (page1.paginationToken) {
+  const page2 = await helius.getTransfersByAddress([
+    'WalletAddress',
+    { limit: 50, paginationToken: page1.paginationToken },
+  ]);
+}
+```
+
+**Config options**: `with` (counterparty), `direction` (`in` | `out` | `any`), `mint`, `solMode` (`merged` | `separate`), `filters.amount` / `filters.blockTime` / `filters.slot` (each with `gt`/`gte`/`lt`/`lte`), `limit`, `sortOrder` (`asc` | `desc`), `paginationToken`, `commitment` (`finalized` | `confirmed`).
+
+**MCP**: `heliusTransaction.getTransfersByAddress` with the same fields flattened (e.g., `blockTimeGte`, `amountGte`).
 
 ### Parameter Name Mapping
 

--- a/helius-mcp/src/router/actions.ts
+++ b/helius-mcp/src/router/actions.ts
@@ -39,6 +39,7 @@ export const HELIUS_ASSET_ACTIONS = [
 export const HELIUS_TRANSACTION_ACTIONS = [
   'parseTransactions',
   'getTransactionHistory',
+  'getTransfersByAddress',
 ] as const;
 
 export const HELIUS_CHAIN_ACTIONS = [

--- a/helius-mcp/src/router/catalog.ts
+++ b/helius-mcp/src/router/catalog.ts
@@ -449,6 +449,12 @@ catalog.getTransactionHistory = makeEntry('getTransactionHistory', {
   continuationModel: 'transactionHistory',
 });
 
+catalog.getTransfersByAddress = makeEntry('getTransfersByAddress', {
+  responseFamily: 'history',
+  defaultDetail: 'standard',
+  continuationModel: 'transactionHistory',
+});
+
 for (const action of ACTION_NAMES) {
   if (!catalog[action]) {
     throw new Error(`Missing action catalog entry for ${action}`);

--- a/helius-mcp/src/router/dispatch.ts
+++ b/helius-mcp/src/router/dispatch.ts
@@ -97,6 +97,17 @@ function detectContinuation(action: ActionName, params: Record<string, unknown>,
     }
   }
 
+  if (action === 'getTransfersByAddress') {
+    // Fragile: depends on handler markdown format "**Next Page Token:** `<token>`" (mirrors getTransactionHistory)
+    const tokenMatch = text.match(/\*\*Next Page Token:\*\*\s+`([^`]+)`/);
+    if (tokenMatch) {
+      return {
+        model: 'transactionHistory',
+        next: { kind: 'rawApi', paginationToken: tokenMatch[1] },
+      };
+    }
+  }
+
   if (typeof params.page === 'number') {
     return { model: 'page', nextPage: params.page + 1 };
   }

--- a/helius-mcp/src/router/instructions.ts
+++ b/helius-mcp/src/router/instructions.ts
@@ -16,7 +16,7 @@ Routing:
 Rules:
 - Use the chosen routed tool plus the Helius action name in \`action\`.
 - Wallet holdings use \`heliusWallet.getTokenBalances\`; raw token accounts use \`heliusChain.getTokenAccounts\`.
-- Parsed transaction details use \`heliusTransaction.parseTransactions\`; wallet activity listing uses \`heliusTransaction.getTransactionHistory\`.
+- Parsed transaction details use \`heliusTransaction.parseTransactions\`; wallet activity listing uses \`heliusTransaction.getTransactionHistory\`; per-transfer rows (token + SOL with mint/direction/counterparty filters) use \`heliusTransaction.getTransfersByAddress\`.
 - Streaming or webhook setup guides live under \`heliusKnowledge\`; actual webhook/subscription config lives under \`heliusStreaming\`.
 - Pricing and plan selection start with \`heliusAccount.getHeliusPlanInfo\`; per-method credit costs or rate limits use \`heliusKnowledge.getRateLimitInfo\` or \`heliusKnowledge.getHeliusCreditsInfo\`.
 - Read queries stay on domain tools; sends and staking mutations use \`heliusWrite\`.

--- a/helius-mcp/src/router/required-params.ts
+++ b/helius-mcp/src/router/required-params.ts
@@ -21,6 +21,7 @@ export const ACTION_REQUIRED_PARAMS: Partial<Record<ActionName, string[]>> = {
   // Transaction
   parseTransactions: ['signatures'],
   getTransactionHistory: ['address'],
+  getTransfersByAddress: ['address'],
 
   // Asset
   getAssetsByOwner: ['address'],

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { getHeliusClient, hasApiKey } from '../utils/helius.js';
 import { formatSol, formatAddress, formatTimestamp, LAMPORTS_PER_SOL } from '../utils/formatters.js';
 import { noApiKeyResponse } from './shared.js';
-import { mcpText, getErrorMessage, validateEnum, handleToolError, http400Error } from '../utils/errors.js';
+import { mcpText, mcpError, getErrorMessage, validateEnum, handleToolError, http400Error } from '../utils/errors.js';
 import bs58 from 'bs58';
 
 // ─── Shared Types ───
@@ -862,27 +862,38 @@ export function registerTransactionTools(server: McpServer) {
         slot?: AmountFilter;
       };
 
-      const parseAmountBound = (raw: string | undefined): number | undefined => {
+      // SDK's TransferComparisonFilter types amount as `number`, so values outside JS safe-integer
+      // range (>2^53) can't be passed without precision loss. u64 raw amounts on high-decimal tokens
+      // can exceed this. Surface a clear error rather than silently dropping the filter.
+      const parseAmountBound = (raw: string | undefined, label: string): number | undefined | { error: string } => {
         if (raw === undefined) return undefined;
         const n = Number(raw);
         if (!Number.isFinite(n)) {
-          return undefined;
+          return { error: `${label} must be a numeric raw u64 amount (got "${raw}")` };
         }
-        if (!Number.isSafeInteger(n)) {
-          // Outside JS safe integer range — bound dropped silently rather than risk precision loss.
-          // SDK filter type is number, not bigint; document in the description.
-          return undefined;
+        if (!Number.isSafeInteger(n) || n < 0) {
+          return {
+            error: `${label}="${raw}" is outside JS safe integer range (>2^53) or negative. The SDK's amount filter is typed as number — pass a smaller raw amount or filter client-side. (u64 raw amounts can exceed this; high-decimal SPL tokens are the common case.)`,
+          };
         }
         return n;
       };
 
       const filters: Filters = {};
-      const aGte = parseAmountBound(amountGte);
-      const aLte = parseAmountBound(amountLte);
+      const aGte = parseAmountBound(amountGte, 'amountGte');
+      const aLte = parseAmountBound(amountLte, 'amountLte');
+      const amountErrMeta = {
+        type: 'VALIDATION' as const,
+        code: 'INVALID_AMOUNT_BOUND',
+        retryable: false,
+        recovery: 'Pass a raw u64 amount within JS safe integer range (<= 2^53), or filter client-side after fetching.',
+      };
+      if (aGte && typeof aGte === 'object') return mcpError(aGte.error, amountErrMeta);
+      if (aLte && typeof aLte === 'object') return mcpError(aLte.error, amountErrMeta);
       if (aGte !== undefined || aLte !== undefined) {
         filters.amount = {};
-        if (aGte !== undefined) filters.amount.gte = aGte;
-        if (aLte !== undefined) filters.amount.lte = aLte;
+        if (typeof aGte === 'number') filters.amount.gte = aGte;
+        if (typeof aLte === 'number') filters.amount.lte = aLte;
       }
       if (blockTimeGte !== undefined || blockTimeLte !== undefined) {
         filters.blockTime = {};
@@ -953,7 +964,9 @@ export function registerTransactionTools(server: McpServer) {
       };
 
       const WSOL = 'So11111111111111111111111111111111111111112';
-      const isNativeSol = (t: TransferRow) => t.mint === WSOL && t.fromTokenAccount === undefined && t.toTokenAccount === undefined;
+      // SDK contract: native SOL transfers omit fromTokenAccount/toTokenAccount. JSON deserialization
+      // can surface either `undefined` (key absent) or `null` (key present with null value) — accept both.
+      const isNativeSol = (t: TransferRow) => t.mint === WSOL && t.fromTokenAccount == null && t.toTokenAccount == null;
 
       const formatAmount = (t: TransferRow): string => {
         if (isNativeSol(t)) {

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -942,8 +942,7 @@ export function registerTransactionTools(server: McpServer) {
 
       let result: TransfersResult;
       try {
-        // SDK method shipped in helius-sdk PR #313; cast until @types catch up in npm release.
-        result = await (helius as any).getTransfersByAddress([address, config]) as TransfersResult;
+        result = await (helius as any).getTransfersByAddress(address, config) as TransfersResult;
       } catch (e) {
         return handleToolError(e, 'Error fetching transfers');
       }

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -810,7 +810,7 @@ export function registerTransactionTools(server: McpServer) {
       direction: z.string().optional().default('any').describe('"in" | "out" | "any" — relative to the queried address'),
       mint: z.string().optional().describe('Filter by token mint. Use the WSOL mint to filter native SOL when solMode="merged".'),
       solMode: z.string().optional().describe('"merged" treats SOL and WSOL as one asset; "separate" keeps them distinct'),
-      limit: z.number().optional().default(25).describe('Max transfers per page (1-100)'),
+      limit: z.number().int().min(1).max(100).optional().default(25).describe('Max transfers per page (1-100)'),
       sortOrder: z.string().optional().default('desc').describe('"desc" = newest first (default), "asc" = oldest first'),
       paginationToken: z.string().optional().describe('Cursor from a previous response — pass to fetch the next page'),
       commitment: z.string().optional().describe('"finalized" | "confirmed"'),

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -986,7 +986,7 @@ export function registerTransactionTools(server: McpServer) {
         const sym = isNativeSol(t) ? 'SOL' : symbolFor(t.mint);
         const from = t.fromUserAccount ? formatAddress(t.fromUserAccount) : (t.type === 'mint' ? 'mint' : '?');
         const to = t.toUserAccount ? formatAddress(t.toUserAccount) : (t.type === 'burn' ? 'burn' : '?');
-        const time = t.blockTime ? formatTimestamp(t.blockTime) : 'N/A';
+        const time = t.blockTime ? formatTimestamp(Number(t.blockTime)) : 'N/A';
         const dirArrow = '→';
         lines.push(`${t.type.toUpperCase()} ${formatAmount(t)} ${sym} (${t.mint})`);
         lines.push(`   ${from} ${dirArrow} ${to}`);

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -799,4 +799,197 @@ export function registerTransactionTools(server: McpServer) {
       }
     }
   );
+
+  // Get Transfers By Address — parsed token + native SOL transfers (one row per transfer)
+  server.tool(
+    'getTransfersByAddress',
+    'BEST FOR: parsed token + native SOL transfers for an address — one row per transfer (not per transaction). Filters: mint, direction (in/out/any), counterparty (with), time/slot/amount ranges, solMode. Use getTransactionHistory when you need whole-transaction context. Paginated via paginationToken.',
+    {
+      address: z.string().describe('Solana address (base58 encoded)'),
+      with: z.string().optional().describe('Filter by counterparty address — returns only transfers to/from this address'),
+      direction: z.string().optional().default('any').describe('"in" | "out" | "any" — relative to the queried address'),
+      mint: z.string().optional().describe('Filter by token mint. Use the WSOL mint to filter native SOL when solMode="merged".'),
+      solMode: z.string().optional().describe('"merged" treats SOL and WSOL as one asset; "separate" keeps them distinct'),
+      limit: z.number().optional().default(25).describe('Max transfers per page (1-100)'),
+      sortOrder: z.string().optional().default('desc').describe('"desc" = newest first (default), "asc" = oldest first'),
+      paginationToken: z.string().optional().describe('Cursor from a previous response — pass to fetch the next page'),
+      commitment: z.string().optional().describe('"finalized" | "confirmed"'),
+      amountGte: z.string().optional().describe('Raw u64 amount (as string) lower bound — not UI amount'),
+      amountLte: z.string().optional().describe('Raw u64 amount (as string) upper bound — not UI amount'),
+      blockTimeGte: z.number().optional().describe('Filter: block time >= this Unix timestamp (seconds)'),
+      blockTimeLte: z.number().optional().describe('Filter: block time <= this Unix timestamp (seconds)'),
+      slotGte: z.number().optional().describe('Filter: slot >= this value'),
+      slotLte: z.number().optional().describe('Filter: slot <= this value'),
+    },
+    async ({
+      address,
+      with: counterparty,
+      direction,
+      mint,
+      solMode,
+      limit,
+      sortOrder,
+      paginationToken,
+      commitment,
+      amountGte,
+      amountLte,
+      blockTimeGte,
+      blockTimeLte,
+      slotGte,
+      slotLte,
+    }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+      const helius = getHeliusClient();
+
+      let err;
+      err = validateEnum(direction, ['in', 'out', 'any'], 'Transfers By Address Error', 'direction');
+      if (err) return err;
+      err = validateEnum(sortOrder, ['asc', 'desc'], 'Transfers By Address Error', 'sortOrder');
+      if (err) return err;
+      if (solMode) {
+        err = validateEnum(solMode, ['merged', 'separate'], 'Transfers By Address Error', 'solMode');
+        if (err) return err;
+      }
+      if (commitment) {
+        err = validateEnum(commitment, ['finalized', 'confirmed'], 'Transfers By Address Error', 'commitment');
+        if (err) return err;
+      }
+
+      type AmountFilter = { gt?: number; gte?: number; lt?: number; lte?: number };
+      type Filters = {
+        amount?: AmountFilter;
+        blockTime?: AmountFilter;
+        slot?: AmountFilter;
+      };
+
+      const parseAmountBound = (raw: string | undefined): number | undefined => {
+        if (raw === undefined) return undefined;
+        const n = Number(raw);
+        if (!Number.isFinite(n)) {
+          return undefined;
+        }
+        if (!Number.isSafeInteger(n)) {
+          // Outside JS safe integer range — bound dropped silently rather than risk precision loss.
+          // SDK filter type is number, not bigint; document in the description.
+          return undefined;
+        }
+        return n;
+      };
+
+      const filters: Filters = {};
+      const aGte = parseAmountBound(amountGte);
+      const aLte = parseAmountBound(amountLte);
+      if (aGte !== undefined || aLte !== undefined) {
+        filters.amount = {};
+        if (aGte !== undefined) filters.amount.gte = aGte;
+        if (aLte !== undefined) filters.amount.lte = aLte;
+      }
+      if (blockTimeGte !== undefined || blockTimeLte !== undefined) {
+        filters.blockTime = {};
+        if (blockTimeGte !== undefined) filters.blockTime.gte = blockTimeGte;
+        if (blockTimeLte !== undefined) filters.blockTime.lte = blockTimeLte;
+      }
+      if (slotGte !== undefined || slotLte !== undefined) {
+        filters.slot = {};
+        if (slotGte !== undefined) filters.slot.gte = slotGte;
+        if (slotLte !== undefined) filters.slot.lte = slotLte;
+      }
+
+      const config: Record<string, unknown> = {
+        direction,
+        limit: Math.min(Math.max(limit, 1), 100),
+        sortOrder,
+      };
+      if (counterparty) config.with = counterparty;
+      if (mint) config.mint = mint;
+      if (solMode) config.solMode = solMode;
+      if (paginationToken) config.paginationToken = paginationToken;
+      if (commitment) config.commitment = commitment;
+      if (Object.keys(filters).length > 0) config.filters = filters;
+
+      type TransferRow = {
+        signature: string;
+        slot: number;
+        blockTime: number;
+        type: string;
+        fromUserAccount: string | null;
+        toUserAccount: string | null;
+        fromTokenAccount?: string;
+        toTokenAccount?: string;
+        mint: string;
+        amount: string;
+        decimals: number;
+        uiAmount: string;
+        feeAmount?: string;
+        feeUiAmount?: string;
+        confirmationStatus: string;
+        transactionIdx: number;
+        instructionIdx: number;
+        innerInstructionIdx: number;
+      };
+      type TransfersResult = { data: ReadonlyArray<TransferRow>; paginationToken: string | null };
+
+      let result: TransfersResult;
+      try {
+        // SDK method shipped in helius-sdk PR #313; cast until @types catch up in npm release.
+        result = await (helius as any).getTransfersByAddress([address, config]) as TransfersResult;
+      } catch (e) {
+        return handleToolError(e, 'Error fetching transfers');
+      }
+
+      if (!result || !result.data || result.data.length === 0) {
+        return mcpText(`**Transfers for ${formatAddress(address)}**\n\nNo transfers found.`);
+      }
+
+      const mints = new Set<string>();
+      for (const t of result.data) {
+        if (t.mint) mints.add(t.mint);
+      }
+      const tokenMetadata = await fetchTokenMetadata(helius, mints);
+
+      const symbolFor = (m: string) => {
+        const asset = tokenMetadata.get(m);
+        return asset?.token_info?.symbol || asset?.content?.metadata?.symbol || asset?.content?.metadata?.name || formatAddress(m);
+      };
+
+      const WSOL = 'So11111111111111111111111111111111111111112';
+      const isNativeSol = (t: TransferRow) => t.mint === WSOL && t.fromTokenAccount === undefined && t.toTokenAccount === undefined;
+
+      const formatAmount = (t: TransferRow): string => {
+        if (isNativeSol(t)) {
+          // amount is raw lamports as string
+          const n = Number(t.amount);
+          if (Number.isFinite(n)) return formatSol(n);
+        }
+        // Use uiAmount (string, precision-preserving) directly and trim trailing zeros for readability
+        const ui = t.uiAmount ?? '';
+        if (!ui.includes('.')) return ui;
+        return ui.replace(/0+$/, '').replace(/\.$/, '');
+      };
+
+      const orderLabel = sortOrder === 'asc' ? 'oldest first' : 'newest first';
+      const lines = [`**Transfers for ${formatAddress(address)}** (${result.data.length} transfers, ${orderLabel})`, ''];
+
+      for (const t of result.data) {
+        const sym = isNativeSol(t) ? 'SOL' : symbolFor(t.mint);
+        const from = t.fromUserAccount ? formatAddress(t.fromUserAccount) : (t.type === 'mint' ? 'mint' : '?');
+        const to = t.toUserAccount ? formatAddress(t.toUserAccount) : (t.type === 'burn' ? 'burn' : '?');
+        const time = t.blockTime ? formatTimestamp(t.blockTime) : 'N/A';
+        const dirArrow = '→';
+        lines.push(`${t.type.toUpperCase()} ${formatAmount(t)} ${sym} (${t.mint})`);
+        lines.push(`   ${from} ${dirArrow} ${to}`);
+        lines.push(`   Sig: \`${t.signature}\` | Slot: ${t.slot.toLocaleString()} | ${time}`);
+        if (t.feeAmount && t.feeAmount !== '0') {
+          lines.push(`   Fee: ${t.feeUiAmount ?? t.feeAmount} ${sym}`);
+        }
+        lines.push('');
+      }
+
+      if (result.paginationToken) {
+        lines.push(`**Next Page Token:** \`${result.paginationToken}\``);
+      }
+
+      return mcpText(truncateResponse(lines.join('\n')));
+    }
+  );
 }

--- a/helius-mcp/system-prompts/helius/claude.system.md
+++ b/helius-mcp/system-prompts/helius/claude.system.md
@@ -101,8 +101,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Reference**: See enhanced-transactions.md
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -151,6 +151,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -194,6 +195,7 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.
 
 
 === END SKILL: helius ===

--- a/helius-mcp/system-prompts/helius/full.md
+++ b/helius-mcp/system-prompts/helius/full.md
@@ -91,8 +91,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Reference**: See enhanced-transactions.md (inlined below)
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -141,6 +141,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -184,6 +185,7 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.
 
 
 ---
@@ -505,6 +507,7 @@ Use these endpoints for transaction analysis — available via MCP tools, SDK me
 | `parseTransactions` | Parse signatures into human-readable format. Returns type, source program, transfers, fees, description. Use `showRaw: true` for instruction-level data. | 100/call | REST: `POST /v0/transactions/`, SDK: `helius.enhanced.getTransactions()`, MCP: `parseTransactions` |
 | `getTransactionsByAddress` | Get parsed transaction history for a wallet via the Enhanced Transactions API. | ~110 | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | `getTransactionsForAddress` | Get transaction history via RPC with advanced filters. Handles `getSignaturesForAddress` + enrichment internally. | ~10-110 | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| `getTransfersByAddress` | RPC method that returns **one row per token/SOL transfer** (not per transaction) with rich filters: mint, direction (in/out/any), counterparty (`with`), time/slot/amount ranges, SOL/WSOL display mode. | RPC | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
 
 Related endpoint (Wallet API, covered in `wallet-api.md`):
 
@@ -520,6 +523,8 @@ Related endpoint (Wallet API, covered in `wallet-api.md`):
 | Get a wallet's recent activity (human-readable) | `getTransactionsByAddress` | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | Get a lightweight list of signatures for a wallet | `getTransactionsForAddress` (signatures mode) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `signatures`) |
 | Filter by time range, slot range, or status | `getTransactionsForAddress` (with filters) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| List per-transfer rows (mint/amount/from/to) for an address | `getTransfersByAddress` | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
+| Aggregate transfers by mint or counterparty | `getTransfersByAddress` with `mint` / `with` filters | SDK / MCP |
 | See balance changes per transaction | `getWalletHistory` (Wallet API) | REST / MCP |
 | Debug raw instruction data | `parseTransactions` with `showRaw: true` | REST / SDK / MCP |
 
@@ -759,6 +764,54 @@ const history = await helius.getTransactionsForAddress(
 ```
 
 **Pagination**: use `paginationToken` from the previous response.
+
+### Method 3: `helius.getTransfersByAddress()` — per-transfer rows
+
+Returns **one row per token or native SOL transfer** (not per transaction). Each row carries `{ signature, slot, blockTime, type, fromUserAccount, toUserAccount, mint, amount, uiAmount, decimals, transactionIdx, instructionIdx, innerInstructionIdx, … }`. Use this when you want to aggregate by mint, counterparty, or direction — far easier than parsing transactions and re-extracting transfers.
+
+Signature: `helius.getTransfersByAddress([address, config?])` — note the positional tuple.
+
+```typescript
+// Recent transfers
+const recent = await helius.getTransfersByAddress([
+  'WalletAddress',
+  { limit: 25, sortOrder: 'desc' },
+]);
+
+// Inbound USDC only
+const inboundUsdc = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    direction: 'in',
+    limit: 50,
+  },
+]);
+
+// Transfers with a specific counterparty in the last 24h
+const oneDayAgo = Math.floor(Date.now() / 1000) - 86400;
+const withCounterparty = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    with: 'CounterpartyAddress',
+    filters: { blockTime: { gte: oneDayAgo } },
+    limit: 100,
+  },
+]);
+
+// Pagination
+const page1 = await helius.getTransfersByAddress(['WalletAddress', { limit: 50 }]);
+if (page1.paginationToken) {
+  const page2 = await helius.getTransfersByAddress([
+    'WalletAddress',
+    { limit: 50, paginationToken: page1.paginationToken },
+  ]);
+}
+```
+
+**Config options**: `with` (counterparty), `direction` (`in` | `out` | `any`), `mint`, `solMode` (`merged` | `separate`), `filters.amount` / `filters.blockTime` / `filters.slot` (each with `gt`/`gte`/`lt`/`lte`), `limit`, `sortOrder` (`asc` | `desc`), `paginationToken`, `commitment` (`finalized` | `confirmed`).
+
+**MCP**: `heliusTransaction.getTransfersByAddress` with the same fields flattened (e.g., `blockTimeGte`, `amountGte`).
 
 ### Parameter Name Mapping
 

--- a/helius-mcp/system-prompts/helius/openai.developer.md
+++ b/helius-mcp/system-prompts/helius/openai.developer.md
@@ -101,8 +101,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Reference**: See enhanced-transactions.md
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -151,6 +151,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -194,6 +195,7 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.
 
 
 === END SKILL: helius ===

--- a/helius-mcp/tests/router-action-handlers.test.ts
+++ b/helius-mcp/tests/router-action-handlers.test.ts
@@ -93,14 +93,14 @@ describe('action handler bridge', () => {
     );
 
     expect(result.isError).not.toBe(true);
-    expect(getTransfersByAddress).toHaveBeenCalledWith([
+    expect(getTransfersByAddress).toHaveBeenCalledWith(
       'BenchWallet11111111111111111111111111111111',
       {
         direction: 'any',
         limit: 5,
         sortOrder: 'desc',
       },
-    ]);
+    );
     expect(result.content?.[0]?.text).toContain('No transfers found.');
   });
 
@@ -143,7 +143,7 @@ describe('action handler bridge', () => {
     );
 
     expect(result.isError).not.toBe(true);
-    expect(getTransfersByAddress).toHaveBeenCalledWith([
+    expect(getTransfersByAddress).toHaveBeenCalledWith(
       'BenchWallet11111111111111111111111111111111',
       {
         direction: 'in',
@@ -153,7 +153,7 @@ describe('action handler bridge', () => {
         paginationToken: 'PREV',
         filters: { blockTime: { gte: 1700000000 } },
       },
-    ]);
+    );
     expect(result.content?.[0]?.text).toContain('**Next Page Token:** `NEXT_TOKEN`');
   });
 

--- a/helius-mcp/tests/router-action-handlers.test.ts
+++ b/helius-mcp/tests/router-action-handlers.test.ts
@@ -157,6 +157,22 @@ describe('action handler bridge', () => {
     expect(result.content?.[0]?.text).toContain('**Next Page Token:** `NEXT_TOKEN`');
   });
 
+  it('rejects amount bounds that exceed JS safe-integer range', async () => {
+    const result = await callActionHandler(
+      'getTransfersByAddress',
+      {
+        address: 'BenchWallet11111111111111111111111111111111',
+        amountGte: '9999999999999999999', // > 2^53
+      },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('amountGte');
+    expect(result.content?.[0]?.text).toContain('safe integer range');
+    expect(getTransfersByAddress).not.toHaveBeenCalled();
+  });
+
   it('returns a clear validation error when getTransfersByAddress is missing address', async () => {
     await expect(
       callActionHandler(

--- a/helius-mcp/tests/router-action-handlers.test.ts
+++ b/helius-mcp/tests/router-action-handlers.test.ts
@@ -4,12 +4,21 @@ import { callActionHandler } from '../src/router/action-handlers.js';
 const getTransactionsForAddress = vi.fn(async () => ({
   data: [],
 }));
+const getTransfersByAddress = vi.fn(async () => ({
+  data: [],
+  paginationToken: null,
+}));
+const getAssetBatch = vi.fn(async () => []);
+const getAsset = vi.fn(async () => null);
 
 vi.mock('../src/utils/helius.js', () => ({
   hasApiKey: vi.fn(() => true),
   getApiKey: vi.fn(() => 'test-key'),
   getHeliusClient: vi.fn(() => ({
     getTransactionsForAddress,
+    getTransfersByAddress,
+    getAssetBatch,
+    getAsset,
   })),
   getEnhancedWebSocketUrl: vi.fn(() => 'wss://atlas-mainnet.helius-rpc.com/?api-key=test'),
   getLaserstreamUrl: vi.fn(() => 'https://laserstream-mainnet-ewr.helius-rpc.com'),
@@ -27,6 +36,9 @@ vi.mock('../src/utils/helius.js', () => ({
 describe('action handler bridge', () => {
   beforeEach(() => {
     getTransactionsForAddress.mockClear();
+    getTransfersByAddress.mockClear();
+    getAssetBatch.mockClear();
+    getAsset.mockClear();
   });
 
   it('applies action-schema defaults before invoking getTransactionHistory', async () => {
@@ -68,5 +80,91 @@ describe('action handler bridge', () => {
       ),
     ).rejects.toThrow('Invalid parameters for getTransactionHistory: address Required');
     expect(getTransactionsForAddress).not.toHaveBeenCalled();
+  });
+
+  it('applies action-schema defaults before invoking getTransfersByAddress', async () => {
+    const result = await callActionHandler(
+      'getTransfersByAddress',
+      {
+        address: 'BenchWallet11111111111111111111111111111111',
+        limit: 5,
+      },
+      {},
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(getTransfersByAddress).toHaveBeenCalledWith([
+      'BenchWallet11111111111111111111111111111111',
+      {
+        direction: 'any',
+        limit: 5,
+        sortOrder: 'desc',
+      },
+    ]);
+    expect(result.content?.[0]?.text).toContain('No transfers found.');
+  });
+
+  it('forwards filters and pagination to getTransfersByAddress', async () => {
+    getTransfersByAddress.mockResolvedValueOnce({
+      data: [
+        {
+          signature: '5J8' + 'a'.repeat(85),
+          slot: 123456,
+          blockTime: 1700000000,
+          type: 'transfer',
+          fromUserAccount: 'AAA11111111111111111111111111111111111111111',
+          toUserAccount: 'BBB22222222222222222222222222222222222222222',
+          fromTokenAccount: 'TA1',
+          toTokenAccount: 'TA2',
+          mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          amount: '1000000',
+          decimals: 6,
+          uiAmount: '1.000000',
+          confirmationStatus: 'finalized',
+          transactionIdx: 0,
+          instructionIdx: 0,
+          innerInstructionIdx: 0,
+        },
+      ],
+      paginationToken: 'NEXT_TOKEN',
+    } as any);
+
+    const result = await callActionHandler(
+      'getTransfersByAddress',
+      {
+        address: 'BenchWallet11111111111111111111111111111111',
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        direction: 'in',
+        limit: 10,
+        blockTimeGte: 1700000000,
+        paginationToken: 'PREV',
+      },
+      {},
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(getTransfersByAddress).toHaveBeenCalledWith([
+      'BenchWallet11111111111111111111111111111111',
+      {
+        direction: 'in',
+        limit: 10,
+        sortOrder: 'desc',
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        paginationToken: 'PREV',
+        filters: { blockTime: { gte: 1700000000 } },
+      },
+    ]);
+    expect(result.content?.[0]?.text).toContain('**Next Page Token:** `NEXT_TOKEN`');
+  });
+
+  it('returns a clear validation error when getTransfersByAddress is missing address', async () => {
+    await expect(
+      callActionHandler(
+        'getTransfersByAddress',
+        { limit: 5 },
+        {},
+      ),
+    ).rejects.toThrow('Invalid parameters for getTransfersByAddress: address Required');
+    expect(getTransfersByAddress).not.toHaveBeenCalled();
   });
 });

--- a/helius-plugin/skills/build/SKILL.md
+++ b/helius-plugin/skills/build/SKILL.md
@@ -85,8 +85,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Read**: `references/enhanced-transactions.md`
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -135,6 +135,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -178,3 +179,4 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.

--- a/helius-plugin/skills/build/references/enhanced-transactions.md
+++ b/helius-plugin/skills/build/references/enhanced-transactions.md
@@ -17,6 +17,7 @@ Use these endpoints for transaction analysis — available via MCP tools, SDK me
 | `parseTransactions` | Parse signatures into human-readable format. Returns type, source program, transfers, fees, description. Use `showRaw: true` for instruction-level data. | 100/call | REST: `POST /v0/transactions/`, SDK: `helius.enhanced.getTransactions()`, MCP: `parseTransactions` |
 | `getTransactionsByAddress` | Get parsed transaction history for a wallet via the Enhanced Transactions API. | ~110 | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | `getTransactionsForAddress` | Get transaction history via RPC with advanced filters. Handles `getSignaturesForAddress` + enrichment internally. | ~10-110 | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| `getTransfersByAddress` | RPC method that returns **one row per token/SOL transfer** (not per transaction) with rich filters: mint, direction (in/out/any), counterparty (`with`), time/slot/amount ranges, SOL/WSOL display mode. | RPC | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
 
 Related endpoint (Wallet API, covered in `wallet-api.md`):
 
@@ -32,6 +33,8 @@ Related endpoint (Wallet API, covered in `wallet-api.md`):
 | Get a wallet's recent activity (human-readable) | `getTransactionsByAddress` | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | Get a lightweight list of signatures for a wallet | `getTransactionsForAddress` (signatures mode) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `signatures`) |
 | Filter by time range, slot range, or status | `getTransactionsForAddress` (with filters) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| List per-transfer rows (mint/amount/from/to) for an address | `getTransfersByAddress` | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
+| Aggregate transfers by mint or counterparty | `getTransfersByAddress` with `mint` / `with` filters | SDK / MCP |
 | See balance changes per transaction | `getWalletHistory` (Wallet API) | REST / MCP |
 | Debug raw instruction data | `parseTransactions` with `showRaw: true` | REST / SDK / MCP |
 
@@ -271,6 +274,54 @@ const history = await helius.getTransactionsForAddress(
 ```
 
 **Pagination**: use `paginationToken` from the previous response.
+
+### Method 3: `helius.getTransfersByAddress()` — per-transfer rows
+
+Returns **one row per token or native SOL transfer** (not per transaction). Each row carries `{ signature, slot, blockTime, type, fromUserAccount, toUserAccount, mint, amount, uiAmount, decimals, transactionIdx, instructionIdx, innerInstructionIdx, … }`. Use this when you want to aggregate by mint, counterparty, or direction — far easier than parsing transactions and re-extracting transfers.
+
+Signature: `helius.getTransfersByAddress([address, config?])` — note the positional tuple.
+
+```typescript
+// Recent transfers
+const recent = await helius.getTransfersByAddress([
+  'WalletAddress',
+  { limit: 25, sortOrder: 'desc' },
+]);
+
+// Inbound USDC only
+const inboundUsdc = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    direction: 'in',
+    limit: 50,
+  },
+]);
+
+// Transfers with a specific counterparty in the last 24h
+const oneDayAgo = Math.floor(Date.now() / 1000) - 86400;
+const withCounterparty = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    with: 'CounterpartyAddress',
+    filters: { blockTime: { gte: oneDayAgo } },
+    limit: 100,
+  },
+]);
+
+// Pagination
+const page1 = await helius.getTransfersByAddress(['WalletAddress', { limit: 50 }]);
+if (page1.paginationToken) {
+  const page2 = await helius.getTransfersByAddress([
+    'WalletAddress',
+    { limit: 50, paginationToken: page1.paginationToken },
+  ]);
+}
+```
+
+**Config options**: `with` (counterparty), `direction` (`in` | `out` | `any`), `mint`, `solMode` (`merged` | `separate`), `filters.amount` / `filters.blockTime` / `filters.slot` (each with `gt`/`gte`/`lt`/`lte`), `limit`, `sortOrder` (`asc` | `desc`), `paginationToken`, `commitment` (`finalized` | `confirmed`).
+
+**MCP**: `heliusTransaction.getTransfersByAddress` with the same fields flattened (e.g., `blockTimeGte`, `amountGte`).
 
 ### Parameter Name Mapping
 

--- a/helius-skills/helius/SKILL.md
+++ b/helius-skills/helius/SKILL.md
@@ -96,8 +96,8 @@ Enhanced WebSockets (Developer+) for most needs; Laserstream gRPC (Business+ mai
 
 ### Transaction History & Parsing
 **Read**: `references/enhanced-transactions.md`
-**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`)
-**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`
+**APIs**: Enhanced Transactions API (`getTransactionsByAddress`, `parseTransactions`), RPC (`getTransactionsForAddress`, `getTransfersByAddress`)
+**MCP tools** (if available): `parseTransactions`, `getTransactionHistory`, `getTransfersByAddress`
 **When**: human-readable tx data, transaction explorers, swap/transfer/NFT sale analysis, history filtering by type/time/slot
 
 ### Getting Started / Onboarding
@@ -146,6 +146,7 @@ Follow these rules in ALL implementations:
 - Use Helius APIs (via MCP, SDK, or REST) for live blockchain data — never hardcode or mock chain state
 - Prefer `parseTransactions` over raw RPC for transaction history — it returns human-readable data
 - For wallet transaction history, use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) or `getTransactionHistory` (MCP) — never manually chain `getSignaturesForAddress` + `getTransaction`. The combined endpoints handle signature fetching, enrichment, and pagination in a single call. Note: these methods have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
+- For a per-transfer feed (one row per token/SOL transfer with mint/direction/counterparty/time filters rather than one row per transaction), use `getTransfersByAddress` (SDK: `helius.getTransfersByAddress([address, config])`, MCP: `heliusTransaction.getTransfersByAddress`).
 - Use `getAssetsByOwner` with `showFungible: true` to get both NFTs and fungible tokens in one call
 - Use `searchAssets` for multi-criteria queries instead of client-side filtering
 - Use batch endpoints (`getAsset` with multiple IDs, `getAssetProofBatch`) to minimize API calls
@@ -189,3 +190,4 @@ Follow these rules in ALL implementations:
 - **Two SDK methods for transaction history** — `helius.enhanced.getTransactionsByAddress()` and `helius.getTransactionsForAddress()` have completely different parameter shapes and pagination mechanisms. Do not mix them. See `references/enhanced-transactions.md` for details.
 - **Don't roll your own transaction history pipeline** — Manually calling `getSignaturesForAddress` then `getTransaction` for each signature is slower, more expensive, and misses Enhanced Transaction parsing. Use `getTransactionsByAddress` (REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`) or `getTransactionsForAddress` ([REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`) for application code, or `getTransactionHistory` (MCP) for agent queries. These combine fetching and parsing in one call. Note: `getTransactionsByAddress` and `getTransactionsForAddress` have **different parameter shapes and pagination** — see `references/enhanced-transactions.md`.
 - **Don't confuse `getTransactionHistory` with `getWalletHistory`** — `getTransactionHistory` (Enhanced Transactions API) returns parsed transaction data (type, transfers, events). `getWalletHistory` (Wallet API) returns balance changes per transaction. They have different response formats and use cases. See `references/enhanced-transactions.md` vs `references/wallet-api.md`.
+- **Don't confuse `getTransactionHistory` with `getTransfersByAddress`** — `getTransactionHistory` returns one row per transaction (full parsed tx). `getTransfersByAddress` returns one row per transfer (mint, amount, from/to, direction). Pick the granularity that matches what you actually need — per-transfer rows are easier to aggregate by mint/counterparty; per-transaction rows are easier for narrative descriptions.

--- a/helius-skills/helius/references/enhanced-transactions.md
+++ b/helius-skills/helius/references/enhanced-transactions.md
@@ -17,6 +17,7 @@ Use these endpoints for transaction analysis — available via MCP tools, SDK me
 | `parseTransactions` | Parse signatures into human-readable format. Returns type, source program, transfers, fees, description. Use `showRaw: true` for instruction-level data. | 100/call | REST: `POST /v0/transactions/`, SDK: `helius.enhanced.getTransactions()`, MCP: `parseTransactions` |
 | `getTransactionsByAddress` | Get parsed transaction history for a wallet via the Enhanced Transactions API. | ~110 | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | `getTransactionsForAddress` | Get transaction history via RPC with advanced filters. Handles `getSignaturesForAddress` + enrichment internally. | ~10-110 | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| `getTransfersByAddress` | RPC method that returns **one row per token/SOL transfer** (not per transaction) with rich filters: mint, direction (in/out/any), counterparty (`with`), time/slot/amount ranges, SOL/WSOL display mode. | RPC | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
 
 Related endpoint (Wallet API, covered in `wallet-api.md`):
 
@@ -32,6 +33,8 @@ Related endpoint (Wallet API, covered in `wallet-api.md`):
 | Get a wallet's recent activity (human-readable) | `getTransactionsByAddress` | REST: `GET /v0/addresses/{addr}/transactions`, SDK: `helius.enhanced.getTransactionsByAddress()`, MCP: `getTransactionHistory` (mode: `parsed`) |
 | Get a lightweight list of signatures for a wallet | `getTransactionsForAddress` (signatures mode) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `signatures`) |
 | Filter by time range, slot range, or status | `getTransactionsForAddress` (with filters) | [REST RPC](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress), SDK: `helius.getTransactionsForAddress()`, MCP: `getTransactionHistory` (mode: `raw`) |
+| List per-transfer rows (mint/amount/from/to) for an address | `getTransfersByAddress` | SDK: `helius.getTransfersByAddress([address, config])`, MCP: `getTransfersByAddress` |
+| Aggregate transfers by mint or counterparty | `getTransfersByAddress` with `mint` / `with` filters | SDK / MCP |
 | See balance changes per transaction | `getWalletHistory` (Wallet API) | REST / MCP |
 | Debug raw instruction data | `parseTransactions` with `showRaw: true` | REST / SDK / MCP |
 
@@ -271,6 +274,54 @@ const history = await helius.getTransactionsForAddress(
 ```
 
 **Pagination**: use `paginationToken` from the previous response.
+
+### Method 3: `helius.getTransfersByAddress()` — per-transfer rows
+
+Returns **one row per token or native SOL transfer** (not per transaction). Each row carries `{ signature, slot, blockTime, type, fromUserAccount, toUserAccount, mint, amount, uiAmount, decimals, transactionIdx, instructionIdx, innerInstructionIdx, … }`. Use this when you want to aggregate by mint, counterparty, or direction — far easier than parsing transactions and re-extracting transfers.
+
+Signature: `helius.getTransfersByAddress([address, config?])` — note the positional tuple.
+
+```typescript
+// Recent transfers
+const recent = await helius.getTransfersByAddress([
+  'WalletAddress',
+  { limit: 25, sortOrder: 'desc' },
+]);
+
+// Inbound USDC only
+const inboundUsdc = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    direction: 'in',
+    limit: 50,
+  },
+]);
+
+// Transfers with a specific counterparty in the last 24h
+const oneDayAgo = Math.floor(Date.now() / 1000) - 86400;
+const withCounterparty = await helius.getTransfersByAddress([
+  'WalletAddress',
+  {
+    with: 'CounterpartyAddress',
+    filters: { blockTime: { gte: oneDayAgo } },
+    limit: 100,
+  },
+]);
+
+// Pagination
+const page1 = await helius.getTransfersByAddress(['WalletAddress', { limit: 50 }]);
+if (page1.paginationToken) {
+  const page2 = await helius.getTransfersByAddress([
+    'WalletAddress',
+    { limit: 50, paginationToken: page1.paginationToken },
+  ]);
+}
+```
+
+**Config options**: `with` (counterparty), `direction` (`in` | `out` | `any`), `mint`, `solMode` (`merged` | `separate`), `filters.amount` / `filters.blockTime` / `filters.slot` (each with `gt`/`gte`/`lt`/`lte`), `limit`, `sortOrder` (`asc` | `desc`), `paginationToken`, `commitment` (`finalized` | `confirmed`).
+
+**MCP**: `heliusTransaction.getTransfersByAddress` with the same fields flattened (e.g., `blockTimeGte`, `amountGte`).
 
 ### Parameter Name Mapping
 


### PR DESCRIPTION
## Summary

Surfaces the new `getTransfersByAddress` RPC wrapper from [helius-sdk PR #313](https://github.com/helius-labs/helius-sdk/pull/313) as a first-class MCP action and CLI subcommand. Returns **one row per parsed token / native SOL transfer** (not per transaction) with rich filters — mint, direction (`in`/`out`/`any`), counterparty (`with`), and time/slot/amount ranges — plus `paginationToken` cursor.

- **MCP**: new `heliusTransaction.getTransfersByAddress` action
- **CLI**: new `helius tx transfers <address>` subcommand
- **Docs/skills**: canonical `helius-skills/helius/` updated, mirrored to plugin/cursor, `.agents/` and `helius-mcp/system-prompts/` regenerated

## Changes

### MCP (`helius-mcp/`)
- `src/tools/transactions.ts` — new `server.tool('getTransfersByAddress', ...)` handler: zod schema for all filter params, `validateEnum` for `direction`/`sortOrder`/`solMode`/`commitment`, filter mapping (`amountGte`/`Lte`, `blockTimeGte`/`Lte`, `slotGte`/`Lte` → nested `filters` object), native-SOL detection for `formatSol` rendering, paginationToken hint
- `src/router/actions.ts` — added to `HELIUS_TRANSACTION_ACTIONS`
- `src/router/required-params.ts` — `address` required
- `src/router/catalog.ts` — `responseFamily: 'history'`, `continuationModel: 'transactionHistory'`
- `src/router/dispatch.ts` — `**Next Page Token:**` regex extended to fire on the new action
- `src/router/instructions.ts` — router routing copy updated
- `tests/router-action-handlers.test.ts` — 3 new cases (defaults, filter+pagination passthrough, missing-address validation). **All 226 existing tests still pass.**

### CLI (`helius-cli/`)
- `src/commands/tx.ts` — new `txTransfersCommand` modeled on `txHistoryCommand`
- `bin/helius.ts` — Commander registration with all filter flags + examples

### Docs
- `helius-skills/helius/SKILL.md` — added to API + MCP tool lists, per-transfer-feed guidance, new "don't confuse with getTransactionHistory" pitfall
- `helius-skills/helius/references/enhanced-transactions.md` — extended method matrix, extended "When to Use" table, new **Method 3** usage section with the four PR examples (recent, mint+direction, counterparty+time, pagination)
- Mirrored to `helius-plugin/skills/build/` and `helius-cursor/skills/build/`
- `.agents/skills/helius/**` and `helius-mcp/system-prompts/helius/**` regenerated via `npx tsx scripts/compile-skills.ts`

## SDK version note

helius-sdk PR #313 is merged to `origin/main` but **not yet published** on npm (latest is `2.2.2`). This PR uses `(helius as any).getTransfersByAddress(...)` casts in both the MCP handler and the CLI command — matching the existing pattern at `helius-mcp/src/tools/transactions.ts:578` for `getSignaturesForAddress`. Once the SDK release lands, drop the casts and bump `helius-sdk` in both `helius-mcp/package.json` and `helius-cli/package.json`.

No `package.json` bump in this PR — would break installs against the published 2.2.2.

## Test plan

- [ ] `cd helius-mcp && pnpm exec vitest run` — 226/226 pass locally
- [ ] `cd helius-mcp && pnpm build` — clean
- [ ] `cd helius-cli && pnpm build` — clean (the pre-existing `signup.ts` TS error on `main` is unrelated)
- [ ] `node dist/bin/helius.js tx transfers --help` — flags render correctly
- [ ] Post-SDK-publish smoke: `node dist/bin/helius.js tx transfers <addr> --limit 3` and `--mint <usdc> --direction in --json`
- [ ] Post-SDK-publish MCP runtime: dispatch `heliusTransaction` with `{ action: 'getTransfersByAddress', address, limit: 5 }`; confirm `**Next Page Token:**` continuation replay re-invokes the new action

🤖 Generated with [Claude Code](https://claude.com/claude-code)