### PR TITLE
fix(cli): exit non-zero when reclaim batches fail to land

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -60,7 +60,7 @@ import { owsLinkCommand, owsUnlinkCommand, owsStatusCommand } from "../src/comma
 import { updateCommand } from "../src/commands/update.js";
 import { completionsCommand } from "../src/commands/completions.js";
 import { VERSION } from "../src/constants.js";
-import { setDebugEnabled, exitWithError, handleCommandError } from "../src/lib/output.js";
+import { setDebugEnabled, exitWithError, handleCommandError, printFeedbackPrompt } from "../src/lib/output.js";
 import { sendCommandEvent, sendCliFeedback, setCurrentCommand } from "../src/lib/feedback.js";
 
 // Detect --json before Commander parses so boundary-path handlers below
@@ -104,7 +104,7 @@ program
   .hook('postAction', (_thisCommand, actionCommand) => {
     const cmd = actionCommand.name();
     if (!actionCommand.opts().json && cmd !== 'feedback') {
-      console.log('\n' + chalk.yellow(`Please run: helius feedback "<your feedback on ${cmd}>" --feedback-tool ${cmd} --model <your-model>`));
+      printFeedbackPrompt(cmd);
     }
   });
 

--- a/helius-cli/src/commands/reclaim.test.ts
+++ b/helius-cli/src/commands/reclaim.test.ts
@@ -39,11 +39,22 @@ vi.mock("../lib/feedback.js", () => ({
   getCurrentCommand: () => "reclaim",
 }));
 
+// Stub ora so the non-json (terminal) path doesn't drive a real spinner.
+vi.mock("ora", () => {
+  const make = () => {
+    const s: any = { start: () => s, stop: () => s, succeed: () => s, fail: () => s };
+    return s;
+  };
+  return { default: make };
+});
+
 import { reclaimCommand } from "./reclaim.js";
+import { sendCommandEvent } from "../lib/feedback.js";
 
 interface CapturedJson {
   ok: boolean;
   error_code?: string;
+  recoverable?: boolean;
   data?: any;
   details?: any;
 }
@@ -151,6 +162,9 @@ describe("reclaim command", () => {
     expect(json?.ok).toBe(false);
     expect(json?.error_code).toBe("PAYMENT_FAILED");
     expect(exitCode).toBe(22); // ExitCode.PAYMENT_FAILED
+    // Failed batches are transient and re-running is safe, so the envelope must
+    // tell an agent it can retry even though PAYMENT_FAILED is normally terminal.
+    expect(json?.recoverable).toBe(true);
     // The breakdown is preserved so callers still know nothing landed.
     expect(json?.details.closed).toBe(0);
     expect(json?.details.failures).toHaveLength(1);
@@ -169,8 +183,25 @@ describe("reclaim command", () => {
 
     expect(json?.ok).toBe(false);
     expect(exitCode).toBe(22);
+    expect(json?.recoverable).toBe(true);
     expect(json?.details.closed).toBe(1);
     expect(json?.details.successes).toHaveLength(1);
     expect(json?.details.failures).toHaveLength(1);
+  });
+
+  it("on terminal (non-json) failure: records the success:false event, prints the feedback prompt, exits 22", async () => {
+    h.mockGetAllTokenAccounts.mockResolvedValue([emptyAta("Ata1")]);
+    h.mockSendViaSender.mockRejectedValue(new Error("Sender unavailable"));
+
+    // json omitted → terminal mode; yes:true skips the confirm prompt.
+    const { raw, exitCode } = await captureStdout(() =>
+      reclaimCommand(OWNER, { keypair: "/tmp/keypair.json", yes: true }),
+    );
+
+    expect(exitCode).toBe(22);
+    // process.exit() halts before the postAction hook, so reclaim emits both by hand.
+    expect(sendCommandEvent).toHaveBeenCalledWith("reclaim", { success: false, exitCode: 22 });
+    expect(raw).toContain('helius feedback "<your feedback on reclaim>"');
+    expect(raw).toContain("--feedback-tool reclaim");
   });
 });

