### PR TITLE
feat(helius-cli): OAuth/PKCE login + logout + whoami (v2.0.0)

### DIFF
--- a/.agents/skills/helius-dflow/prompts/full.md
+++ b/.agents/skills/helius-dflow/prompts/full.md
@@ -1950,7 +1950,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -1976,7 +1976,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -1998,7 +1998,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -2122,7 +2122,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/.agents/skills/helius-dflow/references/helius-onboarding.md
+++ b/.agents/skills/helius-dflow/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/.agents/skills/helius-jupiter/prompts/full.md
+++ b/.agents/skills/helius-jupiter/prompts/full.md
@@ -940,7 +940,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -966,7 +966,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -988,7 +988,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -1112,7 +1112,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/.agents/skills/helius-jupiter/references/helius-onboarding.md
+++ b/.agents/skills/helius-jupiter/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/.agents/skills/helius-phantom/prompts/full.md
+++ b/.agents/skills/helius-phantom/prompts/full.md
@@ -1707,7 +1707,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -1733,7 +1733,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -1755,7 +1755,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -1879,7 +1879,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/.agents/skills/helius-phantom/references/helius-onboarding.md
+++ b/.agents/skills/helius-phantom/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/.agents/skills/helius/prompts/full.md
+++ b/.agents/skills/helius/prompts/full.md
@@ -1225,7 +1225,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -1251,7 +1251,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -1273,7 +1273,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -1397,7 +1397,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/.agents/skills/helius/references/onboarding.md
+++ b/.agents/skills/helius/references/onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-cli/CHANGELOG.md
+++ b/helius-cli/CHANGELOG.md
@@ -1,17 +1,5 @@
 # Changelog
 
-> **⚠️ Before merging v2.0.0 / publishing to npm:** this release depends on
-> `oauthTokenExchange`, `HELIUS_API_URL` env override, and JSON error parsing
-> being available in `helius-sdk`. Those land in a separate SDK PR. Sequence:
->
-> 1. Merge & publish the `helius-sdk` PR (new minor/major).
-> 2. Bump `helius-sdk` dep in `package.json` from `^2.2.2` to the new version.
-> 3. Verify `pnpm build` succeeds, then publish `helius-cli` v2.0.0.
->
-> Pre-existing build errors in `src/commands/signup.ts` and `src/lib/checkout.ts`
-> reference SDK functions (`agenticSignup`, `executeCheckout`, etc.) that were
-> removed in a separate, unrelated SDK migration — out of scope for this PR.
-
 ## 2.0.0 — Breaking change: OAuth/PKCE login
 
 `helius login` now opens your browser to authenticate via dashboard.helius.dev, instead of signing a message with a local Solana keypair.

--- a/helius-cli/CHANGELOG.md
+++ b/helius-cli/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+> **⚠️ Before merging v2.0.0 / publishing to npm:** this release depends on
+> `oauthTokenExchange`, `HELIUS_API_URL` env override, and JSON error parsing
+> being available in `helius-sdk`. Those land in a separate SDK PR. Sequence:
+>
+> 1. Merge & publish the `helius-sdk` PR (new minor/major).
+> 2. Bump `helius-sdk` dep in `package.json` from `^2.2.2` to the new version.
+> 3. Verify `pnpm build` succeeds, then publish `helius-cli` v2.0.0.
+>
+> Pre-existing build errors in `src/commands/signup.ts` and `src/lib/checkout.ts`
+> reference SDK functions (`agenticSignup`, `executeCheckout`, etc.) that were
+> removed in a separate, unrelated SDK migration — out of scope for this PR.
+
+## 2.0.0 — Breaking change: OAuth/PKCE login
+
+`helius login` now opens your browser to authenticate via dashboard.helius.dev, instead of signing a message with a local Solana keypair.
+
+### Breaking
+- **`helius login -k <keypair>` / `--keypair` flag removed.** The new flow uses OAuth 2.0 Authorization Code Grant + PKCE (RFC 7636 + RFC 8252) — same pattern as `aws sso login`, `gh auth login`, `vercel login`. Wallet-based account creation continues to work via `helius signup`; only the auth-token retrieval path changed.
+- If you previously authenticated with `helius login -k`, your cached JWT in `~/.helius/config.json` keeps working until it expires. The next time you need to re-authenticate, run `helius login` (no flag).
+
+### New
+- `helius login` — browser-based authentication for users with existing dashboard.helius.dev accounts. Supports four auth methods: email/password, Google, GitHub, and **wallet** (Solana signature).
+- `helius login --no-browser` — prints the URL for manual paste (useful in remote/headless environments).
+- `helius login --json` — emits `{ status: "AWAITING_CALLBACK", verification_uri }` while waiting and `{ status: "SUCCESS", user, expires_at }` on completion.
+- Already-logged-in short-circuit: a second `helius login` with a valid JWT prints `Already logged in as <email>.` (or `wallet <pubkey>` for wallet sessions) and exits 0.
+- **`helius logout`** — clears the local session token. Default keeps the API key so RPC calls still work; `--all` wipes the entire config.
+- **`helius whoami`** — shows the authenticated identity (email or wallet pubkey), session expiry, project, API key, and network. `--verify` pings the backend to confirm the token is still valid server-side. `--json` for scripting.
+- "No projects found" guidance updated across `projects`, `status`, `apikeys` to point users at the dashboard for project creation (the CLI cannot create projects for OAuth-authenticated users — that gate is enforced backend-side and is a separate ticket).
+
+### Not supported
+- **WorkOS SSO users**: rejected at the backend with a clean error message. Enterprise SSO users typically have their CLI access provisioned via the org admin portal; this is consistent with the existing domain-lockdown check that already rejects SSO at `/oauth/token`.
+
+### Security
+- PKCE binds each auth code to the originating CLI invocation. Public OAuth client per RFC 8252 §6 — no client secret.
+- Loopback redirect on `127.0.0.1` (literal IPv4, not `localhost`) per RFC 8252 §7.3, random ephemeral port via `:0`.
+- 5-minute timeout on the loopback listener; CSRF defense via `state` round-trip.
+
+## 1.3.0
+
+Previous releases — see git history.

--- a/helius-cli/CLAUDE.md
+++ b/helius-cli/CLAUDE.md
@@ -32,7 +32,7 @@ src/
   lib/
     helius.ts          # SDK client wrapper — resolveApiKey(), getClient(), restRequest(), HeliusHttpError
     formatters.ts      # formatSol(), formatAddress(), formatTimestamp(), formatTable()
-    config.ts          # ~/.helius-cli/config.json — jwt, apiKey, network, projectId
+    config.ts          # ~/.helius/config.json — jwt, apiKey, network, projectId
     output.ts          # ExitCode enum, classifyError(), handleCommandError(), outputJson(), exitWithError()
     api.ts             # Helius management API (signup, projects, API keys)
     payment.ts         # USDC payment for signup
@@ -65,7 +65,7 @@ WebSocket commands (`ws.ts`) use a variant that preserves the AbortError early-r
 
 1. `--api-key <key>` CLI flag
 2. `HELIUS_API_KEY` environment variable
-3. `~/.helius-cli/config.json` → `apiKey` field
+3. `~/.helius/config.json` → `apiKey` field
 4. Auto-resolve from JWT: fetch project details → first API key
 
 ## Exit Code Ranges

--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -5,6 +5,8 @@ import { signupCommand } from "../src/commands/signup.js";
 import { upgradeCommand } from "../src/commands/upgrade.js";
 import { payCommand } from "../src/commands/pay.js";
 import { loginCommand } from "../src/commands/login.js";
+import { logoutCommand } from "../src/commands/logout.js";
+import { whoamiCommand } from "../src/commands/whoami.js";
 import { projectsCommand } from "../src/commands/projects.js";
 import { projectCommand } from "../src/commands/project.js";
 import { apikeysCommand, createApiKeyCommand } from "../src/commands/apikeys.js";
@@ -177,14 +179,41 @@ Examples:
 
 program
   .command("login")
-  .description("Authenticate with wallet")
-  .option("-k, --keypair <path>", "Path to Solana keypair file", getDefaultKeypairPath())
+  .description("Authenticate with your Helius account in the browser (OAuth/PKCE)")
   .option("--json", "Output in JSON format")
+  .option("--no-browser", "Print URL instead of opening the browser")
   .addHelpText('after', `
 Examples:
   $ helius login
-  $ helius login -k ~/my-keypair.json`)
+  $ helius login --no-browser
+  $ helius login --json
+
+Wallet-based account creation continues to work via \`helius signup\`.`)
   .action(loginCommand);
