### PR TITLE
feat(ci): Require and Enforce Signed Commits Repo-wide

### DIFF
--- a/.github/workflows/verify-signed-commits.yml
+++ b/.github/workflows/verify-signed-commits.yml
@@ -1,0 +1,57 @@
+name: Verify Signed Commits
+
+# Enforces the repo-wide signed-commits policy (see CONTRIBUTING.md).
+# Every commit in a PR must be signed AND verified by GitHub against the
+# author's registered signing key. We query GitHub's verification API rather
+# than `git verify-commit` because CI does not have contributors' public keys.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify-signatures:
+    name: Verify commit signatures
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that all PR commits are signed and verified
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "Checking commit signatures for PR #$PR_NUMBER in $REPO"
+          echo
+
+          # One compact JSON object per commit: sha, verified flag, and reason.
+          commits=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '.[] | {sha: .sha, verified: .commit.verification.verified, reason: .commit.verification.reason}')
+
+          unverified=0
+          while IFS= read -r commit; do
+            [ -z "$commit" ] && continue
+            sha=$(printf '%s' "$commit" | jq -r '.sha' | cut -c1-8)
+            verified=$(printf '%s' "$commit" | jq -r '.verified')
+            reason=$(printf '%s' "$commit" | jq -r '.reason')
+            if [ "$verified" = "true" ]; then
+              echo "  verified    $sha"
+            else
+              echo "  UNVERIFIED  $sha  (reason: $reason)"
+              unverified=$((unverified + 1))
+            fi
+          done <<< "$commits"
+
+          echo
+          if [ "$unverified" -gt 0 ]; then
+            echo "::error::$unverified commit(s) are not signed/verified."
+            echo "All commits must be signed. See CONTRIBUTING.md and:"
+            echo "https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
+            exit 1
+          fi
+
+          echo "All commits are signed and verified."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to Core AI
+
+Thank you for contributing to Helius Core AI! This monorepo houses several independent packages:
+
+- `helius-mcp/` — MCP server (npm: `helius-mcp`)
+- `helius-skills/` — Standalone Claude Code skill
+- `helius-plugin/` — Claude Code plugin
+- `helius-cursor/` — Cursor plugin
+- `helius-cli/` — CLI for account setup (npm: `helius-cli`)
+
+This guide covers requirements that apply to **every** contribution, no matter which package you're working on. Some packages have their own `CONTRIBUTING.md` (e.g. [`helius-mcp/CONTRIBUTING.md`](helius-mcp/CONTRIBUTING.md)) with package-specific build, test, and style details — read those too when working in that package.
+
+## Signing Your Commits (Required)
+
+**All commits must be signed and verified.** Pull requests that contain unsigned or unverified commits will fail CI and cannot be merged. This applies to every package in the repo.
+
+A "verified" commit is one GitHub can cryptographically tie to a registered signing key (GPG, SSH, or S/MIME). It shows a green **Verified** badge in the GitHub UI.
+
+### One-time setup
+
+Follow GitHub's official guide to generate a signing key and configure Git to sign your commits:
+
+**https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits**
+
+The short version:
+
+1. Generate or choose a signing key (GPG or SSH) — see the guide above.
+2. Add the **public** key to your GitHub account under **Settings → SSH and GPG keys**.
+3. Tell Git to use it and sign every commit automatically:
+
+   ```bash
+   # SSH signing (simplest if you already have an SSH key on GitHub)
+   git config --global gpg.format ssh
+   git config --global user.signingkey ~/.ssh/id_ed25519.pub
+   git config --global commit.gpgsign true
+
+   # — or — GPG signing
+   git config --global user.signingkey <YOUR_KEY_ID>
+   git config --global commit.gpgsign true
+   ```
+
+   Use `--global` to sign across all repos, or drop it to configure just this repo.
+
+4. Confirm the email on your signing key matches a verified email on your GitHub account, otherwise commits show as **Unverified**.
+
+### Verifying it works
+
+After committing, check the signature locally:
+
+```bash
+git log --show-signature -1
+```
+
+Once pushed, the commit should display a **Verified** badge on GitHub. If you have existing unsigned commits on a branch, you can re-sign them with:
+
+```bash
+git rebase --exec 'git commit --amend --no-edit -S' -i <base-branch>
+```
+
+## Pull Requests
+
+- Fork the repository and create a clearly scoped branch from `main` (e.g. `feat/my-feature`, `fix/bug-description`).
+- Make your changes, ensuring all commits are signed (see above).
+- Run the relevant package's build and tests before submitting (see that package's `CONTRIBUTING.md` or `CLAUDE.md`).
+- Open a pull request with a clear, conventional title (e.g. `feat(mcp): ...`, `fix(cli): ...`, `docs(skills): ...`) and reference any related issues (`Closes #1234`).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the repository's [MIT License](LICENSE).
+
+## Thank You!
+
+Your contributions help power better tools for everyone in the Solana ecosystem. We appreciate it!

--- a/helius-mcp/CONTRIBUTING.md
+++ b/helius-mcp/CONTRIBUTING.md
@@ -19,7 +19,7 @@ To maintain high standards of quality, readability, and performance, code should
 
 **All commits must be signed and verified.** Pull requests containing unsigned or unverified commits will fail CI and cannot be merged. Follow GitHub's official guide to set up commit signing (GPG or SSH):
 
-👉 **https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits**
+**https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits**
 
 Once configured, enable automatic signing with `git config --global commit.gpgsign true` and confirm your commits show a **Verified** badge on GitHub. See the [repo-wide contributing guide](../CONTRIBUTING.md#signing-your-commits-required) for the full walkthrough.
 

--- a/helius-mcp/CONTRIBUTING.md
+++ b/helius-mcp/CONTRIBUTING.md
@@ -15,6 +15,14 @@ To maintain high standards of quality, readability, and performance, code should
 - **Documentation**: Update documentation if your changes affect how the MCP server is used.
 - **Testing**: Add or update tests for any new or modified functionality. Run the full test suite before submitting.
 
+## Signing Your Commits (Required)
+
+**All commits must be signed and verified.** Pull requests containing unsigned or unverified commits will fail CI and cannot be merged. Follow GitHub's official guide to set up commit signing (GPG or SSH):
+
+👉 **https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits**
+
+Once configured, enable automatic signing with `git config --global commit.gpgsign true` and confirm your commits show a **Verified** badge on GitHub. See the [repo-wide contributing guide](../CONTRIBUTING.md#signing-your-commits-required) for the full walkthrough.
+
 ## Pull Requests
 
 Pull Requests are the best way to propose changes. We actively welcome all contributions! To contribute:


### PR DESCRIPTION
This PR makes signed commits an explicit, enforced requirement for all contributions, regardless of which package is touched (CLI, MCP, skills, plugin, cursor)