--- a/helius-cli/src/commands/reclaim.test.ts
+++ b/helius-cli/src/commands/reclaim.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the vi.mock factories below (which run before module init) can use
+// these. OWNER is a valid 43-char base58 pubkey reused for the signer, owner,
+// and destination so the real validateAddress() and the signerAddress === owner
+// guard both pass. The mock fns are re-armed in beforeEach.
+const h = vi.hoisted(() => ({
+  OWNER: "86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY",
+  mockGetAllTokenAccounts: vi.fn(),
+  mockSendViaSender: vi.fn(),
+  mockLoadKeypair: vi.fn(),
+  mockCreateSigner: vi.fn(),
+  mockGetCloseIx: vi.fn(),
+}));
+const { OWNER } = h;
+
+vi.mock("../lib/helius.js", () => ({
+  setupClient: vi.fn().mockResolvedValue({
+    getAllTokenAccountsByOwner: (...args: unknown[]) => h.mockGetAllTokenAccounts(...args),
+    tx: { sendTransactionWithSender: (...args: unknown[]) => h.mockSendViaSender(...args) },
+  }),
+}));
+
+vi.mock("../lib/wallet.js", () => ({
+  loadKeypairFromFile: (...args: unknown[]) => h.mockLoadKeypair(...args),
+}));
+
+vi.mock("@solana/kit", () => ({
+  address: (a: string) => a,
+  createKeyPairSignerFromBytes: (...args: unknown[]) => h.mockCreateSigner(...args),
+}));
+
+vi.mock("@solana-program/token", () => ({
+  getCloseAccountInstruction: (...args: unknown[]) => h.mockGetCloseIx(...args),
+}));
+
+vi.mock("../lib/feedback.js", () => ({
+  sendCommandEvent: vi.fn(),
+  getCurrentCommand: () => "reclaim",
+}));
+
+import { reclaimCommand } from "./reclaim.js";
+
+interface CapturedJson {
+  ok: boolean;
+  error_code?: string;
+  data?: any;
+  details?: any;
+}
+
+function captureStdout(fn: () => Promise<void>) {
+  const chunks: string[] = [];
+  let exitCode: number | null = null;
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    chunks.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n");
+  });
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  // The real process.exit terminates immediately; here we throw to unwind. We
+  // record only the FIRST exit code: a command's own try/catch may re-handle
+  // the thrown sentinel and call process.exit again, which never happens in
+  // production where the first exit halts the process.
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code: any) => {
+    if (exitCode === null) exitCode = typeof code === "number" ? code : 0;
+    throw new Error("__test_exit__");
+  }) as never);
+
+  return fn()
+    .catch((e) => {
+      if (e instanceof Error && e.message === "__test_exit__") return;
+      throw e;
+    })
+    .finally(() => {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    })
+    .then(() => {
+      // Each writeEnvelope() is one console.log call → one chunk. Return the
+      // first JSON envelope emitted (the meaningful one in production).
+      let json: CapturedJson | null = null;
+      for (const c of chunks) {
+        try {
+          const parsed = JSON.parse(c.trim());
+          if (parsed && typeof parsed === "object" && "ok" in parsed) {
+            json = parsed;
+            break;
+          }
+        } catch {
+          /* not a JSON chunk */
+        }
+      }
+      return { json, raw: chunks.join(""), exitCode };
+    });
+}
+
+/** An empty, closable SPL token account owned by OWNER. */
+function emptyAta(pubkey: string) {
+  return {
+    pubkey,
+    account: {
+      lamports: 2_039_280,
+      data: {
+        parsed: {
+          info: {
+            state: "initialized",
+            mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            tokenAmount: { amount: "0" },
+            closeAuthority: null,
+          },
+        },
+      },
+    },
+  };
+}
+
+const baseOpts = {
+  keypair: "/tmp/keypair.json",
+  yes: true,
+  json: true,
+};
+
+describe("reclaim command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.mockGetAllTokenAccounts.mockReset();
+    h.mockSendViaSender.mockReset();
+    h.mockLoadKeypair.mockResolvedValue({ secretKey: new Uint8Array(64) });
+    h.mockCreateSigner.mockResolvedValue({ address: OWNER });
+    h.mockGetCloseIx.mockReturnValue({});
+  });
+
+  it("returns ok:true and exit 0 when every batch lands", async () => {
+    h.mockGetAllTokenAccounts.mockResolvedValue([emptyAta("Ata1")]);
+    h.mockSendViaSender.mockResolvedValue("sig-1");
+
+    const { json, exitCode } = await captureStdout(() => reclaimCommand(OWNER, baseOpts));
+
+    expect(json?.ok).toBe(true);
+    expect(json?.data.closed).toBe(1);
+    expect(json?.data.failures).toHaveLength(0);
+    // Success path never calls process.exit → natural exit 0.
+    expect(exitCode).toBeNull();
+  });
+
+  it("returns ok:false and exits non-zero when every batch fails to land", async () => {
+    h.mockGetAllTokenAccounts.mockResolvedValue([emptyAta("Ata1"), emptyAta("Ata2")]);
+    h.mockSendViaSender.mockRejectedValue(new Error("Sender unavailable"));
+
+    const { json, exitCode } = await captureStdout(() => reclaimCommand(OWNER, baseOpts));
+
+    expect(json?.ok).toBe(false);
+    expect(json?.error_code).toBe("PAYMENT_FAILED");
+    expect(exitCode).toBe(22); // ExitCode.PAYMENT_FAILED
+    // The breakdown is preserved so callers still know nothing landed.
+    expect(json?.details.closed).toBe(0);
+    expect(json?.details.failures).toHaveLength(1);
+  });
+
+  it("exits non-zero on partial failure but still reports the landed batches", async () => {
+    // batch-size 1 → two single-account batches; first lands, second fails.
+    h.mockGetAllTokenAccounts.mockResolvedValue([emptyAta("Ata1"), emptyAta("Ata2")]);
+    h.mockSendViaSender
+      .mockResolvedValueOnce("sig-1")
+      .mockRejectedValueOnce(new Error("boom"));
+
+    const { json, exitCode } = await captureStdout(() =>
+      reclaimCommand(OWNER, { ...baseOpts, batchSize: "1" }),
+    );
+
+    expect(json?.ok).toBe(false);
+    expect(exitCode).toBe(22);
+    expect(json?.details.closed).toBe(1);
+    expect(json?.details.successes).toHaveLength(1);
+    expect(json?.details.failures).toHaveLength(1);
+  });
+});

