### PR TITLE
chore(mcp): 2.0.0 Release

### DIFF
--- a/helius-mcp/package.json
+++ b/helius-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-mcp",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Official Helius MCP Server - Complete Solana blockchain data access for AI assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/helius-mcp/package.json
+++ b/helius-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helius-mcp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Official Helius MCP Server - Complete Solana blockchain data access for AI assistants",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR bumps `helius-mcp` from `1.3.0` to `2.0.0`. This is the first MCP release since 1.3.0 (Mar 12) and accumulates ~3 months of work, so it warrants a major bump because the public tool surface was restructured 