### PR TITLE
chore(cli): Add `package.json` Metadata and Bundle `LICENSE`

### DIFF
--- a/helius-cli/LICENSE
+++ b/helius-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Helius Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/helius-cli/package.json
+++ b/helius-cli/package.json
@@ -2,6 +2,28 @@
   "name": "helius-cli",
   "version": "1.3.0",
   "description": "CLI to create free Helius accounts and manage projects",
+  "homepage": "https://www.helius.dev/cli.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/helius-labs/core-ai.git",
+    "directory": "helius-cli"
+  },
+  "bugs": {
+    "url": "https://github.com/helius-labs/core-ai/issues"
+  },
+  "keywords": [
+    "solana",
+    "helius",
+    "cli",
+    "rpc",
+    "das",
+    "blockchain",
+    "agent",
+    "ai-agent",
+    "web3"
+  ],
+  "license": "MIT",
+  "author": "Helius Labs",
   "type": "module",
   "bin": {
     "helius": "./dist/bin/helius.js"
@@ -9,7 +31,8 @@
   "files": [
     "dist",
     "llms.txt",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "prebuild": "node -p \"'export const version = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",


### PR DESCRIPTION
This PR adds the missing `homepage`, `repository`, `bugs`, `keywords`, `license`, and `author` fields to `helius-cli/package.json`, and bundles a `LICENSE` file into the published package. The package currently ships with all of these metadata fields set to null and no license file, which prevents npm and downstream registries from linking the package back to Helius