--- a/helius-cli/src/commands/reclaim.ts
+++ b/helius-cli/src/commands/reclaim.ts
@@ -9,6 +9,7 @@ import { formatSol } from "../lib/formatters.js";
 import {
   outputJson,
   exitWithError,
+  getExitCode,
   handleCommandError,
   createSpinner,
   withRetry,
@@ -400,21 +401,35 @@ export async function reclaimCommand(
       0,
     );
 
+    const summary = {
+      owner,
+      destination: String(destination),
+      region: options.region || "Default",
+      swqosOnly: !!options.swqosOnly,
+      batchSize,
+      totalBatches: batches.length,
+      closed: closedCount,
+      reclaimedLamports,
+      reclaimedSol: reclaimedLamports / 1_000_000_000,
+      successes,
+      failures,
+    };
+
     if (options.json) {
-      outputJson({
-        owner,
-        destination: String(destination),
-        region: options.region || "Default",
-        swqosOnly: !!options.swqosOnly,
-        batchSize,
-        totalBatches: batches.length,
-        closed: closedCount,
-        reclaimedLamports,
-        reclaimedSol: reclaimedLamports / 1_000_000_000,
-        successes,
-        failures,
-      });
-      return;
+      // A failed batch must never be reported as success: scripts and agents
+      // key off the exit code and the envelope `ok` flag. Emit a success
+      // envelope only when every batch landed; otherwise emit an error
+      // envelope (non-zero exit) that still carries the full breakdown under
+      // `details` so callers can see which batches are already on-chain.
+      if (failures.length === 0) {
+        outputJson(summary);
+        return;
+      }
+      exitWithError(
+        "PAYMENT_FAILED",
+        `${failures.length} of ${batches.length} reclaim batch(es) failed to land; ${closedCount} of ${toClose.length} account(s) closed.`,
+        summary,
+      );
     }
 
     console.log(chalk.bold("\nReclaim complete:\n"));
@@ -439,6 +454,9 @@ export async function reclaimCommand(
           "\n  Re-run the command to retry. Successful batches are already on-chain.",
         ),
       );
+      // Mirror the JSON path: a partial or total failure must exit non-zero so
+      // scripts wrapping the CLI don't treat it as a clean success.
+      process.exit(getExitCode("PAYMENT_FAILED"));
     }
   } catch (error) {
     handleCommandError(error, options, spinner);

--- a/helius-cli/src/commands/reclaim.ts
+++ b/helius-cli/src/commands/reclaim.ts
@@ -15,9 +15,11 @@ import {
   withRetry,
   confirm,
   isAgent,
+  printFeedbackPrompt,
   type OutputOptions,
   type RetryOptions,
 } from "../lib/output.js";
+import { sendCommandEvent, getCurrentCommand } from "../lib/feedback.js";
 import { validateAddress } from "../lib/validation.js";
 
 const TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
@@ -425,10 +427,17 @@ export async function reclaimCommand(
         outputJson(summary);
         return;
       }
+      // recoverable:true — re-running is safe (closed accounts are skipped on the
+      // next scan) and failed batches are usually transient (rate-limited / Sender
+      // down). Without the override the envelope would say recoverable:false while
+      // the message advises re-running, so an agent keying off `recoverable`
+      // wouldn't auto-retry. See exitWithError's default-classification note.
       exitWithError(
         "PAYMENT_FAILED",
         `${failures.length} of ${batches.length} reclaim batch(es) failed to land; ${closedCount} of ${toClose.length} account(s) closed.`,
         summary,
+        !!options.json,
+        { recoverable: true },
       );
     }
 