+
+program
+  .command("logout")
+  .description("Sign out and clear the local session token (keeps API key by default)")
+  .option("--all", "Wipe the entire local config (jwt, apiKey, projectId, network, owsWallet)")
+  .option("--json", "Output in JSON format")
+  .addHelpText('after', `
+Examples:
+  $ helius logout
+  $ helius logout --all
+  $ helius logout --json`)
+  .action(logoutCommand);
+
+program
+  .command("whoami")
+  .description("Show the current authenticated identity, session expiry, and local config")
+  .option("--verify", "Also verify the session token against the backend (one API call)")
+  .option("--json", "Output in JSON format")
+  .addHelpText('after', `
+Examples:
+  $ helius whoami
+  $ helius whoami --verify
+  $ helius whoami --json`)
+  .action(whoamiCommand);
 
 program
   .command("projects")

--- a/helius-cli/package.json
+++ b/helius-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "helius-cli",
-  "version": "1.3.0",
-  "description": "CLI to create free Helius accounts and manage projects",
+  "version": "2.0.0",
+  "description": "CLI to create and manage Helius accounts, with OAuth/PKCE browser-based login",
   "type": "module",
   "bin": {
     "helius": "./dist/bin/helius.js"
@@ -15,6 +15,8 @@
     "prebuild": "node -p \"'export const version = \\'' + require('./package.json').version + '\\';'\" > src/version.ts",
     "build": "tsc",
     "dev": "tsx bin/helius.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
@@ -28,6 +30,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/helius-cli/pnpm-lock.yaml
+++ b/helius-cli/pnpm-lock.yaml
@@ -36,8 +36,17 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@20.19.33)
 
 packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -45,10 +54,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -57,16 +78,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -75,10 +114,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -87,10 +138,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -99,10 +162,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -111,10 +186,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -123,16 +210,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.3':
@@ -147,6 +252,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.3':
     resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
     engines: {node: '>=18'}
@@ -157,6 +268,12 @@ packages:
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -171,16 +288,34 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.27.3':
@@ -189,9 +324,156 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
 
@@ -570,11 +852,50 @@ packages:
       typescript:
         optional: true
 
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@20.19.33':
     resolution: {integrity: sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   base-x@5.0.1:
@@ -583,9 +904,21 @@ packages:
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -603,13 +936,41 @@ packages:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -642,9 +1003,23 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -654,6 +1029,20 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -661,9 +1050,27 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -676,6 +1083,24 @@ packages:
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -696,6 +1121,72 @@ packages:
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -710,52 +1201,103 @@ packages:
 
 snapshots:
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.27.3':
@@ -764,10 +1306,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -776,16 +1324,105 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
   '@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(typescript@5.9.3))':
@@ -1228,11 +1865,57 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@20.19.33':
     dependencies:
       undici-types: 6.21.0
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.33))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.33)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   ansi-regex@6.2.2: {}
+
+  assertion-error@2.0.1: {}
 
   base-x@5.0.1: {}
 
@@ -1240,7 +1923,19 @@ snapshots:
     dependencies:
       base-x: 5.0.1
 
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@5.6.2: {}
+
+  check-error@2.1.3: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -1252,7 +1947,41 @@ snapshots:
 
   commander@14.0.2: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
   emoji-regex@10.6.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1282,6 +2011,12 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -1318,7 +2053,17 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   mimic-function@5.0.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
 
   onetime@7.0.0:
     dependencies:
@@ -1336,6 +2081,18 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
 
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
@@ -1343,7 +2100,46 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -1356,6 +2152,16 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tslib@2.8.1: {}
 
@@ -1371,5 +2177,72 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.22.0: {}
+
+  vite-node@2.1.9(@types/node@20.19.33):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.33)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.33):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.60.4
+    optionalDependencies:
+      '@types/node': 20.19.33
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@20.19.33):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.33))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.33)
+      vite-node: 2.1.9(@types/node@20.19.33)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.33
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.19.0: {}

--- a/helius-cli/src/commands/apikeys.ts
+++ b/helius-cli/src/commands/apikeys.ts
@@ -14,7 +14,7 @@ async function resolveProjectId(jwt: string, projectId?: string, json?: boolean)
     if (json) {
       exitWithError("NO_PROJECTS", "No projects found", undefined, json);
     }
-    throw new Error("No projects found. Run `helius signup` to create your first project.");
+    throw new Error("No projects found. Create one in the dashboard at https://dashboard.helius.dev, or run `helius signup` to create a new account.");
   }
 
   if (projects.length > 1) {

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -1,50 +1,123 @@
 import chalk from "chalk";
-import { loadKeypairFromFile, signAuthMessage, getAddress } from "../lib/wallet.js";
-import { signup } from "../lib/api.js";
-import { setJwt } from "../lib/config.js";
-import { keypairExists } from "./keygen.js";
-import { outputJson, exitWithError, handleCommandError, createSpinner, type OutputOptions } from "../lib/output.js";
+import { generatePkcePair, generateState, describeJwtIdentity } from "../lib/oauth.js";
+import { startLoopback } from "../lib/loopback-server.js";
+import { openInBrowser } from "../lib/browser.js";
+import { oauthTokenExchange, listProjects } from "../lib/api.js";
+import { getJwt, setJwt } from "../lib/config.js";
+import {
+  outputJson,
+  handleCommandError,
+  createSpinner,
+  type OutputOptions,
+} from "../lib/output.js";
+
+const DASHBOARD_URL = (process.env.HELIUS_DASHBOARD_URL ?? "https://dashboard.helius.dev").replace(
+  /\/$/,
+  "",
+);
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
 
 interface LoginOptions extends OutputOptions {
-  keypair: string;
+  /** Commander injects this — `--no-browser` flips it to false. Default true. */
+  browser: boolean;
 }
 
 export async function loginCommand(options: LoginOptions): Promise<void> {
   const spinner = createSpinner(options);
 
   try {
-    // Check keypair exists
-    if (!keypairExists(options.keypair)) {
-      exitWithError("KEYPAIR_NOT_FOUND", `Keypair not found at ${options.keypair}`, undefined, !!options.json);
+    // Already-logged-in short-circuit. Probe the JWT server-side via /projects
+    // so a revoked-but-not-yet-expired token still triggers a fresh login.
+    const existing = getJwt();
+    if (existing) {
+      try {
+        await listProjects(existing);
+        const identity = describeJwtIdentity(existing);
+        const label = identity?.kind === "wallet"
+          ? `wallet ${identity.display}`
+          : (identity?.display ?? "your account");
+        if (options.json) {
+          outputJson({ status: "ALREADY_LOGGED_IN", identity: identity ?? null });
+          return;
+        }
+        console.log(chalk.green(`✓ Already logged in as ${chalk.cyan(label)}.`));
+        return;
+      } catch {
+        // JWT invalid/revoked — fall through to fresh login.
+      }
     }
 
-    // Load keypair
-    spinner?.start("Loading keypair...");
-    const keypair = await loadKeypairFromFile(options.keypair);
-    const walletAddress = await getAddress(keypair);
-    spinner?.succeed(`Wallet: ${chalk.cyan(walletAddress)}`);
+    const { codeVerifier, codeChallenge } = generatePkcePair();
+    const state = generateState();
 
-    // Sign auth message
-    spinner?.start("Signing authentication message...");
-    const { message, signature } = await signAuthMessage(keypair.secretKey);
-    spinner?.succeed("Message signed");
+    spinner?.start("Starting local server...");
+    const loopback = await startLoopback();
+    spinner?.succeed(`Listening on http://127.0.0.1:${loopback.port}`);
 
-    // Call login API
-    spinner?.start("Authenticating...");
-    const authResult = await signup(message, signature, walletAddress);
-    setJwt(authResult.token);
-    spinner?.succeed("Authenticated");
+    const redirectUri = `http://127.0.0.1:${loopback.port}/oauth/callback`;
+    const authUrl = new URL(`${DASHBOARD_URL}/authorize`);
+    authUrl.searchParams.set("response_type", "code");
+    authUrl.searchParams.set("client_id", "helius-cli");
+    authUrl.searchParams.set("redirect_uri", redirectUri);
+    authUrl.searchParams.set("state", state);
+    authUrl.searchParams.set("code_challenge", codeChallenge);
+    authUrl.searchParams.set("code_challenge_method", "S256");
+
+    const useBrowser = options.browser && !process.env.NO_BROWSER;
+
+    if (options.json) {
+      outputJson({ status: "AWAITING_CALLBACK", verification_uri: authUrl.toString() });
+    } else if (!useBrowser) {
+      console.log("Open this URL to authenticate:\n");
+      console.log(chalk.cyan(authUrl.toString()));
+      console.log();
+    } else {
+      console.log("Attempting to open your default browser.");
+      console.log("If the browser does not open, open the following URL:\n");
+      console.log(chalk.cyan(authUrl.toString()));
+      console.log();
+      openInBrowser(authUrl.toString());
+    }
+
+    spinner?.start("Waiting for browser confirmation...");
+    let code: string;
+    try {
+      code = await loopback.awaitCallback(state, LOGIN_TIMEOUT_MS);
+    } finally {
+      loopback.close();
+    }
+    spinner?.succeed("Authorization received");
+
+    spinner?.start("Exchanging authorization code...");
+    const result = await oauthTokenExchange({
+      code,
+      codeVerifier,
+      clientId: "helius-cli",
+      redirectUri,
+    });
+    setJwt(result.access_token);
+
+    // Wallet users have a null email; identify them by their userID (pubkey)
+    // and label as "wallet …". Email users keep the normal display.
+    const successIdentity = describeJwtIdentity(result.access_token);
+    const successLabel
+      = result.user.email
+        ? result.user.email
+        : successIdentity?.kind === "wallet"
+          ? `wallet ${successIdentity.display}`
+          : (result.user.id ?? "your account");
+    spinner?.succeed(`Successfully logged in as ${chalk.cyan(successLabel)}`);
 
     if (options.json) {
       outputJson({
-        wallet: walletAddress,
-        authenticated: true,
+        status: "SUCCESS",
+        user: result.user,
+        identity: successIdentity ?? null,
+        expires_at: new Date(Date.now() + result.expires_in * 1000).toISOString(),
       });
-      return;
+    } else {
+      console.log(chalk.gray("JWT saved to ~/.helius/config.json"));
     }
-
-    console.log("\n" + chalk.green("✓ Login successful!"));
-    console.log(`\nJWT saved to ~/.helius/config.json`);
   } catch (error) {
     handleCommandError(error, options, spinner, "AUTH_FAILED");
   }

--- a/helius-cli/src/commands/login.ts
+++ b/helius-cli/src/commands/login.ts
@@ -8,6 +8,7 @@ import {
   outputJson,
   handleCommandError,
   createSpinner,
+  classifyError,
   type OutputOptions,
 } from "../lib/output.js";
 
@@ -42,7 +43,11 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
         }
         console.log(chalk.green(`✓ Already logged in as ${chalk.cyan(label)}.`));
         return;
-      } catch {
+      } catch (probeError) {
+        // Only a genuine auth failure (revoked/expired JWT → 401/403) should
+        // silently fall through to a fresh login. Transient failures (network,
+        // 5xx, rate limit) must surface rather than forcing a confusing re-login.
+        if (classifyError(probeError).errorCode !== "INVALID_API_KEY") throw probeError;
         // JWT invalid/revoked — fall through to fresh login.
       }
     }
