### PR TITLE
feat(mcp): Add Timeout and Retry With Backoff For MCP RPC Reads

### DIFF
--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -1,6 +1,7 @@
 import { createHelius, type HeliusClient } from 'helius-sdk';
 import { MCP_USER_AGENT } from '../http.js';
 import { getSharedApiKey } from './config.js';
+import { wrapClientWithResilience, withResilience, READ_TIMEOUT_MS } from './resilience.js';
 
 let sessionApiKey: string | null = null;
 let sessionNetwork: 'mainnet-beta' | 'devnet' = 'mainnet-beta';
@@ -46,7 +47,9 @@ export function hasApiKey(): boolean {
 export function getHeliusClient(): HeliusClient {
   if (!heliusClient) {
     const apiKey = getApiKey();
-    heliusClient = createHelius({ apiKey, userAgent: MCP_USER_AGENT });
+    // Wrap so idempotent reads get a timeout + retry-with-backoff; writes,
+    // sends, and streaming pass through untouched. See utils/resilience.ts.
+    heliusClient = wrapClientWithResilience(createHelius({ apiKey, userAgent: MCP_USER_AGENT }));
   }
   return heliusClient;
 }
@@ -129,19 +132,26 @@ export async function restRequest(endpoint: string, options: RequestInit = {}): 
     headers['Content-Type'] ??= 'application/json';
   }
 
-  const response = await fetch(url, {
-    ...options,
-    headers,
-  });
+  // Reads here are idempotent: retry transient failures, and abort (not just
+  // race) a hung request via AbortSignal so the socket is released.
+  return withResilience(async () => {
+    const response = await fetch(url, {
+      ...options,
+      headers,
+      signal: AbortSignal.timeout(READ_TIMEOUT_MS),
+    });
 
-  if (!response.ok) {
+    if (!response.ok) {
+      const text = await response.text();
+      const error = new Error(`HTTP ${response.status}: ${text}`) as Error & { statusCode?: number };
+      error.statusCode = response.status;
+      throw error;
+    }
+
     const text = await response.text();
-    throw new Error(`HTTP ${response.status}: ${text}`);
-  }
-
-  const text = await response.text();
-  if (!text || text === 'null') {
-    return null;
-  }
-  return JSON.parse(text);
+    if (!text || text === 'null') {
+      return null;
+    }
+    return JSON.parse(text);
+  }, `restRequest ${endpoint}`, { timeoutMs: 0 });
 }

--- a/helius-mcp/src/utils/resilience.ts
+++ b/helius-mcp/src/utils/resilience.ts
@@ -14,7 +14,7 @@
  */
 
 const READ_METHOD_RE = /^(get|search|simulate)/;