@@ -455,8 +464,15 @@ export async function reclaimCommand(
         ),
       );
       // Mirror the JSON path: a partial or total failure must exit non-zero so
-      // scripts wrapping the CLI don't treat it as a clean success.
-      process.exit(getExitCode("PAYMENT_FAILED"));
+      // scripts wrapping the CLI don't treat it as a clean success. process.exit()
+      // halts before Commander's postAction hook runs, so we record the
+      // success:false telemetry event (otherwise only the preAction success:true
+      // event lands) and print the feedback prompt by hand before exiting.
+      const exitCode = getExitCode("PAYMENT_FAILED");
+      const cmd = getCurrentCommand() ?? "reclaim";
+      sendCommandEvent(cmd, { success: false, exitCode });
+      printFeedbackPrompt(cmd);
+      process.exit(exitCode);
     }
   } catch (error) {
     handleCommandError(error, options, spinner);

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -420,14 +420,35 @@ export function outputJson(data: unknown): void {
   writeEnvelope({ ok: true, v: ENVELOPE_VERSION, data });
 }
 
+/**
+ * Print the post-command "share feedback" nudge. This mirrors the program's
+ * postAction hook (see bin/helius.ts). It lives here so command paths that call
+ * process.exit() before Commander runs postAction — like reclaim's non-zero
+ * terminal exit — can emit the same prompt instead of silently dropping it.
+ */
+export function printFeedbackPrompt(commandName: string): void {
+  console.log(
+    "\n" +
+      chalk.yellow(
+        `Please run: helius feedback "<your feedback on ${commandName}>" --feedback-tool ${commandName} --model <your-model>`,
+      ),
+  );
+}
+
 export function exitWithError(
   errorCode: string,
   message: string,
   details?: Record<string, unknown>,
   json = true,
+  opts?: { recoverable?: boolean },
 ): never {
   const exitCode = getExitCode(errorCode);
-  const retryable = RETRYABLE_CODES.has(exitCode);
+  // recoverable defaults to the exit code's classification, but callers can
+  // override it when they know better. reclaim does this: a failed broadcast
+  // batch is transient (rate-limited / Sender down) and the command tells the
+  // user to re-run, so the envelope must report recoverable:true even though
+  // PAYMENT_FAILED is non-retryable for genuine payment failures.
+  const retryable = opts?.recoverable ?? RETRYABLE_CODES.has(exitCode);
 
   const cmdName = getCurrentCommand() || 'unknown';
   sendCommandEvent(cmdName, { exitCode, success: false });


### PR DESCRIPTION
hey, its moondev. was reading through helius-cli and hit a bug in `helius reclaim` that i think matters for anyone scripting against it.

### what's wrong

the batch send loop is continue-on-error (collects successes/failures, doesn't abort), which is the right call. but the summarize step at the end always reports success: in `--json` mode it calls `outputJson(...)` which emits `{ ok: true, ... }`, and in terminal mode it just prints and returns. either way the process exits 0.

so if every batch fails to broadcast (sender down, rate limited, tip too low, whatever), the command still exits 0 with `ok: true`. a script doing `helius reclaim --json && ...` treats a fully failed run as success, the rent never actually gets reclaimed, and nobody knows. same story for partial failures.

the readme pitches the cli as "built for developers and LLM agents to ... automate workflows", and agents/scripts key off the exit code and the `ok` flag, so this felt worth fixing.

### the fix

if any batch fails to land, exit non-zero (`PAYMENT_FAILED` / 22):

- `--json`: emit an error envelope (`ok: false`) with the full breakdown under `details` (closed count + per-batch successes and failures) so callers still see which batches landed
- terminal: keep the existing summary output, just exit non-zero at the end

fully successful runs are untouched (still `ok: true` / exit 0).

### tests

added `src/commands/reclaim.test.ts` covering all-fail, partial-fail, and all-succeed. ran the full helius-cli suite, 45 passing. commit is signed/verified per CONTRIBUTING.

not a huge change but should save someone a confusing debugging session. cheers