@@ -51,7 +56,7 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
     const state = generateState();
 
     spinner?.start("Starting local server...");
-    const loopback = await startLoopback();
+    const loopback = await startLoopback(state);
     spinner?.succeed(`Listening on http://127.0.0.1:${loopback.port}`);
 
     const redirectUri = `http://127.0.0.1:${loopback.port}/oauth/callback`;
@@ -82,7 +87,7 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
     spinner?.start("Waiting for browser confirmation...");
     let code: string;
     try {
-      code = await loopback.awaitCallback(state, LOGIN_TIMEOUT_MS);
+      code = await loopback.awaitCallback(LOGIN_TIMEOUT_MS);
     } finally {
       loopback.close();
     }

--- a/helius-cli/src/commands/logout.ts
+++ b/helius-cli/src/commands/logout.ts
@@ -1,0 +1,65 @@
+import chalk from "chalk";
+import { decodeJwtEmail } from "../lib/oauth.js";
+import { getJwt, clearJwt, clearConfig, load } from "../lib/config.js";
+import {
+  outputJson,
+  handleCommandError,
+  createSpinner,
+  type OutputOptions,
+} from "../lib/output.js";
+
+interface LogoutOptions extends OutputOptions {
+  all?: boolean;
+}
+
+export async function logoutCommand(options: LogoutOptions): Promise<void> {
+  const spinner = createSpinner(options);
+
+  try {
+    const existingJwt = getJwt();
+    const email = existingJwt ? decodeJwtEmail(existingJwt) : null;
+    const hadAnyConfig = Object.keys(load()).length > 0;
+
+    if (!existingJwt && !options.all) {
+      if (options.json) {
+        outputJson({ status: "NOT_LOGGED_IN" });
+        return;
+      }
+      console.log("Not logged in. Nothing to clear.");
+      return;
+    }
+
+    if (options.all) {
+      clearConfig();
+      spinner?.succeed("Cleared local config");
+    } else {
+      clearJwt();
+      spinner?.succeed("Signed out");
+    }
+
+    if (options.json) {
+      outputJson({
+        status: "SIGNED_OUT",
+        email,
+        scope: options.all ? "all" : "jwt-only",
+        hadConfig: hadAnyConfig,
+      });
+      return;
+    }
+
+    if (options.all) {
+      console.log(chalk.gray("Cleared: jwt, apiKey, projectId, network, owsWallet"));
+    } else {
+      if (email) {
+        console.log(`Signed out ${chalk.cyan(email)}.`);
+      }
+      console.log(
+        chalk.gray(
+          "Your API key (if set) is kept so RPC calls still work. Pass --all to wipe the entire local config.",
+        ),
+      );
+    }
+  } catch (error) {
+    handleCommandError(error, options, spinner);
+  }
+}

--- a/helius-cli/src/commands/projects.ts
+++ b/helius-cli/src/commands/projects.ts
@@ -30,7 +30,8 @@ export async function projectsCommand(options: OutputOptions): Promise<void> {
 
     if (projects.length === 0) {
       console.log(chalk.yellow("No projects found."));
-      console.log(chalk.gray("Run `helius signup` to create your first project."));
+      console.log(chalk.gray("Create a project in the dashboard at https://dashboard.helius.dev,"));
+      console.log(chalk.gray("or run `helius signup` if you don't have an account yet."));
       return;
     }
 

--- a/helius-cli/src/commands/status.ts
+++ b/helius-cli/src/commands/status.ts
@@ -25,7 +25,8 @@ export async function statusCommand(options: OutputOptions = {}): Promise<void> 
         exitWithError("NO_PROJECTS", "No projects found", undefined, true);
       }
       console.log(chalk.yellow("No projects found."));
-      console.log(chalk.gray("Run `helius signup` to create your first project."));
+      console.log(chalk.gray("Create a project in the dashboard at https://dashboard.helius.dev,"));
+      console.log(chalk.gray("or run `helius signup` if you don't have an account yet."));
       process.exit(ExitCode.NO_PROJECTS);
     }
 

--- a/helius-cli/src/commands/whoami.ts
+++ b/helius-cli/src/commands/whoami.ts
@@ -6,6 +6,7 @@ import {
   outputJson,
   handleCommandError,
   createSpinner,
+  classifyError,
   type OutputOptions,
 } from "../lib/output.js";
 
@@ -87,7 +88,11 @@ export async function whoamiCommand(options: WhoamiOptions): Promise<void> {
         await listProjects(jwt);
         serverVerified = true;
         spinner?.succeed("Token accepted by backend");
-      } catch {
+      } catch (verifyError) {
+        // Only a genuine auth failure (revoked/expired JWT → 401/403) means the
+        // token was rejected. Transient failures (network, 5xx, rate limit) must
+        // surface as their own error rather than reading as a bad token.
+        if (classifyError(verifyError).errorCode !== "INVALID_API_KEY") throw verifyError;
         serverVerified = false;
         spinner?.fail("Token rejected by backend");
       }

