### PR TITLE
fix(cli): Store Config With Owner-only Permissions

### DIFF
--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -79,7 +79,8 @@ interface Config {
 
 function ensureDir(): void {
   if (!fs.existsSync(CONFIG_DIR)) {
-    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    // Owner-only — the config holds a JWT and API key.
+    fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
   }
 }
 
@@ -139,7 +140,14 @@ export function load(): Config {
 
 export function save(data: Config): void {
   ensureDir();
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(data, null, 2));
+  // Owner-only. `mode` only applies on create, so chmod existing files too
+  // (best-effort: no-op on Windows, must not break save).
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(CONFIG_FILE, 0o600);
+  } catch {
+    // Filesystem may not support POSIX permissions.
+  }
 }
 
 export function getJwt(): string | undefined {

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -8,6 +8,9 @@ const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
 // Alias for backwards compatibility (used by signup.ts)
 export const SHARED_CONFIG_PATH = CONFIG_FILE;
 
+// Warn at most once per process if we can't lock down config permissions.
+let warnedConfigPerms = false;
+
 /**
  * Shared shape for any in-flight checkout pending local resume. Each
  * caller (signup / upgrade / credits) extends with flow-specific identity
@@ -140,13 +143,20 @@ export function load(): Config {
 
 export function save(data: Config): void {
   ensureDir();
-  // Owner-only. `mode` only applies on create, so chmod existing files too
-  // (best-effort: no-op on Windows, must not break save).
+  // Owner-only. `mode` only applies on create, so chmod existing files too.
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
   try {
     fs.chmodSync(CONFIG_FILE, 0o600);
   } catch {
-    // Filesystem may not support POSIX permissions.
+    // Non-fatal (e.g. non-POSIX filesystem), but the file may stay readable by
+    // other users — warn once so credentials aren't silently left exposed.
+    if (!warnedConfigPerms) {
+      warnedConfigPerms = true;
+      console.error(
+        `Warning: could not restrict permissions on ${CONFIG_FILE}; it may be ` +
+          `readable by other users. If possible, run: chmod 600 ${CONFIG_FILE}`,
+      );
+    }
   }
 }
 

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -82,8 +82,15 @@ interface Config {
 
 function ensureDir(): void {
   if (!fs.existsSync(CONFIG_DIR)) {
-    // Owner-only — the config holds a JWT and API key.
     fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+  // Owner-only — the dir holds a JWT and API key. chmod unconditionally: another
+  // path (feedback.ts at module load) may have created it modeless before we got
+  // here, and this also tightens existing installs. Best-effort like the file below.
+  try {
+    fs.chmodSync(CONFIG_DIR, 0o700);
+  } catch {
+    // Non-POSIX filesystem — the save() permission warning already covers this.
   }
 }
 

--- a/helius-cli/src/lib/feedback.ts
+++ b/helius-cli/src/lib/feedback.ts
@@ -22,7 +22,8 @@ try {
   } else {
     sessionId = crypto.randomUUID();
     try {
-      fs.mkdirSync(HELIUS_DIR, { recursive: true });
+      // Owner-only — this dir also holds the JWT/API-key config (see config.ts).
+      fs.mkdirSync(HELIUS_DIR, { recursive: true, mode: 0o700 });
       fs.writeFileSync(ANON_ID_PATH, sessionId, 'utf-8');
     } catch {}
   }


### PR DESCRIPTION
This PR tightens permissions on `~/.helius/config.json` so the credentials it holds (i.e., a JWT session token and the Helius API key) are readable only by the owner. 

TLDR:
- `ensureDir()` creates `~/.helius` with mode `0o700`
- `save()` writes `config.json` with mode `0o600`
- `save()` also `chmod`s the file to `0o600` on every write, so configs created by installs predating this change get tightened on next save. Note that the `mode` write option only applies at file creation
- If chmod fails (e.g., non-POSIX filesystem), warn once to stderr with an actionable hint instead of silently leaving the file exposed