### PR TITLE
feat(cli): Add Confirmation Prompts For Destructive Commands

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -255,6 +255,7 @@ program
   .command("logout")
   .description("Sign out and clear the local session token (keeps API key by default)")
   .option("--all", "Wipe the entire local config (jwt, apiKey, projectId, network, owsWallet)")
+  .option("-y, --yes", "Skip confirmation prompt (only relevant with --all)")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -843,6 +844,7 @@ webhookCmd
   .command("delete <id>")
   .description("Delete a webhook")
   .option("--dry-run", "Preview which webhook would be deleted")
+  .option("-y, --yes", "Skip confirmation prompt")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -911,6 +913,7 @@ stakeCmd
   .command("unstake <stake-account>")
   .description("Create an unstake transaction")
   .option("-k, --keypair <path>", "Path to Solana keypair file")
+  .option("-y, --yes", "Skip confirmation prompt")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -921,6 +924,7 @@ stakeCmd
   .command("withdraw <stake-account>")
   .description("Create a withdraw transaction")
   .option("-k, --keypair <path>", "Path to Solana keypair file")
+  .option("-y, --yes", "Skip confirmation prompt")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:

--- a/helius-cli/src/commands/logout.ts
+++ b/helius-cli/src/commands/logout.ts
@@ -5,11 +5,13 @@ import {
   outputJson,
   handleCommandError,
   createSpinner,
+  confirmDestructive,
   type OutputOptions,
 } from "../lib/output.js";
 
 interface LogoutOptions extends OutputOptions {
   all?: boolean;
+  yes?: boolean;
 }
 
 export async function logoutCommand(options: LogoutOptions): Promise<void> {
@@ -30,6 +32,13 @@ export async function logoutCommand(options: LogoutOptions): Promise<void> {
     }
 
     if (options.all) {
+      if (!(await confirmDestructive(
+        chalk.yellow("\n  Wipe the entire local config (jwt, apiKey, projectId, network, owsWallet)? (y/N) "),
+        options,
+      ))) {
+        console.log(chalk.gray("  Cancelled."));
+        return;
+      }
       clearConfig();
       spinner?.succeed("Cleared local config");
     } else {

--- a/helius-cli/src/commands/stake.ts
+++ b/helius-cli/src/commands/stake.ts
@@ -1,10 +1,12 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatSol } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, confirmDestructive, type OutputOptions, type RetryOptions } from "../lib/output.js";
 import { validateAddress } from "../lib/validation.js";
 