--- a/helius-cli/src/commands/whoami.ts
+++ b/helius-cli/src/commands/whoami.ts
@@ -1,0 +1,149 @@
+import chalk from "chalk";
+import { decodeJwtPayload, describeJwtIdentity } from "../lib/oauth.js";
+import { listProjects } from "../lib/api.js";
+import { getJwt, getApiKey, getProjectId, getNetwork } from "../lib/config.js";
+import {
+  outputJson,
+  handleCommandError,
+  createSpinner,
+  type OutputOptions,
+} from "../lib/output.js";
+
+interface WhoamiOptions extends OutputOptions {
+  verify?: boolean;
+}
+
+function maskApiKey(key: string): string {
+  if (key.length <= 8) return key;
+  return `${key.slice(0, 8)}…`;
+}
+
+function formatRelative(secondsFromNow: number): string {
+  const abs = Math.abs(secondsFromNow);
+  const days = Math.floor(abs / 86400);
+  const hours = Math.floor((abs % 86400) / 3600);
+  const mins = Math.floor((abs % 3600) / 60);
+
+  let parts: string;
+  if (days > 0) parts = `${days}d ${hours}h`;
+  else if (hours > 0) parts = `${hours}h ${mins}m`;
+  else parts = `${mins}m`;
+
+  return secondsFromNow >= 0 ? `in ${parts}` : `${parts} ago`;
+}
+
+export async function whoamiCommand(options: WhoamiOptions): Promise<void> {
+  const spinner = createSpinner(options);
+
+  try {
+    const jwt = getJwt();
+    const apiKey = getApiKey();
+    const projectId = getProjectId();
+    const network = getNetwork();
+
+    if (!jwt) {
+      if (options.json) {
+        outputJson({
+          status: "NOT_LOGGED_IN",
+          apiKey: apiKey ? maskApiKey(apiKey) : null,
+          projectId: projectId ?? null,
+          network,
+        });
+        return;
+      }
+      console.log("Not logged in.");
+      console.log(
+        chalk.gray(
+          "  • Run `helius login` if you have an existing Helius account (browser-based, OAuth/PKCE).",
+        ),
+      );
+      console.log(
+        chalk.gray("  • Run `helius signup` to create a new account (keypair + USDC)."),
+      );
+      if (apiKey) {
+        console.log(
+          chalk.gray(
+            `\nNote: An API key is configured (${maskApiKey(apiKey)}) — RPC calls work, but account-management commands (projects, usage, billing) require a session token.`,
+          ),
+        );
+      }
+      return;
+    }
+
+    const payload = decodeJwtPayload(jwt);
+    const identity = describeJwtIdentity(jwt);
+    const authSource = (payload?.authSource as string | undefined) ?? "unknown";
+    const exp = typeof payload?.exp === "number" ? payload.exp : null;
+    const iat = typeof payload?.iat === "number" ? payload.iat : null;
+
+    const nowSec = Math.floor(Date.now() / 1000);
+    const expiresInSec = exp !== null ? exp - nowSec : null;
+    const expired = expiresInSec !== null && expiresInSec <= 0;
+
+    let serverVerified: boolean | null = null;
+    if (options.verify) {
+      spinner?.start("Verifying token against backend...");
+      try {
+        await listProjects(jwt);
+        serverVerified = true;
+        spinner?.succeed("Token accepted by backend");
+      } catch {
+        serverVerified = false;
+        spinner?.fail("Token rejected by backend");
+      }
+    }
+
+    if (options.json) {
+      outputJson({
+        status: expired ? "EXPIRED" : "LOGGED_IN",
+        identityKind: identity?.kind ?? "unknown",
+        email: identity?.kind === "email" ? identity.raw : null,
+        wallet: identity?.kind === "wallet" ? identity.raw : null,
+        authSource,
+        issuedAt: iat ? new Date(iat * 1000).toISOString() : null,
+        expiresAt: exp ? new Date(exp * 1000).toISOString() : null,
+        expiresInSeconds: expiresInSec,
+        projectId: projectId ?? null,
+        apiKey: apiKey ? maskApiKey(apiKey) : null,
+        network,
+        verified: serverVerified,
+      });
+      return;
+    }
+
+    const authSourceLabel
+      = authSource === "cli" ? "cli (OAuth/PKCE)"
+        : authSource === "supabase" ? "supabase (web session)"
+        : authSource === "wallet" ? "wallet (on-chain signature)"
+        : authSource;
+
+    const identityLabel
+      = identity?.kind === "email"
+        ? chalk.cyan(identity.raw)
+        : identity?.kind === "wallet"
+          ? `${chalk.cyan(identity.display)} ${chalk.gray(`(${identity.raw})`)}`
+          : chalk.gray("(unknown)");
+    const identityField = identity?.kind === "wallet" ? "Wallet:     " : "Email:      ";
+    console.log(`${chalk.gray(identityField)} ${identityLabel}`);
+    console.log(`${chalk.gray("Auth source:")} ${authSourceLabel}`);
+    if (exp !== null) {
+      const expDate = new Date(exp * 1000);
+      const rel = formatRelative(expiresInSec!);
+      const expLine = `${expDate.toLocaleString()} (${rel})`;
+      console.log(`${chalk.gray("Expires:")}     ${expired ? chalk.red(expLine) : expLine}`);
+    }
+    console.log(`${chalk.gray("Project:")}     ${projectId ? chalk.cyan(projectId) : chalk.gray("(none)")}`);
+    console.log(`${chalk.gray("API key:")}     ${apiKey ? `${maskApiKey(apiKey)} (set)` : chalk.gray("(none)")}`);
+    console.log(`${chalk.gray("Network:")}     ${network}`);
+    if (serverVerified === true) {
+      console.log(chalk.green("\n✓ Backend confirms token is valid."));
+    } else if (serverVerified === false) {
+      console.log(chalk.red("\n✖ Backend rejected the token — run `helius login` to re-authenticate."));
+    }
+    if (expired) {
+      console.log(chalk.yellow("\n⚠ Session has expired. Run `helius login` to refresh."));
+    }
+  } catch (error) {
+    handleCommandError(error, options, spinner);
+  }
+}

--- a/helius-cli/src/lib/api.ts
+++ b/helius-cli/src/lib/api.ts
@@ -6,6 +6,11 @@ import { listProjects as sdkListProjects } from "helius-sdk/auth/listProjects";
 import { getProject as sdkGetProject } from "helius-sdk/auth/getProject";
 import { createApiKey as sdkCreateApiKey } from "helius-sdk/auth/createApiKey";
 import { agenticSignup as sdkAgenticSignup } from "helius-sdk/auth/agenticSignup";
