### PR TITLE
feat(mcp): Add `simulateTransaction` Tool For Pre-Send Transaction Dry-Runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ Each skill has:
 - Always include `maxRetries: 0` when using Sender
 - Always include a Jito tip (minimum 0.0002 SOL) and priority fee
 - Use `heliusChain` + `getPriorityFeeEstimate` to get fee levels — never hardcode fees
+- Use `heliusChain` + `simulateTransaction` to dry-run a transaction before sending — checks success/failure, compute units, and logs without submitting on-chain
 
 ### Data Queries
 - Use `heliusTransaction` + `parseTransactions` over raw RPC for human-readable transaction data

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The server exposes 10 public tools total: 9 routed domain tools plus `expandResu
 - `heliusWallet` — wallet balances, holdings, identity, wallet history
 - `heliusAsset` — assets, NFTs, collections, token holders
 - `heliusTransaction` — parsed transactions and wallet transaction history
-- `heliusChain` — raw chain state, token accounts, blocks, network status, stake reads, priority fees
+- `heliusChain` — raw chain state, token accounts, blocks, network status, stake reads, priority fees, transaction simulation
 - `heliusStreaming` — webhook CRUD and live subscription configuration
 - `heliusKnowledge` — docs, guides, pricing references, troubleshooting, source, blog, SIMDs
 - `heliusWrite` — SOL/token transfers and staking mutations

--- a/helius-mcp/README.md
+++ b/helius-mcp/README.md
@@ -78,7 +78,7 @@ Helius MCP exposes 10 public tools total: 9 routed domain tools plus `expandResu
 - `heliusWallet` — wallet balances, holdings, wallet history, identity
 - `heliusAsset` — assets, NFTs, collections, token holders
 - `heliusTransaction` — transaction parsing and wallet transaction history
-- `heliusChain` — chain state, token accounts, blocks, network status, stake reads
+- `heliusChain` — chain state, token accounts, blocks, network status, stake reads, transaction simulation
 - `heliusStreaming` — webhook CRUD and subscription config
 - `heliusKnowledge` — docs, guides, pricing, troubleshooting, source, blog, SIMDs
 - `heliusWrite` — transfers and staking mutations

--- a/helius-mcp/src/router/actions.ts
+++ b/helius-mcp/src/router/actions.ts
@@ -49,6 +49,7 @@ export const HELIUS_CHAIN_ACTIONS = [
   'getBlock',
   'getNetworkStatus',
   'getPriorityFeeEstimate',
+  'simulateTransaction',
   'getStakeAccounts',
   'getWithdrawableAmount',
 ] as const;

