### PR TITLE
feat(cli): Add Confirmation Prompt Before Submitting Transactions

### DIFF
--- a/helius-cli/bin/helius.ts
+++ b/helius-cli/bin/helius.ts
@@ -1214,6 +1214,7 @@ sendCmd
   .command("broadcast <base64-tx>")
   .description("Broadcast a signed transaction and poll for confirmation")
   .option("--dry-run", "Preview without submitting the transaction")
+  .option("-y, --yes", "Skip confirmation prompt")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1224,6 +1225,7 @@ sendCmd
   .command("raw <base64-tx>")
   .description("Send a raw transaction")
   .option("--dry-run", "Preview without submitting the transaction")
+  .option("-y, --yes", "Skip confirmation prompt")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:
@@ -1235,6 +1237,7 @@ sendCmd
   .description("Send via Helius Sender for ultra-low latency")
   .option("--region <region>", "Sender region (Default, US_SLC, US_EAST, etc.)")
   .option("--dry-run", "Preview without submitting the transaction")
+  .option("-y, --yes", "Skip confirmation prompt")
   .option("--json", "Output in JSON format")
   .addHelpText('after', `
 Examples:

--- a/helius-cli/src/commands/send.ts
+++ b/helius-cli/src/commands/send.ts
@@ -1,10 +1,11 @@
 import chalk from "chalk";
 import { setupClient, type ResolveOptions } from "../lib/helius.js";
-import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, type OutputOptions, type RetryOptions } from "../lib/output.js";
+import { outputJson, exitWithError, handleCommandError, createSpinner, withRetry, confirmDestructive, type OutputOptions, type RetryOptions } from "../lib/output.js";
 import { validateSignature } from "../lib/validation.js";
 
 interface SendOptions extends OutputOptions, ResolveOptions, RetryOptions {
   dryRun?: boolean;
+  yes?: boolean;
 }
 
 export async function sendBroadcastCommand(base64Tx: string, options: SendOptions = {}): Promise<void> {
@@ -14,6 +15,14 @@ export async function sendBroadcastCommand(base64Tx: string, options: SendOption
       spinner?.succeed("Dry run — transaction not submitted");
       if (options.json) { outputJson({ dryRun: true, transaction: base64Tx }); return; }
       console.log(chalk.yellow("\n  Dry run — transaction would be broadcast but was not submitted."));
+      return;
+    }
+
+    if (!(await confirmDestructive(
+      chalk.yellow("\n  Broadcast this transaction to the network? (y/N) "),
+      options,
+    ))) {
+      console.log(chalk.gray("  Cancelled."));
       return;
     }
 
@@ -39,6 +48,14 @@ export async function sendRawCommand(base64Tx: string, options: SendOptions = {}
       return;
     }
 
+    if (!(await confirmDestructive(
+      chalk.yellow("\n  Send this transaction to the network? (y/N) "),
+      options,
+    ))) {
+      console.log(chalk.gray("  Cancelled."));
+      return;
+    }
+
     const helius = await setupClient(spinner, options, "Sending transaction...");
     const signature = await withRetry(() => helius.tx.sendTransaction({ base64: base64Tx }), options, spinner);
     spinner?.stop();
@@ -59,6 +76,14 @@ export async function sendSenderCommand(base64Tx: string, options: SendOptions &
       spinner?.succeed("Dry run — transaction not submitted");
       if (options.json) { outputJson({ dryRun: true, transaction: base64Tx, region }); return; }
       console.log(chalk.yellow(`\n  Dry run — transaction would be sent via Helius Sender (${region}) but was not submitted.`));
+      return;
+    }
+
+    if (!(await confirmDestructive(
+      chalk.yellow(`\n  Send this transaction via Helius Sender (${options.region || "Default"})? (y/N) `),
+      options,
+    ))) {
+      console.log(chalk.gray("  Cancelled."));
       return;
     }
 


### PR DESCRIPTION
This PR is a follow-up to the destructive-command confirmation work added in #133 that adds a confirmation prompt before the `send` subcommands that actually submit a transaction on-chain, closing the gap noted there (the stake commands only sign; `send` is what hits the network)

The following commands are gated with `-y, --yes`:

| Command | Action |
|---|---|
| `send broadcast <tx>` | Broadcasts a signed transaction |
| `send raw <tx>` | Sends a raw transaction |
| `send sender <tx>` | Submits via Helius Sender |

`send poll` (i.e., read-only confirmation polling) and `send compute-units` (i.e., simulation only) are not gated