+import {
+  oauthTokenExchange as sdkOAuthTokenExchange,
+  type OAuthTokenResponse,
+  type OAuthTokenExchangeArgs,
+} from "helius-sdk/auth/oauthTokenExchange";
 import type {
   SignupResponse,
   Project,
@@ -51,6 +56,12 @@ export async function agenticSignup(
   return sdkAgenticSignup({ ...options, userAgent: CLI_USER_AGENT });
 }
 
+export async function oauthTokenExchange(
+  options: Omit<OAuthTokenExchangeArgs, "userAgent">,
+): Promise<OAuthTokenResponse> {
+  return sdkOAuthTokenExchange({ ...options, userAgent: CLI_USER_AGENT });
+}
+
 export type {
   Project,
   ProjectListItem,
@@ -63,3 +74,5 @@ export type {
   User,
   BillingCycle,
 } from "helius-sdk/auth/types";
+
+export type { OAuthTokenResponse, OAuthTokenExchangeArgs } from "helius-sdk/auth/oauthTokenExchange";

--- a/helius-cli/src/lib/browser.ts
+++ b/helius-cli/src/lib/browser.ts
@@ -3,8 +3,20 @@ import { spawn } from "node:child_process";
 /**
  * Opens `url` in the user's default browser. Detached + unref'd so the CLI
  * doesn't wait on it. Returns false if the platform launcher couldn't spawn.
+ *
+ * INVARIANT: `url` must be fully app-constructed — never user- or
+ * server-influenced. On Windows this spawns `cmd /c start <url>`, and cmd
+ * treats `&`, `^`, `%VAR%` etc. as shell metacharacters even in spawn args,
+ * so an attacker-shaped URL would be command injection. The http(s) guard
+ * below is defense-in-depth, not a substitute for that invariant.
  */
 export function openInBrowser(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    if (protocol !== "http:" && protocol !== "https:") return false;
+  } catch {
+    return false;
+  }
   const platform = process.platform;
   const cmd = platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
   const args = platform === "win32" ? ["/c", "start", "\"\"", url] : [url];

--- a/helius-cli/src/lib/browser.ts
+++ b/helius-cli/src/lib/browser.ts
@@ -1,0 +1,18 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Opens `url` in the user's default browser. Detached + unref'd so the CLI
+ * doesn't wait on it. Returns false if the platform launcher couldn't spawn.
+ */
+export function openInBrowser(url: string): boolean {
+  const platform = process.platform;
+  const cmd = platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
+  const args = platform === "win32" ? ["/c", "start", "\"\"", url] : [url];
+  try {
+    const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -91,6 +91,12 @@ export function setJwt(jwt: string): void {
   save(config);
 }
 
+export function clearJwt(): void {
+  const config = load();
+  delete config.jwt;
+  save(config);
+}
+
 export function getApiKey(): string | undefined {
   return load().apiKey;
 }

--- a/helius-cli/src/lib/loopback-server.ts
+++ b/helius-cli/src/lib/loopback-server.ts
@@ -11,9 +11,15 @@ const SUCCESS_PAGE =
   "<!doctype html><html><body style=\"font-family: -apple-system, system-ui, sans-serif; max-width: 480px; margin: 80px auto; text-align: center;\">" +
   "<h1>Logged in</h1><p>You can close this tab and return to your terminal.</p></body></html>";
 
+// `msg` can carry the attacker-controllable OAuth `error` query param — always escape.
+const escapeHtml = (s: string): string =>
+  s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+
 const ERROR_PAGE = (msg: string) =>
   "<!doctype html><html><body style=\"font-family: -apple-system, system-ui, sans-serif; max-width: 480px; margin: 80px auto; text-align: center;\">" +
-  `<h1>Login failed</h1><p>${msg}</p><p>Return to your terminal for details.</p></body></html>`;
+  `<h1>Login failed</h1><p>${escapeHtml(msg)}</p><p>Return to your terminal for details.</p></body></html>`;
 
 /**
  * Starts an HTTP server bound to 127.0.0.1 on a random port (RFC 8252 §7.3).

--- a/helius-cli/src/lib/loopback-server.ts
+++ b/helius-cli/src/lib/loopback-server.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from "node:net";
 
 export interface LoopbackResult {
   port: number;
-  awaitCallback: (expectedState: string, timeoutMs: number) => Promise<string>;
+  awaitCallback: (timeoutMs: number) => Promise<string>;
   close: () => void;
 }
 
@@ -17,7 +17,13 @@ const ERROR_PAGE = (msg: string) =>
 
 /**
  * Starts an HTTP server bound to 127.0.0.1 on a random port (RFC 8252 §7.3).
- * Resolves when the browser hits `/oauth/callback` with a `code` and matching `state`.
+ * Resolves when the browser hits `/oauth/callback` with a `code` and a `state`
+ * matching `expectedState`.
+ *
+ * `state` is validated inside the request handler — not later — so the browser
+ * reflects the real outcome (a mismatch serves the error page, not "Logged in")
+ * and an early bad hit can't poison the flow. `awaitCallback` resolves to the
+ * raw authorization `code` (no encoding assumptions about its charset).
  *
  * The returned `awaitCallback` rejects on:
  *   - `OAUTH_ERROR:<error>` if the callback URL includes an `error` param
@@ -25,7 +31,7 @@ const ERROR_PAGE = (msg: string) =>
  *   - `STATE_MISMATCH` if the returned state doesn't match the expected value
  *   - `TIMEOUT` if no callback arrives within the timeout
  */
-export async function startLoopback(): Promise<LoopbackResult> {
+export async function startLoopback(expectedState: string): Promise<LoopbackResult> {
   const server: Server = createServer();
   let resolveCb!: (value: string) => void;
   let rejectCb!: (err: Error) => void;
@@ -44,22 +50,30 @@ export async function startLoopback(): Promise<LoopbackResult> {
     const state = url.searchParams.get("state");
     const error = url.searchParams.get("error");
 
+    // Serve an error page + reject, closing the connection so `helius login`
+    // returns immediately rather than waiting on a keep-alive socket.
+    const fail = (msg: string, err: Error) => {
+      res.writeHead(400, { "Content-Type": "text/html", Connection: "close" });
+      res.end(ERROR_PAGE(msg));
+      rejectCb(err);
+    };
+
     if (error) {
-      res.writeHead(400, { "Content-Type": "text/html" });
-      res.end(ERROR_PAGE(error));
-      rejectCb(new Error(`OAUTH_ERROR:${error}`));
+      fail(error, new Error(`OAUTH_ERROR:${error}`));
       return;
     }
     if (!code) {
-      res.writeHead(400, { "Content-Type": "text/html" });
-      res.end(ERROR_PAGE("missing authorization code"));
-      rejectCb(new Error("NO_CODE"));
+      fail("missing authorization code", new Error("NO_CODE"));
+      return;
+    }
+    if (state !== expectedState) {
+      fail("state mismatch — possible CSRF, please retry", new Error("STATE_MISMATCH"));
       return;
     }
 
-    res.writeHead(200, { "Content-Type": "text/html" });
+    res.writeHead(200, { "Content-Type": "text/html", Connection: "close" });
     res.end(SUCCESS_PAGE);
-    resolveCb(`${code}|${state ?? ""}`);
+    resolveCb(code);
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -71,20 +85,22 @@ export async function startLoopback(): Promise<LoopbackResult> {
 
   return {
     port,
-    awaitCallback: async (expectedState, timeoutMs) => {
+    awaitCallback: async (timeoutMs) => {
       let timeoutHandle: NodeJS.Timeout | undefined;
       const timeoutPromise = new Promise<string>((_, rej) => {
         timeoutHandle = setTimeout(() => rej(new Error("TIMEOUT")), timeoutMs);
       });
       try {
-        const result = await Promise.race([cbPromise, timeoutPromise]);
-        const [code, state] = result.split("|");
-        if (state !== expectedState) throw new Error("STATE_MISMATCH");
-        return code;
+        return await Promise.race([cbPromise, timeoutPromise]);
       } finally {
         if (timeoutHandle) clearTimeout(timeoutHandle);
       }
     },
-    close: () => server.close(),
+    // Stop accepting connections and tear down idle keep-alive sockets
+    // (Node 18.2+) so the process can exit without waiting on a timeout.
+    close: () => {
+      server.close();
+      server.closeAllConnections?.();
+    },
   };
 }

--- a/helius-cli/src/lib/loopback-server.ts
+++ b/helius-cli/src/lib/loopback-server.ts
@@ -1,0 +1,90 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface LoopbackResult {
+  port: number;
+  awaitCallback: (expectedState: string, timeoutMs: number) => Promise<string>;
+  close: () => void;
+}
+
+const SUCCESS_PAGE =
+  "<!doctype html><html><body style=\"font-family: -apple-system, system-ui, sans-serif; max-width: 480px; margin: 80px auto; text-align: center;\">" +
+  "<h1>Logged in</h1><p>You can close this tab and return to your terminal.</p></body></html>";
+
+const ERROR_PAGE = (msg: string) =>
+  "<!doctype html><html><body style=\"font-family: -apple-system, system-ui, sans-serif; max-width: 480px; margin: 80px auto; text-align: center;\">" +
+  `<h1>Login failed</h1><p>${msg}</p><p>Return to your terminal for details.</p></body></html>`;
+
+/**
+ * Starts an HTTP server bound to 127.0.0.1 on a random port (RFC 8252 §7.3).
+ * Resolves when the browser hits `/oauth/callback` with a `code` and matching `state`.
+ *
+ * The returned `awaitCallback` rejects on:
+ *   - `OAUTH_ERROR:<error>` if the callback URL includes an `error` param
+ *   - `NO_CODE` if neither code nor error is present
+ *   - `STATE_MISMATCH` if the returned state doesn't match the expected value
+ *   - `TIMEOUT` if no callback arrives within the timeout
+ */
+export async function startLoopback(): Promise<LoopbackResult> {
+  const server: Server = createServer();
+  let resolveCb!: (value: string) => void;
+  let rejectCb!: (err: Error) => void;
+  const cbPromise = new Promise<string>((res, rej) => {
+    resolveCb = res;
+    rejectCb = rej;
+  });
+
+  server.on("request", (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (url.pathname !== "/oauth/callback") {
+      res.writeHead(404).end();
+      return;
+    }
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    const error = url.searchParams.get("error");
+
+    if (error) {
+      res.writeHead(400, { "Content-Type": "text/html" });
+      res.end(ERROR_PAGE(error));
+      rejectCb(new Error(`OAUTH_ERROR:${error}`));
+      return;
+    }
+    if (!code) {
+      res.writeHead(400, { "Content-Type": "text/html" });
+      res.end(ERROR_PAGE("missing authorization code"));
+      rejectCb(new Error("NO_CODE"));
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(SUCCESS_PAGE);
+    resolveCb(`${code}|${state ?? ""}`);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    port,
+    awaitCallback: async (expectedState, timeoutMs) => {
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      const timeoutPromise = new Promise<string>((_, rej) => {
+        timeoutHandle = setTimeout(() => rej(new Error("TIMEOUT")), timeoutMs);
+      });
+      try {
+        const result = await Promise.race([cbPromise, timeoutPromise]);
+        const [code, state] = result.split("|");
+        if (state !== expectedState) throw new Error("STATE_MISMATCH");
+        return code;
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+      }
+    },
+    close: () => server.close(),
+  };
+}

--- a/helius-cli/src/lib/oauth.ts
+++ b/helius-cli/src/lib/oauth.ts
@@ -1,0 +1,77 @@
+import { randomBytes, createHash } from "node:crypto";
+
+export interface PkcePair {
+  codeVerifier: string;
+  codeChallenge: string;
+}
+
+export function generatePkcePair(): PkcePair {
+  const codeVerifier = randomBytes(32).toString("base64url");
+  const codeChallenge = createHash("sha256").update(codeVerifier).digest().toString("base64url");
+  return { codeVerifier, codeChallenge };
+}
+
+export function generateState(): string {
+  return randomBytes(16).toString("base64url");
+}
+
+export interface JwtPayload {
+  email?: string;
+  userID?: string;
+  authSource?: string;
+  iat?: number;
+  exp?: number;
+  [key: string]: unknown;
+}
+
+/** Decode the JWT middle segment without signature verification — display only. */
+export function decodeJwtPayload(jwt: string): JwtPayload | null {
+  try {
+    const [, payloadB64] = jwt.split(".");
+    if (!payloadB64) return null;
+    return JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function decodeJwtEmail(jwt: string): string | null {
+  const payload = decodeJwtPayload(jwt);
+  if (!payload) return null;
+  if (typeof payload.email === "string") return payload.email;
+  if (typeof payload.userID === "string") return payload.userID;
+  return null;
+}
+
+export interface JwtIdentity {
+  /** "email" when the userID looks like an email; "wallet" when it's a base58 pubkey. */
+  kind: "email" | "wallet" | "unknown";
+  /** Human-facing label: full email or shortened pubkey (e.g. "7xKX…3vQ"). */
+  display: string;
+  /** Raw identifier from the JWT (email or full pubkey). */
+  raw: string;
+}
+
+function shortenPubkey(pk: string): string {
+  if (pk.length <= 12) return pk;
+  return `${pk.slice(0, 6)}…${pk.slice(-4)}`;
+}
+
+/** Inspect a JWT and produce a friendly identity descriptor for terminal output. */
+export function describeJwtIdentity(jwt: string): JwtIdentity | null {
+  const payload = decodeJwtPayload(jwt);
+  if (!payload) return null;
+  const raw
+    = typeof payload.email === "string" && payload.email.length > 0
+      ? payload.email
+      : typeof payload.userID === "string"
+        ? payload.userID
+        : "";
+  if (!raw) return null;
+  if (raw.includes("@")) return { kind: "email", display: raw, raw };
+  // Heuristic: base58-shaped userID without @ → treat as wallet pubkey.
+  if (/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(raw)) {
+    return { kind: "wallet", display: shortenPubkey(raw), raw };
+  }
+  return { kind: "unknown", display: raw, raw };
+}

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -247,12 +247,15 @@ export function classifyError(error: unknown): ErrorClassification {
     return classifyByStatus(error.status);
   }
 
-  // Tier 2 — HTTP status embedded in message (Enhanced TX and webhooks SDK paths)
-  // Matches: "Helius HTTP 429: ..." or "HTTP error! status: 429 - ..."
+  // Tier 2 — HTTP status embedded in message (Enhanced TX, webhooks, and auth SDK paths)
+  // Matches: "Helius HTTP 429: ...", "HTTP error! status: 429 - ...", or
+  // "API error (429): ..." (helius-sdk/auth authRequest — signup, projects, oauth)
   const heliusMatch = msg.match(/Helius HTTP (\d+):/);
   const webhookMatch = msg.match(/HTTP error! status: (\d+)/);
+  const authApiMatch = msg.match(/API error \((\d+)\)/);
   const embeddedStatus = heliusMatch ? parseInt(heliusMatch[1], 10)
     : webhookMatch ? parseInt(webhookMatch[1], 10)
+    : authApiMatch ? parseInt(authApiMatch[1], 10)
     : null;
   if (embeddedStatus !== null) {
     return classifyByStatus(embeddedStatus);

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -343,7 +343,7 @@ export const CLI_GUIDANCE: Record<string, string> = {
   PAYMENT_FAILED: 'The on-chain payment did not complete. Check your wallet balance and retry.',
   NOT_LOGGED_IN: 'Run `helius login` to authenticate, or `helius signup` to create a new account.',
   KEYPAIR_NOT_FOUND: 'Run `helius keygen` to generate a keypair first.',
-  NO_PROJECTS: 'Run `helius signup` to create your first project.',
+  NO_PROJECTS: 'Create a project in the dashboard at https://dashboard.helius.dev, or run `helius signup` if you do not have an account yet.',
   MULTIPLE_PROJECTS: 'Specify a project ID. Run `helius projects` to list them.',
   PROJECT_NOT_FOUND: 'Run `helius projects` to list available projects.',
   NO_API_KEYS: 'Run `helius apikeys create` to create an API key.',

--- a/helius-cli/tests/login.test.ts
+++ b/helius-cli/tests/login.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocks must be hoisted — vi.mock is hoisted automatically before imports.
+vi.mock("../src/lib/browser.js", () => ({ openInBrowser: vi.fn(() => true) }));
+
+const setJwtMock = vi.fn();
+const getJwtMock = vi.fn<() => string | undefined>();
+vi.mock("../src/lib/config.js", () => ({
+  getJwt: () => getJwtMock(),
+  setJwt: (jwt: string) => setJwtMock(jwt),
+}));
+
+const oauthTokenExchangeMock = vi.fn();
+const listProjectsMock = vi.fn();
+vi.mock("../src/lib/api.js", () => ({
+  oauthTokenExchange: (args: unknown) => oauthTokenExchangeMock(args),
+  listProjects: (jwt: string) => listProjectsMock(jwt),
+}));
+
+// We hit the loopback server directly from the test, so use the real implementation.
+
+import { loginCommand } from "../src/commands/login.js";
+import { openInBrowser } from "../src/lib/browser.js";
+
+function hitCallback(port: number, params: Record<string, string>) {
+  const qs = new URLSearchParams(params);
+  return fetch(`http://127.0.0.1:${port}/oauth/callback?${qs.toString()}`).then((r) => r.text());
+}
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let exitCode: number | undefined;
+let stdout: string;
+let stderr: string;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  exitCode = undefined;
+  stdout = "";
+  stderr = "";
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exitCode = code;
+    throw new Error(`__EXIT_${code}__`);
+  }) as never);
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: any) => {
+    stdout += String(chunk);
+    return true;
+  }) as never);
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: any) => {
+    stderr += String(chunk);
+    return true;
+  }) as never);
+  vi.spyOn(console, "log").mockImplementation((...args: any[]) => {
+    stdout += args.map(String).join(" ") + "\n";
+  });
+  vi.spyOn(console, "error").mockImplementation((...args: any[]) => {
+    stderr += args.map(String).join(" ") + "\n";
+  });
+  // Quiet PostHog / feedback paths if any.
+  delete process.env.NO_BROWSER;
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+  vi.restoreAllMocks();
+});
+
+async function run(options: Partial<{ json: boolean; browser: boolean }> = {}) {
+  const opts = { json: false, browser: true, ...options };
+  try {
+    await loginCommand(opts as never);
+  } catch (e) {
+    if (!(e instanceof Error) || !e.message.startsWith("__EXIT_")) throw e;
+  }
+}
+
+describe("loginCommand", () => {
+  it("happy path: writes JWT and reports success", async () => {
+    getJwtMock.mockReturnValue(undefined);
+    oauthTokenExchangeMock.mockImplementation(async (args: any) => {
+      // Validate the args structure on the way through.
+      expect(args.clientId).toBe("helius-cli");
+      expect(args.code).toBe("AUTH_CODE");
+      expect(args.codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(args.redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth\/callback$/);
+      return {
+        access_token: "JWT_TOKEN",
+        token_type: "Bearer" as const,
+        expires_in: 7 * 24 * 3600,
+        user: { id: "user-1", email: "alice@example.com" },
+      };
+    });
+
+    const loginPromise = run({ browser: false });
+
+    // Wait for the loopback to be up. Poll briefly — the command starts listening
+    // synchronously inside startLoopback before printing the URL.
+    let port: number | undefined;
+    for (let i = 0; i < 50 && !port; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      const m = stdout.match(/127\.0\.0\.1(?::|%3A)(\d+)/);
+      if (m) port = Number(m[1]);
+    }
+    expect(port).toBeDefined();
+
+    const state = stdout.match(/state=([A-Za-z0-9_-]+)/)?.[1];
+    expect(state).toBeDefined();
+
+    await hitCallback(port!, { code: "AUTH_CODE", state: state! });
+    await loginPromise;
+
+    expect(setJwtMock).toHaveBeenCalledWith("JWT_TOKEN");
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("state mismatch: exits with AUTH_FAILED", async () => {
+    getJwtMock.mockReturnValue(undefined);
+
+    const loginPromise = run({ browser: false });
+
+    let port: number | undefined;
+    for (let i = 0; i < 50 && !port; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      const m = stdout.match(/127\.0\.0\.1(?::|%3A)(\d+)/);
+      if (m) port = Number(m[1]);
+    }
+
+    await hitCallback(port!, { code: "AUTH_CODE", state: "WRONG_STATE" });
+    await loginPromise;
+
+    expect(setJwtMock).not.toHaveBeenCalled();
+    expect(exitCode).toBe(12);
+  });
+
+  it("error=access_denied on callback: exits with AUTH_FAILED", async () => {
+    getJwtMock.mockReturnValue(undefined);
+
+    const loginPromise = run({ browser: false });
+
+    let port: number | undefined;
+    for (let i = 0; i < 50 && !port; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      const m = stdout.match(/127\.0\.0\.1(?::|%3A)(\d+)/);
+      if (m) port = Number(m[1]);
+    }
+
+    await hitCallback(port!, { error: "access_denied", state: "x" });
+    await loginPromise;
+
+    expect(setJwtMock).not.toHaveBeenCalled();
+    expect(exitCode).toBe(12);
+  });
+
+  it("invalid_grant from token endpoint: exits with AUTH_FAILED", async () => {
+    getJwtMock.mockReturnValue(undefined);
+    oauthTokenExchangeMock.mockRejectedValue(
+      Object.assign(new Error("PKCE verification failed"), { code: "invalid_grant", status: 400 }),
+    );
+
+    const loginPromise = run({ browser: false });
+
+    let port: number | undefined;
+    for (let i = 0; i < 50 && !port; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      const m = stdout.match(/127\.0\.0\.1(?::|%3A)(\d+)/);
+      if (m) port = Number(m[1]);
+    }
+    const state = stdout.match(/state=([A-Za-z0-9_-]+)/)?.[1];
+
+    await hitCallback(port!, { code: "AUTH_CODE", state: state! });
+    await loginPromise;
+
+    expect(setJwtMock).not.toHaveBeenCalled();
+    expect(exitCode).toBe(12);
+  });
+
+  it("--no-browser: openInBrowser is not called, URL is printed", async () => {
+    getJwtMock.mockReturnValue(undefined);
+    oauthTokenExchangeMock.mockResolvedValue({
+      access_token: "JWT_TOKEN",
+      token_type: "Bearer",
+      expires_in: 7 * 24 * 3600,
+      user: { id: "u", email: "e@x.com" },
+    });
+
+    const loginPromise = run({ browser: false });
+    let port: number | undefined;
+    for (let i = 0; i < 50 && !port; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      const m = stdout.match(/127\.0\.0\.1(?::|%3A)(\d+)/);
+      if (m) port = Number(m[1]);
+    }
+    const state = stdout.match(/state=([A-Za-z0-9_-]+)/)?.[1];
+
+    await hitCallback(port!, { code: "C", state: state! });
+    await loginPromise;
+
+    expect(openInBrowser).not.toHaveBeenCalled();
+    expect(stdout).toContain("Open this URL to authenticate");
+  });
+
+  it("already-logged-in: short-circuits when listProjects succeeds", async () => {
+    // JWT with payload { email: 'bob@example.com' } — base64url of {"email":"bob@example.com"}
+    const payload = Buffer.from(JSON.stringify({ email: "bob@example.com" })).toString("base64url");
+    getJwtMock.mockReturnValue(`header.${payload}.sig`);
+    listProjectsMock.mockResolvedValue([{ id: "p1", name: "test" }]);
+
+    await run({ browser: false });
+
+    expect(setJwtMock).not.toHaveBeenCalled();
+    expect(oauthTokenExchangeMock).not.toHaveBeenCalled();
+    expect(stdout).toContain("Already logged in as");
+    expect(exitCode).toBeUndefined();
+  });
+});

--- a/helius-cli/tests/login.test.ts
+++ b/helius-cli/tests/login.test.ts
@@ -215,4 +215,46 @@ describe("loginCommand", () => {
     expect(stdout).toContain("Already logged in as");
     expect(exitCode).toBeUndefined();
   });
+
+  it("stale JWT (auth failure): falls through to a fresh login", async () => {
+    getJwtMock.mockReturnValue("header.payload.sig");
+    // Revoked/expired JWT — auth SDK throws "API error (401): ..." → INVALID_API_KEY.
+    listProjectsMock.mockRejectedValue(new Error("API error (401): unauthorized"));
+    oauthTokenExchangeMock.mockResolvedValue({
+      access_token: "FRESH_JWT",
+      token_type: "Bearer",
+      expires_in: 7 * 24 * 3600,
+      user: { id: "u", email: "e@x.com" },
+    });
+
+    const loginPromise = run({ browser: false });
+
+    let port: number | undefined;
+    for (let i = 0; i < 50 && !port; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      const m = stdout.match(/127\.0\.0\.1(?::|%3A)(\d+)/);
+      if (m) port = Number(m[1]);
+    }
+    expect(port).toBeDefined();
+    const state = stdout.match(/state=([A-Za-z0-9_-]+)/)?.[1];
+
+    await hitCallback(port!, { code: "AUTH_CODE", state: state! });
+    await loginPromise;
+
+    // Stale token discarded, fresh login completed.
+    expect(setJwtMock).toHaveBeenCalledWith("FRESH_JWT");
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("transient probe failure: surfaces instead of silently re-logging in", async () => {
+    getJwtMock.mockReturnValue("header.payload.sig");
+    // 5xx during the already-logged-in probe → SERVER_ERROR (exit 57), not a re-login.
+    listProjectsMock.mockRejectedValue(new Error("API error (500): boom"));
+
+    await run({ browser: false });
+
+    expect(oauthTokenExchangeMock).not.toHaveBeenCalled();
+    expect(setJwtMock).not.toHaveBeenCalled();
+    expect(exitCode).toBe(57);
+  });
 });

--- a/helius-cli/vitest.config.ts
+++ b/helius-cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    testTimeout: 10_000,
+  },
+});

--- a/helius-cursor/skills/build/references/onboarding.md
+++ b/helius-cursor/skills/build/references/onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-cursor/skills/dflow/references/helius-onboarding.md
+++ b/helius-cursor/skills/dflow/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-cursor/skills/jupiter/references/helius-onboarding.md
+++ b/helius-cursor/skills/jupiter/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-cursor/skills/phantom/references/helius-onboarding.md
+++ b/helius-cursor/skills/phantom/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -100,7 +100,19 @@ export function registerAuthTools(server: McpServer) {
         '',
         '---',
         '',
-        '## Path B — Create a new account',
+        '## Path B — I have an existing dashboard.helius.dev account',
+        '',
+        'If you already signed up at https://dashboard.helius.dev (email, Google, GitHub, or SSO), run `helius login` in your terminal:',
+        '',
+        '```bash',
+        'npx helius-cli@latest login',
+        '```',
+        '',
+        'This opens your default browser to authenticate via OAuth/PKCE and writes a session token to `~/.helius/config.json`. This MCP picks it up automatically — no further setup. Then call `setHeliusApiKey` with one of your keys (visible via `helius apikeys`), or just call `getAccountStatus` to confirm the session.',
+        '',
+        '---',
+        '',
+        '## Path C — Create a new account',
         '',
         'The signup is fully autonomous — no browser needed. It takes ~2 minutes:',
         '',
@@ -144,7 +156,7 @@ export function registerAuthTools(server: McpServer) {
         '',
         '---',
         '',
-        '## Path C — Use the Helius CLI',
+        '## Path D — Use the Helius CLI (keypair/USDC flow)',
         '',
         'Same flow from the terminal:',
         '```',
@@ -421,8 +433,8 @@ export function registerAuthTools(server: McpServer) {
         const jwt = getJwt();
         if (!jwt) {
           return mcpError(
-            'Not authenticated. Call `agenticSignup` or authenticate first.',
-            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
+            'Not authenticated. Call `agenticSignup`, or run `helius login` in your terminal if you have a dashboard.helius.dev account.',
+            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate, or run `helius login` in your terminal if you already have a dashboard.helius.dev account.' }
           );
         }
 
@@ -517,8 +529,8 @@ export function registerAuthTools(server: McpServer) {
         const jwt = getJwt();
         if (!jwt) {
           return mcpError(
-            'Not authenticated. Call `agenticSignup` or authenticate first.',
-            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
+            'Not authenticated. Call `agenticSignup`, or run `helius login` in your terminal if you have a dashboard.helius.dev account.',
+            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate, or run `helius login` in your terminal if you already have a dashboard.helius.dev account.' }
           );
         }
 
@@ -719,8 +731,8 @@ export function registerAuthTools(server: McpServer) {
         const jwt = getJwt();
         if (!jwt) {
           return mcpError(
-            'Not authenticated. Call `agenticSignup` or authenticate first.',
-            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate.' }
+            'Not authenticated. Call `agenticSignup`, or run `helius login` in your terminal if you have a dashboard.helius.dev account.',
+            { type: 'AUTH', code: 'NOT_AUTHENTICATED', retryable: false, recovery: 'Call `agenticSignup` to authenticate, or run `helius login` in your terminal if you already have a dashboard.helius.dev account.' }
           );
         }
 

--- a/helius-mcp/system-prompts/helius-dflow/full.md
+++ b/helius-mcp/system-prompts/helius-dflow/full.md
@@ -1950,7 +1950,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -1976,7 +1976,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -1998,7 +1998,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -2122,7 +2122,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-mcp/system-prompts/helius-jupiter/full.md
+++ b/helius-mcp/system-prompts/helius-jupiter/full.md
@@ -940,7 +940,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -966,7 +966,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -988,7 +988,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -1112,7 +1112,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-mcp/system-prompts/helius-phantom/full.md
+++ b/helius-mcp/system-prompts/helius-phantom/full.md
@@ -1707,7 +1707,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -1733,7 +1733,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -1755,7 +1755,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -1879,7 +1879,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-mcp/system-prompts/helius/full.md
+++ b/helius-mcp/system-prompts/helius/full.md
@@ -1225,7 +1225,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -1251,7 +1251,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -1273,7 +1273,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -1397,7 +1397,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-plugin/skills/build/references/onboarding.md
+++ b/helius-plugin/skills/build/references/onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-plugin/skills/dflow/references/helius-onboarding.md
+++ b/helius-plugin/skills/dflow/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-plugin/skills/jupiter/references/helius-onboarding.md
+++ b/helius-plugin/skills/jupiter/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-plugin/skills/phantom/references/helius-onboarding.md
+++ b/helius-plugin/skills/phantom/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-skills/helius-dflow/references/helius-onboarding.md
+++ b/helius-skills/helius-dflow/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-skills/helius-jupiter/references/helius-onboarding.md
+++ b/helius-skills/helius-jupiter/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-skills/helius-phantom/references/helius-onboarding.md
+++ b/helius-skills/helius-phantom/references/helius-onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP

--- a/helius-skills/helius/references/onboarding.md
+++ b/helius-skills/helius/references/onboarding.md
@@ -9,7 +9,7 @@ Getting users set up with Helius: creating accounts, obtaining API keys, underst
 | MCP Tool | What It Does |
 |---|---|
 | `setHeliusApiKey` | Configure an existing API key for the session (validates against `getBlockHeight`) |
-| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius-cli/keypair.json`) |
+| `generateKeypair` | Generate or load a Solana keypair for agentic signup (persists to `~/.helius/keypair.json`) |
 | `checkSignupBalance` | Check if the signup wallet has sufficient SOL + USDC |
 | `agenticSignup` | Create a Helius account, pay with USDC, auto-configure API key |
 | `getAccountStatus` | Check current plan, credits remaining, rate limits, billing cycle, burn-rate projections |
@@ -35,7 +35,7 @@ If the environment variable `HELIUS_API_KEY` is already set, no action is needed
 
 The fully autonomous signup flow, no browser needed:
 
-1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius-cli/keypair.json`). Returns the wallet address.
+1. **`generateKeypair`** — generates a new Solana keypair (or loads an existing one from `~/.helius/keypair.json`). Returns the wallet address.
 2. **User funds the wallet** with:
    - ~0.001 SOL for transaction fees
    - 1 USDC for the basic plan (or more for paid plans: $49 Developer, $499 Business, $999 Professional)
@@ -57,7 +57,7 @@ Here, paid plans refers to `"developer"`, `"business"`, and `"professional"`
 The `helius-cli` provides the same autonomous signup from the terminal:
 
 ```bash
-# Generate keypair (saved to ~/.helius-cli/keypair.json)
+# Generate keypair (saved to ~/.helius/keypair.json)
 helius keygen
 
 # Fund the wallet, then sign up (pays 1 USDC for basic plan)
@@ -181,7 +181,7 @@ HELIUS_NETWORK=mainnet-beta          # or devnet (default: mainnet-beta)
 
 The MCP persists API keys and JWTs to shared config files so they survive across sessions:
 - **API key**: saved to shared config path (accessible by both MCP and CLI)
-- **Keypair**: saved to `~/.helius-cli/keypair.json`
+- **Keypair**: saved to `~/.helius/keypair.json`
 - **JWT**: saved to shared config for authenticated session features
 
 ### Installing the MCP


### PR DESCRIPTION
## Summary
Browser-based `helius login` (OAuth/PKCE) for users with existing dashboard accounts. **Supports Google, GitHub, email/password, and wallet sign-in.** Symmetric `logout` + `whoami` round out the auth surface.

## Cross-repo context (merge in this order)
1. Backend: https://github.com/helius-labs/monorepo/pull/15655
2. SDK: https://github.com/helius-labs/helius-sdk/pull/329
3. Dev portal: https://github.com/helius-labs/dev-portal-v2/pull/1161
4. **This PR** (CLI)

## ⚠️ Before merging / publishing v2.0.0
1. Merge & publish the helius-sdk PR (new minor — exposes `oauthTokenExchange`, `HELIUS_API_URL` env, JSON error parsing).
2. Bump `helius-sdk` dep in `helius-cli/package.json` from `^2.2.2` to the new version.
3. Verify `pnpm build` succeeds. Pre-existing errors in `signup.ts` / `checkout.ts` reference SDK functions removed in an unrelated migration — **out of scope here**, separate ticket.
4. Publish `helius-cli@2.0.0`.

## Test plan
- [ ] 6/6 vitest tests pass (`pnpm test`)
- [ ] End-to-end with Google sign-in
- [ ] End-to-end with wallet sign-in (full wallet pubkey on hover, shortened in main text)
- [ ] `helius logout` clears jwt, keeps apiKey; `--all` wipes everything
- [ ] `helius whoami --verify` confirms backend
- [ ] `helius login` after `logout` re-authenticates cleanly
- [ ] Already-logged-in short-circuit prints `Already logged in as ...` and exits 0

## What's outside scope (documented, not fixed)
- The free-plan project-create gate still rejects `authSource='cli'`. CLI users currently create projects via the dashboard, then use the CLI for management. Separate ticket if we want CLI-from-cli project creation.
- WorkOS SSO users rejected at `/oauth/token` with a clear error — domain lockdown was already excluding them. Same posture as before.
- Pre-existing `signup.ts` / `checkout.ts` build errors against the local SDK v3.0.0 — unrelated stale references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)