-const WRAPPED_NAMESPACES = new Set(['enhanced', 'webhooks', 'tx']);
+const WRAPPED_NAMESPACES = new Set(['enhanced', 'webhooks', 'tx', 'wallet', 'zk']);
 const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
 const NETWORK_ERROR_CODES = new Set([
   'ECONNRESET',
@@ -113,8 +113,8 @@ export async function withResilience<T>(fn: () => Promise<T>, label = '', opts: 
 
 /**
  * Wrap a Helius client so idempotent reads get timeout + retry. Recurses into the
- * `enhanced`/`webhooks`/`tx` namespaces; leaves `ws` (streaming) and all
- * non-read methods (sends, webhook mutations) untouched.
+ * `enhanced`/`webhooks`/`tx`/`wallet`/`zk` namespaces; leaves `ws` (streaming) and
+ * all non-read methods (sends, webhook mutations) untouched.
  */
 export function wrapClientWithResilience<T extends object>(client: T, opts: ResilienceOptions = {}): T {
   const makeHandler = (prefix: string): ProxyHandler<Record<string | symbol, unknown>> => ({

--- a/helius-mcp/src/utils/resilience.ts
+++ b/helius-mcp/src/utils/resilience.ts
@@ -1,0 +1,144 @@
+/**
+ * RPC resilience for the Helius client: a per-call timeout plus retry-with-backoff
+ * for transient failures (HTTP 429/502/503/504 and network resets).
+ *
+ * Only idempotent reads are wrapped — methods whose name matches `READ_METHOD_RE`
+ * (`get*` / `search*` / `simulate*`). Everything else passes through untouched:
+ * sends (`sendTransactionWithSender`, `sendSmartTransaction`, `broadcastTransaction`),
+ * webhook `create`/`update`/`delete`, `pollTransactionConfirmation`, and streaming
+ * (`ws`). This guarantees we never retry a non-idempotent write or abandon a
+ * transaction that is still confirming — sends self-bound via the SDK's poll timeout.
+ *
+ * Client-side timeouts fail fast (no retry): retrying a hung call just hangs again.
+ * Only fast-failing transients (429/5xx/network reset) are retried.
+ */
+
+const READ_METHOD_RE = /^(get|search|simulate)/;
+const WRAPPED_NAMESPACES = new Set(['enhanced', 'webhooks', 'tx']);
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+const NETWORK_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'EPIPE',
+]);
+
+/** Default per-attempt timeout for idempotent reads. */
+export const READ_TIMEOUT_MS = 30_000;
+
+export interface ResilienceOptions {
+  /** Total attempts including the first. */
+  attempts?: number;
+  baseDelayMs?: number;
+  factor?: number;
+  maxDelayMs?: number;
+  /** Fractional jitter, 0..1. */
+  jitter?: number;
+  /** Per-attempt timeout in ms. 0 disables the timeout race. */
+  timeoutMs?: number;
+}
+
+const DEFAULTS: Required<ResilienceOptions> = {
+  attempts: 3,
+  baseDelayMs: 400,
+  factor: 2,
+  maxDelayMs: 5_000,
+  jitter: 0.2,
+  timeoutMs: READ_TIMEOUT_MS,
+};
+
+class TimeoutError extends Error {
+  constructor(ms: number, label: string) {
+    super(`Request timed out after ${ms}ms${label ? ` (${label})` : ''}`);
+    this.name = 'TimeoutError';
+  }
+}
+
+function statusOf(err: { context?: { statusCode?: number }; statusCode?: number; status?: number }): number | undefined {
+  return err?.context?.statusCode ?? err?.statusCode ?? err?.status;
+}
+
+/** True when an error is a transient failure worth retrying. */
+export function isRetryable(err: unknown): boolean {
+  if (err && typeof err === 'object') {
+    const e = err as { name?: string; code?: string; cause?: { code?: string } };
+    // Client-side timeout/abort: fail fast (retrying a hung call just hangs again).
+    if (e.name === 'TimeoutError' || e.name === 'AbortError') return false;
+    const status = statusOf(e as Parameters<typeof statusOf>[0]);
+    if (typeof status === 'number' && RETRYABLE_STATUS.has(status)) return true;
+    const code = e.code ?? e.cause?.code;
+    if (typeof code === 'string' && NETWORK_ERROR_CODES.has(code)) return true;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  // Match a bare status code (kit: "HTTP error (429): ...", restRequest: "HTTP 429: ...").
+  if (/(?:^|[^\d])(429|502|503|504)(?:[^\d]|$)/.test(msg)) return true;
+  if (/fetch failed|socket hang up|network error|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND/i.test(msg)) return true;
+  return false;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Race a promise-returning fn against a timeout. `ms <= 0` disables the race. */
+export async function withTimeout<T>(fn: () => Promise<T>, ms: number, label = ''): Promise<T> {
+  if (!ms || ms <= 0) return fn();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new TimeoutError(ms, label)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Run `fn` with a timeout and exponential backoff on transient errors. */
+export async function withResilience<T>(fn: () => Promise<T>, label = '', opts: ResilienceOptions = {}): Promise<T> {
+  const o = { ...DEFAULTS, ...opts };
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await withTimeout(fn, o.timeoutMs, label);
+    } catch (err) {
+      if (attempt >= o.attempts || !isRetryable(err)) throw err;
+      const base = Math.min(o.maxDelayMs, o.baseDelayMs * o.factor ** (attempt - 1));
+      const jittered = base * (1 + (Math.random() * 2 - 1) * o.jitter);
+      await sleep(Math.max(0, Math.round(jittered)));
+    }
+  }
+}
+
+/**
+ * Wrap a Helius client so idempotent reads get timeout + retry. Recurses into the
+ * `enhanced`/`webhooks`/`tx` namespaces; leaves `ws` (streaming) and all
+ * non-read methods (sends, webhook mutations) untouched.
+ */
+export function wrapClientWithResilience<T extends object>(client: T, opts: ResilienceOptions = {}): T {
+  const makeHandler = (prefix: string): ProxyHandler<Record<string | symbol, unknown>> => ({
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof prop !== 'string') return value;
+
+      // Recurse into request/response namespaces. `ws` is intentionally excluded.
+      if (WRAPPED_NAMESPACES.has(prop) && value && typeof value === 'object') {
+        return new Proxy(value as Record<string | symbol, unknown>, makeHandler(`${prop}.`));
+      }
+
+      if (typeof value !== 'function') return value;
+
+      const retry = READ_METHOD_RE.test(prop);
+      const label = `${prefix}${prop}`;
+      const fn = value as (...args: unknown[]) => unknown;
+      return (...args: unknown[]) => {
+        const invoke = () => fn.apply(target, args);
+        // Reads: timeout + retry. Everything else: untouched passthrough.
+        return retry ? withResilience(() => Promise.resolve(invoke()), label, opts) : invoke();
+      };
+    },
+  });
+
+  return new Proxy(client as Record<string | symbol, unknown>, makeHandler('')) as T;
+}

--- a/helius-mcp/tests/resilience.test.ts
+++ b/helius-mcp/tests/resilience.test.ts
@@ -105,6 +105,16 @@ describe('wrapClientWithResilience', () => {
         getComputeUnits: flaky(1, err({ statusCode: 429 }), 4200),
         sendTransactionWithSender: flaky(1, err({ statusCode: 429 }), 'sig'),
       },
+      // wallet/zk are pure-read namespaces; the second method in each is a
+      // synthetic non-read that guards the prefix gate within the namespace.
+      wallet: {
+        getBalances: flaky(1, err({ statusCode: 429 }), 'wallet-read'),
+        updateLabel: flaky(1, err({ statusCode: 429 }), 'wallet-write'),
+      },
+      zk: {
+        getCompressedAccount: flaky(1, err({ statusCode: 429 }), 'zk-read'),
+        sendCompressed: flaky(1, err({ statusCode: 429 }), 'zk-write'),
+      },
       ws: {
         // Streaming: must NOT be wrapped.
         logsNotifications: flaky(1, err({ statusCode: 429 }), 'sub'),
@@ -134,6 +144,26 @@ describe('wrapClientWithResilience', () => {
 
     await expect(wrapped.tx.sendTransactionWithSender()).rejects.toMatchObject({ statusCode: 429 });
     expect(c.tx.sendTransactionWithSender).toHaveBeenCalledTimes(1);
+  });
+
+  it('recurses into the wallet namespace: getBalances retried, non-read not', async () => {
+    const c = makeClient();
+    const wrapped = wrapClientWithResilience(c, FAST);
+    await expect(wrapped.wallet.getBalances()).resolves.toBe('wallet-read');
+    expect(c.wallet.getBalances).toHaveBeenCalledTimes(2);
+
+    await expect(wrapped.wallet.updateLabel()).rejects.toMatchObject({ statusCode: 429 });
+    expect(c.wallet.updateLabel).toHaveBeenCalledTimes(1);
+  });
+
+  it('recurses into the zk namespace: getCompressedAccount retried, non-read not', async () => {
+    const c = makeClient();
+    const wrapped = wrapClientWithResilience(c, FAST);
+    await expect(wrapped.zk.getCompressedAccount()).resolves.toBe('zk-read');
+    expect(c.zk.getCompressedAccount).toHaveBeenCalledTimes(2);
+
+    await expect(wrapped.zk.sendCompressed()).rejects.toMatchObject({ statusCode: 429 });
+    expect(c.zk.sendCompressed).toHaveBeenCalledTimes(1);
   });
 
   it('leaves the ws namespace untouched (no retry on streaming)', async () => {

--- a/helius-mcp/tests/resilience.test.ts
+++ b/helius-mcp/tests/resilience.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isRetryable,
+  withTimeout,
+  withResilience,
+  wrapClientWithResilience,
+  type ResilienceOptions,
+} from '../src/utils/resilience.js';
+
+// Fast settings so retry/backoff tests don't sleep for real.
+const FAST: ResilienceOptions = { baseDelayMs: 0, maxDelayMs: 0, jitter: 0, attempts: 3, timeoutMs: 1_000 };
+
+function err(props: Record<string, unknown>, message = 'boom'): Error {
+  return Object.assign(new Error(message), props);
+}
+
+/** A fn that rejects `failCount` times then resolves to `value`. */
+function flaky(failCount: number, error: unknown, value: unknown = 'ok') {
+  let calls = 0;
+  return vi.fn(async () => {
+    calls += 1;
+    if (calls <= failCount) throw error;
+    return value;
+  });
+}
+
+describe('isRetryable', () => {
+  it('retries kit SolanaError 429 via context.statusCode', () => {
+    expect(isRetryable(err({ context: { statusCode: 429 } }, 'HTTP error (429): Too Many Requests'))).toBe(true);
+  });
+
+  it('retries 502/503/504 via statusCode', () => {
+    expect(isRetryable(err({ statusCode: 502 }))).toBe(true);
+    expect(isRetryable(err({ statusCode: 503 }))).toBe(true);
+    expect(isRetryable(err({ statusCode: 504 }))).toBe(true);
+  });
+
+  it('retries on a bare status code in the message', () => {
+    expect(isRetryable(new Error('HTTP 429: rate limited'))).toBe(true);
+    expect(isRetryable(new Error('RPC error: server returned 503'))).toBe(true);
+  });
+
+  it('retries network resets via code and cause.code', () => {
+    expect(isRetryable(err({ code: 'ECONNRESET' }))).toBe(true);
+    expect(isRetryable(err({ cause: { code: 'ETIMEDOUT' } }))).toBe(true);
+    expect(isRetryable(new Error('fetch failed'))).toBe(true);
+  });
+
+  it('does NOT retry client-side timeouts/aborts (fail fast)', () => {
+    expect(isRetryable(err({ name: 'TimeoutError' }))).toBe(false);
+    expect(isRetryable(err({ name: 'AbortError' }))).toBe(false);
+  });
+
+  it('does NOT retry 4xx client errors', () => {
+    expect(isRetryable(err({ statusCode: 400 }))).toBe(false);
+    expect(isRetryable(err({ context: { statusCode: 404 } }, 'HTTP error (404): Not Found'))).toBe(false);
+    expect(isRetryable(new Error('invalid address'))).toBe(false);
+  });
+});
+
+describe('withTimeout', () => {
+  it('returns the value when fn resolves in time', async () => {
+    await expect(withTimeout(async () => 42, 1_000)).resolves.toBe(42);
+  });
+
+  it('rejects with a non-retryable TimeoutError when fn hangs', async () => {
+    const p = withTimeout(() => new Promise<never>(() => {}), 20, 'getThing');
+    await expect(p).rejects.toMatchObject({ name: 'TimeoutError' });
+    await p.catch((e) => expect(isRetryable(e)).toBe(false));
+  });
+
+  it('passes through when ms <= 0', async () => {
+    await expect(withTimeout(async () => 'x', 0)).resolves.toBe('x');
+  });
+});
+
+describe('withResilience', () => {
+  it('retries a transient failure then succeeds', async () => {
+    const fn = flaky(2, err({ statusCode: 429 }), 'done');
+    await expect(withResilience(fn, 'read', FAST)).resolves.toBe('done');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a non-retryable error', async () => {
+    const fn = flaky(1, err({ statusCode: 400 }), 'done');
+    await expect(withResilience(fn, 'read', FAST)).rejects.toMatchObject({ statusCode: 400 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the attempt budget', async () => {
+    const fn = flaky(99, err({ statusCode: 503 }), 'never');
+    await expect(withResilience(fn, 'read', FAST)).rejects.toMatchObject({ statusCode: 503 });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('wrapClientWithResilience', () => {
+  function makeClient() {
+    return {
+      getThing: flaky(1, err({ statusCode: 429 }), 'read-ok'),
+      searchThing: flaky(0, null, 'search-ok'),
+      sendThing: flaky(1, err({ statusCode: 429 }), 'send-ok'),
+      version: '1.0.0',
+      tx: {
+        getComputeUnits: flaky(1, err({ statusCode: 429 }), 4200),
+        sendTransactionWithSender: flaky(1, err({ statusCode: 429 }), 'sig'),
+      },
+      ws: {
+        // Streaming: must NOT be wrapped.
+        logsNotifications: flaky(1, err({ statusCode: 429 }), 'sub'),
+      },
+    };
+  }
+
+  it('retries read methods (get/search/simulate)', async () => {
+    const c = makeClient();
+    const wrapped = wrapClientWithResilience(c, FAST);
+    await expect(wrapped.getThing()).resolves.toBe('read-ok');
+    expect(c.getThing).toHaveBeenCalledTimes(2); // 1 fail + 1 success
+  });
+
+  it('does NOT retry non-read methods (sends)', async () => {
+    const c = makeClient();
+    const wrapped = wrapClientWithResilience(c, FAST);
+    await expect(wrapped.sendThing()).rejects.toMatchObject({ statusCode: 429 });
+    expect(c.sendThing).toHaveBeenCalledTimes(1);
+  });
+
+  it('recurses into the tx namespace: getComputeUnits retried, send not', async () => {
+    const c = makeClient();
+    const wrapped = wrapClientWithResilience(c, FAST);
+    await expect(wrapped.tx.getComputeUnits()).resolves.toBe(4200);
+    expect(c.tx.getComputeUnits).toHaveBeenCalledTimes(2);
+
+    await expect(wrapped.tx.sendTransactionWithSender()).rejects.toMatchObject({ statusCode: 429 });
+    expect(c.tx.sendTransactionWithSender).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the ws namespace untouched (no retry on streaming)', async () => {
+    const c = makeClient();
+    const wrapped = wrapClientWithResilience(c, FAST);
+    await expect(wrapped.ws.logsNotifications()).rejects.toMatchObject({ statusCode: 429 });
+    expect(c.ws.logsNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns non-function properties as-is', () => {
+    const wrapped = wrapClientWithResilience(makeClient(), FAST);
+    expect(wrapped.version).toBe('1.0.0');
+  });
+
+  it('does not retry a read that times out', async () => {
+    const hang = vi.fn(() => new Promise<never>(() => {}));
+    const wrapped = wrapClientWithResilience({ getStuck: hang }, { ...FAST, timeoutMs: 20 });
+    await expect(wrapped.getStuck()).rejects.toMatchObject({ name: 'TimeoutError' });
+    expect(hang).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This PR makes the Helius MCP resilient to transient RPC failures for agent workloads. Today, the MCP has no retries and no timeouts, meaning that a 429 (rate limit) or 5xx failure on the tool call outright, and a slow/hung backend can block the tool indefinitely. This wraps the client so idempotent reads get a per-call timeout plus exponential-backoff retries, while writes, sends, and streaming are left untouched

This is introduced via a single `Proxy` wrapper applied once in `getHeliusClient()` with no per-tool changes. Resilience is applied only to methods matching `^(get|search|simulate)`:

| Call | Behavior |
|---|---|
| `get*` / `search*` / `simulate*` (DAS, raw RPC, `enhanced.getTransactions`, `webhooks.get/getAll`, `tx.getComputeUnits`) | 30s timeout + retry on 429/5xx/network |
| `sendTransactionWithSender`, `sendSmartTransaction`, `broadcastTransaction` | **untouched** — never retried, no external timeout |
| `webhooks.create/update/delete`, `pollTransactionConfirmation` | **untouched** |
| `ws` (streaming) | **untouched** |