### PR TITLE
feat(security): Enforce 7-day Minimum Release Age For Deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080


### PR DESCRIPTION
This PR adds `.npmrc` at the repo root with `minimum-release-age=10080` (i.e.,7 days, in minutes). pnpm will refuse to install any package version published within the last 7 days, mitigating supply-chain attacks in which a compromised maintainer account publishes a malicious release

Existing lockfile entries are unaffected, as the check applies only to version resolution (e.g., new installs, `pnpm update`, range bumps). pnpm walks up from each package directory to find `.npmrc`, so a single root-level file covers both `helius-mcp/`, `helius-cli/`, etc., plus any future packages added to the monorepo

Note: this protects only developers / CI installing dependencies. It does not affect end users of `helius-mcp` or `helius-cli`, since published artifacts are built ahead of time