--- a/helius-mcp/src/router/instructions.ts
+++ b/helius-mcp/src/router/instructions.ts
@@ -7,7 +7,7 @@ Routing:
 - Wallet-centric balances, holdings, identity, wallet history: \`heliusWallet\`
 - Assets, NFTs, collections, token holders: \`heliusAsset\`
 - Parsed transactions or wallet transaction history: \`heliusTransaction\`
-- Raw chain state, token accounts, stake reads, blocks, network status, priority fees: \`heliusChain\`
+- Raw chain state, token accounts, stake reads, blocks, network status, priority fees, transaction simulation: \`heliusChain\`
 - Webhook CRUD or live subscription configuration: \`heliusStreaming\`
 - Docs, guides, pricing references, troubleshooting, source, blog, SIMDs: \`heliusKnowledge\`
 - SOL/token transfers or staking mutations: \`heliusWrite\`

--- a/helius-mcp/src/router/register.ts
+++ b/helius-mcp/src/router/register.ts
@@ -45,7 +45,7 @@ export function registerRouterTools(server: McpServer): void {
 
   server.tool(
     'heliusChain',
-    'Raw chain state, token accounts, stake reads, blocks, network status, and priority fees. Use for token accounts or blocks, not wallet portfolio summaries.',
+    'Raw chain state, token accounts, stake reads, blocks, network status, priority fees, and transaction simulation. Use for token accounts or blocks, not wallet portfolio summaries.',
     HELIUS_CHAIN_SCHEMA,
     withTelemetryHandler('heliusChain', (params, extra) => dispatchRoutedTool('heliusChain', params, extra)),
   );

--- a/helius-mcp/src/router/required-params.ts
+++ b/helius-mcp/src/router/required-params.ts
@@ -35,6 +35,7 @@ export const ACTION_REQUIRED_PARAMS: Partial<Record<ActionName, string[]>> = {
   getTokenHolders: ['mint'],
   getProgramAccounts: ['programId'],
   getBlock: ['slot'],
+  simulateTransaction: ['transaction'],
   getWithdrawableAmount: ['stakeAccount'],
 
   // Streaming

--- a/helius-mcp/src/router/schemas.ts
+++ b/helius-mcp/src/router/schemas.ts
@@ -129,6 +129,11 @@ export const HELIUS_CHAIN_SCHEMA = withTelemetry({
   dataSize: optionalNumber(),
   owner: optionalString(),
   mint: optionalString(),
+  // simulateTransaction
+  transaction: optionalString(),
+  sigVerify: optionalBoolean(),
+  replaceRecentBlockhash: optionalBoolean(),
+  commitment: optionalString(),
 });
 
 export const HELIUS_STREAMING_SCHEMA = withTelemetry({

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -499,6 +499,119 @@ export function registerTransactionTools(server: McpServer) {
     }
   );
 
+  // Simulate Transaction (preflight dry-run — does NOT submit on-chain)
+  server.tool(
+    'simulateTransaction',
+    'BEST FOR: dry-running a transaction before sending. Simulates a base64-encoded transaction against current chain state and returns whether it would succeed/fail, the program error (if any), compute units consumed, program logs, return data, and — when `addresses` are provided — post-simulation account state. Does NOT submit anything on-chain. Defaults: replaces the recent blockhash (so unsigned or stale-blockhash transactions can still be simulated) and skips signature verification. Set sigVerify=true to verify signatures (requires a valid recent blockhash; mutually exclusive with replaceRecentBlockhash). Credit cost: 1 credit/call.',
+    {
+      transaction: z.string().describe('Base64-encoded serialized transaction (not base58). Signed or unsigned.'),
+      sigVerify: z.boolean().optional().default(false).describe('Verify transaction signatures. Requires a valid recent blockhash. Mutually exclusive with replaceRecentBlockhash (sigVerify wins if both set).'),
+      replaceRecentBlockhash: z.boolean().optional().default(true).describe('Replace the recent blockhash with the latest before simulating (default true) so unsigned/stale transactions can be simulated. Ignored when sigVerify=true.'),
+      commitment: z.string().optional().describe('Commitment level: "processed" | "confirmed" | "finalized".'),
+      addresses: z.array(z.string()).optional().describe('Optional account addresses (base58) to return post-simulation state for.')
+    },
+    async ({ transaction, sigVerify, replaceRecentBlockhash, commitment, addresses }) => {
+      if (!hasApiKey()) return noApiKeyResponse();
+
+      if (typeof transaction !== 'string' || transaction.trim().length === 0) {
+        return mcpError('A base64-encoded transaction string is required.', {
+          type: 'VALIDATION',
+          code: 'INVALID_TRANSACTION',
+          retryable: false,
+          recovery: 'Pass the base64-encoded (not base58) serialized transaction in the `transaction` field.',
+        });
+      }
+
+      if (commitment) {
+        const err = validateEnum(commitment, ['processed', 'confirmed', 'finalized'], 'Simulate Transaction Error', 'commitment');
+        if (err) return err;
+      }
+
+      const helius = getHeliusClient();
+
+      // sigVerify and replaceRecentBlockhash are mutually exclusive at the RPC layer.
+      const verify = sigVerify === true;
+      const replaceBlockhash = verify ? false : replaceRecentBlockhash !== false;
+
+      const config: Record<string, unknown> = {
+        encoding: 'base64',
+        sigVerify: verify,
+        replaceRecentBlockhash: replaceBlockhash,
+      };
+      if (commitment) config.commitment = commitment;
+      if (addresses && addresses.length > 0) {
+        config.accounts = { encoding: 'base64', addresses };
+      }
+
+      type SimAccount = { lamports: number | bigint; owner: string; executable: boolean } | null;
+      type SimValue = {
+        err: unknown;
+        logs: string[] | null;
+        unitsConsumed?: number | bigint | null;
+        returnData?: { programId: string; data: [string, string] } | null;
+        accounts?: SimAccount[] | null;
+      };
+      type SimResult = { context?: { slot?: number | bigint }; value?: SimValue };
+
+      let result: SimResult;
+      try {
+        result = await (helius as any).simulateTransaction(transaction, config) as SimResult;
+      } catch (err) {
+        return handleToolError(err, 'Simulate Transaction Error', [
+          http400Error('Simulate Transaction Error'),
+        ]);
+      }
+
+      const value = result?.value;
+      if (!value) {
+        return mcpText('**Transaction Simulation**\n\nNo simulation result was returned by the RPC.');
+      }
+
+      const failed = value.err != null;
+      const lines: string[] = ['**Transaction Simulation**', ''];
+
+      if (result.context?.slot != null) {
+        lines.push(`**Simulated at slot:** ${Number(result.context.slot).toLocaleString()}`);
+      }
+      lines.push(`**Status:** ${failed ? '❌ Would fail' : '✅ Would succeed'}`);
+
+      if (failed) {
+        const errStr = typeof value.err === 'object' ? JSON.stringify(value.err) : String(value.err);
+        lines.push(`**Error:** ${errStr}`);
+      }
+      if (value.unitsConsumed != null) {
+        lines.push(`**Compute Units Consumed:** ${Number(value.unitsConsumed).toLocaleString()}`);
+      }
+      lines.push(`**Signature verification:** ${verify ? 'on' : 'off'} | **Replace blockhash:** ${replaceBlockhash ? 'on' : 'off'}`);
+
+      if (value.returnData?.data?.[0]) {
+        lines.push('', `**Return Data** (program \`${value.returnData.programId}\`):`, `\`${value.returnData.data[0]}\``);
+      }
+
+      if (value.logs && value.logs.length > 0) {
+        lines.push('', `**Program Logs (${value.logs.length}):**`, '```');
+        value.logs.forEach((log) => lines.push(log));
+        lines.push('```');
+      } else {
+        lines.push('', '_No program logs returned._');
+      }
+
+      if (config.accounts && Array.isArray(value.accounts)) {
+        lines.push('', '**Post-Simulation Account State:**');
+        (addresses as string[]).forEach((addr, i) => {
+          const acc = value.accounts![i];
+          if (!acc) {
+            lines.push(`- ${formatAddress(addr)}: (not found or empty)`);
+          } else {
+            lines.push(`- ${formatAddress(addr)}: ${formatSol(Number(acc.lamports))}, owner ${acc.owner}${acc.executable ? ' (executable)' : ''}`);
+          }
+        });
+      }
+
+      return mcpText(truncateResponse(lines.join('\n')));
+    }
+  );
+
   // Get Transaction History (unified: parsed, signatures, or raw mode)
   server.tool(
     'getTransactionHistory',

--- a/helius-mcp/tests/tools.test.ts
+++ b/helius-mcp/tests/tools.test.ts
@@ -20,7 +20,7 @@ import { normalizeTelemetry } from '../src/router/telemetry.js';
 import { clearStoredResults, getStoredResult, getStoredResultStats, putStoredResult } from '../src/results/store.js';
 import { getRouterContext } from '../src/router/context.js';
 import { registerTools } from '../src/tools/index.js';
-import { hasApiKey } from '../src/utils/helius.js';
+import { hasApiKey, getHeliusClient } from '../src/utils/helius.js';
 import { callActionHandler, type ActionHandlerResponse } from '../src/router/action-handlers.js';
 
 vi.mock('../src/router/action-handlers.js', async (importOriginal) => {
@@ -361,6 +361,83 @@ describe('Dispatch per routed tool', () => {
     );
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text).toContain('Epoch');
+  });
+
+  it('heliusChain — simulateTransaction formats a successful simulation', async () => {
+    vi.mocked(getHeliusClient).mockReturnValueOnce({
+      simulateTransaction: async (_tx: string, _cfg: unknown) => ({
+        context: { slot: 250_000_000 },
+        value: { err: null, logs: ['Program log: hello'], unitsConsumed: 4200, returnData: null, accounts: null },
+      }),
+    } as unknown as ReturnType<typeof getHeliusClient>);
+
+    const result = await tools.heliusChain.handler(
+      { action: 'simulateTransaction', transaction: 'AQABz000base64', ...telemetry() },
+      {},
+    );
+
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Would succeed');
+    expect(text).toContain('4,200');
+    expect(text).toContain('Program log: hello');
+  });
+
+  it('heliusChain — simulateTransaction surfaces a program error as "would fail"', async () => {
+    vi.mocked(getHeliusClient).mockReturnValueOnce({
+      simulateTransaction: async () => ({
+        context: { slot: 1 },
+        value: { err: { InstructionError: [0, 'Custom'] }, logs: [], unitsConsumed: 0 },
+      }),
+    } as unknown as ReturnType<typeof getHeliusClient>);
+
+    const result = await tools.heliusChain.handler(
+      { action: 'simulateTransaction', transaction: 'AQABz000base64', ...telemetry() },
+      {},
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('Would fail');
+    expect(result.content[0].text).toContain('InstructionError');
+  });
+
+  it('heliusChain — simulateTransaction sends base64 encoding and enforces sigVerify/replaceRecentBlockhash exclusivity', async () => {
+    let captured: Record<string, unknown> = {};
+    const stub = {
+      simulateTransaction: async (_tx: string, cfg: Record<string, unknown>) => {
+        captured = cfg;
+        return { context: { slot: 1 }, value: { err: null, logs: [], unitsConsumed: 0 } };
+      },
+    } as unknown as ReturnType<typeof getHeliusClient>;
+    vi.mocked(getHeliusClient).mockReturnValueOnce(stub).mockReturnValueOnce(stub);
+
+    // Defaults: replace the blockhash, do not verify signatures.
+    await tools.heliusChain.handler(
+      { action: 'simulateTransaction', transaction: 'AQABbase64', ...telemetry() },
+      {},
+    );
+    expect(captured.encoding).toBe('base64');
+    expect(captured.sigVerify).toBe(false);
+    expect(captured.replaceRecentBlockhash).toBe(true);
+
+    // sigVerify=true forces replaceRecentBlockhash off (mutually exclusive at the RPC layer).
+    await tools.heliusChain.handler(
+      { action: 'simulateTransaction', transaction: 'AQABbase64', sigVerify: true, ...telemetry() },
+      {},
+    );
+    expect(captured.sigVerify).toBe(true);
+    expect(captured.replaceRecentBlockhash).toBe(false);
+  });
+
+  it('heliusChain — simulateTransaction requires the transaction param', async () => {
+    const result = await tools.heliusChain.handler(
+      { action: 'simulateTransaction', ...telemetry() },
+      {},
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Missing required parameter');
+    expect(result.content[0].text).toContain('transaction');
+    expect(result._meta?.code).toBe('MISSING_PARAMS');
   });
 
   it('heliusStreaming — getAllWebhooks dispatches successfully', async () => {


### PR DESCRIPTION
This PR adds a `simulateTransaction` tool to the Helius MCP. Given a base64-encoded transaction, it dry-runs it against the current chain state and returns success/failure, program error, compute units consumed, program logs, return data, and optional post-simulation account state, without submitting anything on-chain

This is the agent-facing counterpart to the human `--dry-run`/confirmation work shipped for the CLI: it enables the build -> simulate -> inspect -> send loop that autonomous agents need

Previously, the only simulation-adjacent capability was the CLI's `send compute-units`, which is a compute-unit estimate only; the MCP had nothing