-interface StakeOptions extends OutputOptions, ResolveOptions, RetryOptions {}
+interface StakeOptions extends OutputOptions, ResolveOptions, RetryOptions {
+  yes?: boolean;
+}
 
 interface AmountOptions {
   amount?: string;     // --amount <sol> (human-readable, e.g. "1.5")
@@ -218,6 +220,13 @@ export async function stakeUnstakeCommand(stakeAccount: string, options: StakeOp
   try {
     const addrErr = validateAddress(stakeAccount);
     if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
+    if (!(await confirmDestructive(
+      chalk.yellow(`\n  Sign an unstake (deactivate) transaction for ${stakeAccount} with this keypair? (y/N) `),
+      options,
+    ))) {
+      console.log(chalk.gray("  Cancelled."));
+      return;
+    }
     const helius = await setupClient(spinner, options, "Creating unstake transaction...");
     const result = await withRetry(() => helius.stake.createUnstakeTransaction(stakeAccount as any), options, spinner);
     spinner?.stop();
@@ -239,6 +248,13 @@ export async function stakeWithdrawCommand(stakeAccount: string, options: StakeO
   try {
     const addrErr = validateAddress(stakeAccount);
     if (addrErr) exitWithError("INVALID_ADDRESS", addrErr, undefined, !!options.json);
+    if (!(await confirmDestructive(
+      chalk.yellow(`\n  Sign a withdraw transaction for ${stakeAccount} with this keypair? (y/N) `),
+      options,
+    ))) {
+      console.log(chalk.gray("  Cancelled."));
+      return;
+    }
     const helius = await setupClient(spinner, options, "Creating withdraw transaction...");
     const result = await withRetry(() => helius.stake.createWithdrawTransaction(stakeAccount as any), options, spinner);
     spinner?.stop();

--- a/helius-cli/src/commands/webhook.ts
+++ b/helius-cli/src/commands/webhook.ts
@@ -1,11 +1,12 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
 import { formatEnumLabel } from "../lib/formatters.js";
-import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, confirmDestructive, type OutputOptions, type RetryOptions } from "../lib/output.js";
 import { validateSolanaAddresses } from "../lib/validation.js";
 
 interface WebhookOptions extends OutputOptions, ResolveOptions, RetryOptions {
   dryRun?: boolean;
+  yes?: boolean;
 }
 
 export async function webhookListCommand(options: WebhookOptions = {}): Promise<void> {
@@ -151,6 +152,14 @@ export async function webhookDeleteCommand(webhookId: string, options: WebhookOp
       spinner?.succeed("Dry run — webhook not deleted");
       if (options.json) { outputJson({ dryRun: true, webhookID: webhookId }); return; }
       console.log(chalk.yellow(`\n  Dry run — webhook ${webhookId} would be deleted.`));
+      return;
+    }
+
+    if (!(await confirmDestructive(
+      chalk.yellow(`\n  Delete webhook ${webhookId}? This cannot be undone. (y/N) `),
+      options,
+    ))) {
+      console.log(chalk.gray("  Cancelled."));
       return;
     }
 

--- a/helius-cli/src/lib/output.ts
+++ b/helius-cli/src/lib/output.ts
@@ -496,3 +496,21 @@ export function confirm(question: string): Promise<boolean> {
     });
   });
 }
+
+/**
+ * Gate a destructive action behind an interactive y/N prompt.
+ * Returns `true` when the action should proceed.
+ *
+ * The prompt is skipped (and the action proceeds) when the user passed
+ * `--yes`, when output is `--json`, in agent mode (`NO_DNA`), or when stdin is
+ * not a TTY (CI / pipes). This preserves backward-compatible scriptability —
+ * these commands had no confirmation before — while protecting interactive
+ * users from accidental destructive actions.
+ */
+export async function confirmDestructive(
+  question: string,
+  options: { yes?: boolean; json?: boolean } = {},
+): Promise<boolean> {
+  if (options.yes || options.json || isAgent || !process.stdin.isTTY) return true;
+  return confirm(question);
+}

--- a/helius-cli/tests/confirm.test.ts
+++ b/helius-cli/tests/confirm.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock readline so the interactive prompt path is controllable.
+const questionMock = vi.fn<(q: string, cb: (answer: string) => void) => void>();
+vi.mock("readline", () => ({
+  default: {
+    createInterface: () => ({
+      question: (q: string, cb: (a: string) => void) => questionMock(q, cb),
+      close: () => {},
+    }),
+  },
+}));
+
+import { confirmDestructive } from "../src/lib/output.js";
+
+const originalIsTTY = process.stdin.isTTY;
+
+function setTTY(value: boolean) {
+  Object.defineProperty(process.stdin, "isTTY", { value, configurable: true });
+}
+
+afterEach(() => {
+  Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
+  questionMock.mockReset();
+});
+
+describe("confirmDestructive", () => {
+  it("proceeds without prompting when --yes is passed", async () => {
+    setTTY(true);
+    expect(await confirmDestructive("Delete? ", { yes: true })).toBe(true);
+    expect(questionMock).not.toHaveBeenCalled();
+  });
+
+  it("proceeds without prompting in --json mode", async () => {
+    setTTY(true);
+    expect(await confirmDestructive("Delete? ", { json: true })).toBe(true);
+    expect(questionMock).not.toHaveBeenCalled();
+  });
+
+  it("proceeds without prompting in non-interactive (non-TTY) contexts", async () => {
+    setTTY(false);
+    expect(await confirmDestructive("Delete? ", {})).toBe(true);
+    expect(questionMock).not.toHaveBeenCalled();
+  });
+
+  it("prompts on a TTY and proceeds when the user answers yes", async () => {
+    setTTY(true);
+    questionMock.mockImplementation((_q, cb) => cb("y"));
+    expect(await confirmDestructive("Delete? ", {})).toBe(true);
+    expect(questionMock).toHaveBeenCalledOnce();
+  });
+
+  it("prompts on a TTY and aborts when the user answers no", async () => {
+    setTTY(true);
+    questionMock.mockImplementation((_q, cb) => cb(""));
+    expect(await confirmDestructive("Delete? ", {})).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR adds an interactive confirmation prompt before destructive CLI actions, since these commands were previously executed without confirmation. Each command also gains a `-y, --yes` flag to skip the prompt.

The following commands were gated:

| Command | Why it's destructive |
|---|---|
| `webhook delete <id>` | Deletes a webhook server-side, which is irreversible |
| `logout --all` | Wipes the entire local config (`jwt`, `apiKey`, `projectId`, `network`, `owsWallet`) |
| `stake unstake <acct>` | Signs a deactivate transaction with a user's keypair |
| `stake withdraw <acct>` | Signs a withdraw transaction with a user's keypair |

Note that it prompts only for an interactive human and auto-proceeds (i.e., no prompt) when any of these hold:

| Context | Prompt? |
|---|---|
| `--yes` | No |
| `--json` | No |
| Agent mode (`NO_DNA`) | No |
| Non-TTY (CI / pipes) | No |
| Interactive TTY, no flags | **Yes** (`y`/`yes` proceeds, anything else cancels) |