### PR TITLE
feat(mcp): Refactor Regex-Parsing Output to Structured Continuation Metadata

### DIFF
--- a/helius-mcp/src/results/types.ts
+++ b/helius-mcp/src/results/types.ts
@@ -7,6 +7,15 @@ export type TransactionHistoryContinuation =
   | { kind: 'historyApi'; paginationToken?: string }
   | { kind: 'rawApi'; paginationToken?: string };
 
+/**
+ * Structured continuation metadata emitted by an action handler on its response,
+ * describing how to fetch the next page. The router reads this directly instead
+ * of regex-parsing the handler's human-readable output.
+ */
+export type ContinuationHint =
+  | { kind: 'paginationToken'; api: 'history' | 'raw'; token: string }
+  | { kind: 'signaturesQuick'; lastSignature: string; until?: string };
+
 export type ContinuationState =
   | { model: 'none' }
   | { model: 'page'; nextPage?: number }

--- a/helius-mcp/src/router/action-handlers.ts
+++ b/helius-mcp/src/router/action-handlers.ts
@@ -24,11 +24,14 @@ import { registerTransferTools } from '../tools/transfers.js';
 import { registerZkCompressionTools } from '../tools/zk-compression.js';
 import { registerStakingTools } from '../tools/staking.js';
 import type { ActionName } from './actions.js';
+import type { ContinuationHint } from '../results/types.js';
 
 export type ActionHandlerResponse = {
   content?: Array<{ type?: string; text?: string }>;
   isError?: boolean;
   structuredContent?: unknown;
+  /** Structured next-page metadata; the router uses it to build continuation state. */
+  continuation?: ContinuationHint;
 };
 
 export type ActionHandler = (

--- a/helius-mcp/src/router/dispatch.ts
+++ b/helius-mcp/src/router/dispatch.ts
@@ -1,5 +1,5 @@
 import { getStoredResult, putStoredResult } from '../results/store.js';
-import type { ContinuationState, StoredResult, TransactionHistoryContinuation } from '../results/types.js';
+import type { ContinuationHint, ContinuationState, StoredResult } from '../results/types.js';
 import { callActionHandler, type ActionHandlerResponse } from './action-handlers.js';
 import { getActionCatalogEntry } from './catalog.js';
 import { getRouterContext } from './context.js';
@@ -54,60 +54,31 @@ function buildActionParams(input: Record<string, unknown>): Record<string, unkno
   return merged;
 }
 
-function detectContinuation(action: ActionName, params: Record<string, unknown>, text: string): ContinuationState {
-  if (action === 'getTransactionHistory') {
-    // Fragile: depends on handler markdown format "**Next Page Token:** `<token>`"
-    const tokenMatch = text.match(/\*\*Next Page Token:\*\*\s+`([^`]+)`/);
-    if (tokenMatch) {
-      const mode = typeof params.mode === 'string' ? params.mode : 'parsed';
-      const next: TransactionHistoryContinuation = mode === 'raw'
-        ? { kind: 'rawApi', paginationToken: tokenMatch[1] }
-        : { kind: 'historyApi', paginationToken: tokenMatch[1] };
-      return { model: 'transactionHistory', next };
-    }
-
-    const hasFilters = [
-      'paginationToken',
-      'status',
-      'tokenAccounts',
-      'blockTimeGte',
-      'blockTimeLte',
-      'slotGte',
-      'slotLte',
-    ].some((key) => params[key] !== undefined);
-    const mode = typeof params.mode === 'string' ? params.mode : 'parsed';
-    const sortOrder = typeof params.sortOrder === 'string' ? params.sortOrder : 'desc';
-    if (mode === 'signatures' && sortOrder === 'desc' && !hasFilters) {
-      // Fragile: depends on handler "✅/❌ <base58sig>" line format for signature extraction
-      const signatures = Array.from(
-        text.matchAll(/^[^\S\r\n]*[✅❌]\s+([1-9A-HJ-NP-Za-km-z]{86,88})$/gm),
-      ).map((match) => match[1]);
-      const lastSignature = signatures.at(-1);
-      if (lastSignature) {
-        return {
-          model: 'transactionHistory',
-          next: {
-            kind: 'signaturesQuick',
-            nextBefore: lastSignature,
-            lastSeenSignature: lastSignature,
-            until: typeof params.until === 'string' ? params.until : undefined,
-          },
-        };
-      }
-    }
-  }
-
-  if (action === 'getTransfersByAddress') {
-    // Fragile: depends on handler markdown format "**Next Page Token:** `<token>`" (mirrors getTransactionHistory)
-    const tokenMatch = text.match(/\*\*Next Page Token:\*\*\s+`([^`]+)`/);
-    if (tokenMatch) {
+function detectContinuation(params: Record<string, unknown>, hint?: ContinuationHint): ContinuationState {
+  // Prefer structured metadata emitted by the handler over parsing its output.
+  if (hint) {
+    if (hint.kind === 'paginationToken') {
       return {
         model: 'transactionHistory',
-        next: { kind: 'rawApi', paginationToken: tokenMatch[1] },
+        next: hint.api === 'raw'
+          ? { kind: 'rawApi', paginationToken: hint.token }
+          : { kind: 'historyApi', paginationToken: hint.token },
+      };
+    }
+    if (hint.kind === 'signaturesQuick') {
+      return {
+        model: 'transactionHistory',
+        next: {
+          kind: 'signaturesQuick',
+          nextBefore: hint.lastSignature,
+          lastSeenSignature: hint.lastSignature,
+          until: hint.until,
+        },
       };
     }
   }
 
+  // Page-based pagination is param-driven (not output-parsed), so it stays here.
   if (typeof params.page === 'number') {
     return { model: 'page', nextPage: params.page + 1 };
   }
@@ -148,9 +119,10 @@ function buildStoredResult(
   params: Record<string, unknown>,
   summary: string,
   text: string,
+  hint?: ContinuationHint,
 ): StoredResult {
   const context = getRouterContext();
-  const continuation = detectContinuation(entry.action, params, text);
+  const continuation = detectContinuation(params, hint);
   const sectionHints = collectSectionHints(text);
   const stored = putStoredResult({
     kind: entry.responseFamily,
@@ -180,6 +152,7 @@ function normalizeSuccessResponse(
   text: string,
   requestedDetail: DetailLevel,
   allowHandles: boolean,
+  hint?: ContinuationHint,
 ): RouterResponse {
   const baseText = text.trim();
   const summaryText = buildTextVariant(entry.responseFamily, 'summary', baseText);
@@ -199,7 +172,7 @@ function normalizeSuccessResponse(
     && (requestedDetail === 'summary' || size > limit);
 
   if (needsHandle) {
-    const stored = buildStoredResult(entry, publicTool, params, summaryText, fullText);
+    const stored = buildStoredResult(entry, publicTool, params, summaryText, fullText, hint);
     return mcpResultHandle(summaryText, stored.resultId, stored.availableExpansions, {
       family: entry.responseFamily,
       action: entry.action,
@@ -232,7 +205,7 @@ function normalizeActionResponse(
     });
   }
 
-  return normalizeSuccessResponse(entry, publicTool, params, text, requestedDetail, allowHandles);
+  return normalizeSuccessResponse(entry, publicTool, params, text, requestedDetail, allowHandles, result.continuation);
 }
 
 async function executeActionViaRouter(
@@ -375,6 +348,7 @@ export async function expandStoredResult(
         selected,
         requestedDetail,
         true,
+        rawResponse.continuation,
       );
     }
 

--- a/helius-mcp/src/tools/transactions.ts
+++ b/helius-mcp/src/tools/transactions.ts
@@ -707,7 +707,10 @@ export function registerTransactionTools(server: McpServer) {
               }
             });
 
-            return mcpText(lines.join('\n'));
+            const lastSignature = sigs[sigs.length - 1]?.signature as string | undefined;
+            return mcpText(lines.join('\n'), lastSignature
+              ? { continuation: { kind: 'signaturesQuick', lastSignature, until: typeof until === 'string' ? until : undefined } }
+              : undefined);
           } catch (err) {
             return handleToolError(err, 'Error fetching signatures');
           }
@@ -745,7 +748,9 @@ export function registerTransactionTools(server: McpServer) {
             lines.push('', `**Next Page Token:** \`${result.paginationToken}\``);
           }
 
-          return mcpText(lines.join('\n'));
+          return mcpText(lines.join('\n'), result.paginationToken
+            ? { continuation: { kind: 'paginationToken', api: 'history', token: result.paginationToken } }
+            : undefined);
         } catch (err) {
           return handleToolError(err, 'Error fetching signatures');
         }
@@ -812,7 +817,9 @@ export function registerTransactionTools(server: McpServer) {
             lines.push('', `**Next Page Token:** \`${result.paginationToken}\``);
           }
 
-          return mcpText(lines.join('\n'));
+          return mcpText(lines.join('\n'), result.paginationToken
+            ? { continuation: { kind: 'paginationToken', api: 'raw', token: result.paginationToken } }
+            : undefined);
         } catch (err) {
           return handleToolError(err, 'Error fetching transactions');
         }
@@ -906,7 +913,9 @@ export function registerTransactionTools(server: McpServer) {
         }
 
         const fullText = lines.join('\n');
-        return mcpText(truncateResponse(fullText));
+        return mcpText(truncateResponse(fullText), sigResult.paginationToken
+          ? { continuation: { kind: 'paginationToken', api: 'history', token: sigResult.paginationToken } }
+          : undefined);
       } catch (err) {
         return handleToolError(err, 'Error fetching transaction history');
       }
@@ -1114,7 +1123,9 @@ export function registerTransactionTools(server: McpServer) {
         lines.push(`**Next Page Token:** \`${result.paginationToken}\``);
       }
 
-      return mcpText(truncateResponse(lines.join('\n')));
+      return mcpText(truncateResponse(lines.join('\n')), result.paginationToken
+        ? { continuation: { kind: 'paginationToken', api: 'raw', token: result.paginationToken } }
+        : undefined);
     }
   );
 }

--- a/helius-mcp/src/utils/errors.ts
+++ b/helius-mcp/src/utils/errors.ts
@@ -1,8 +1,12 @@
 // ─── MCP Response Builders ───
 
+import type { ContinuationHint } from '../results/types.js';
+
 type McpToolResponse = {
   content: [{ type: 'text'; text: string }];
   isError?: boolean;
+  /** Structured next-page metadata the router reads to enable expandResult continuation. */
+  continuation?: ContinuationHint;
 };
 
 export type ErrorMeta = {
@@ -12,8 +16,11 @@ export type ErrorMeta = {
   recovery: string;
 };
 
-export function mcpText(text: string): McpToolResponse {
-  return { content: [{ type: 'text', text }] };
+export function mcpText(text: string, opts?: { continuation?: ContinuationHint }): McpToolResponse {
+  return {
+    content: [{ type: 'text', text }],
+    ...(opts?.continuation ? { continuation: opts.continuation } : {}),
+  };
 }
 
 export function mcpError(text: string, meta?: ErrorMeta): McpToolResponse {

--- a/helius-mcp/tests/tools.test.ts
+++ b/helius-mcp/tests/tools.test.ts
@@ -527,6 +527,82 @@ describe('Dispatch per routed tool', () => {
   });
 });
 
+describe('Structured continuation', () => {
+  let tools: RegisteredToolMap;
+  const mockedCallHandler = vi.mocked(callActionHandler);
+
+  beforeEach(() => {
+    clearStoredResults();
+    vi.mocked(hasApiKey).mockReturnValue(true);
+    mockedCallHandler.mockReset();
+    ({ tools } = createServer());
+  });
+
+  function resultIdFrom(text: string): string {
+    const match = text.match(/resultId:\s+([^\n]+)/);
+    expect(match, 'response should carry a resultId').toBeTruthy();
+    return match![1].trim();
+  }
+
+  it('threads a paginationToken hint into the expandResult continuation', async () => {
+    mockedCallHandler.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'page 1' }],
+      continuation: { kind: 'paginationToken', api: 'history', token: 'TKN1' },
+    });
+    const initial = await tools.heliusTransaction.handler(
+      { action: 'getTransactionHistory', address: '11111111111111111111111111111111', detail: 'summary', ...telemetry() },
+      {},
+    );
+    const resultId = resultIdFrom(initial.content[0].text);
+
+    mockedCallHandler.mockResolvedValueOnce({ content: [{ type: 'text', text: 'page 2' }] });
+    await tools.expandResult.handler({ resultId, continuation: 'next', ...telemetry() }, {});
+
+    expect(mockedCallHandler).toHaveBeenLastCalledWith(
+      'getTransactionHistory',
+      expect.objectContaining({ paginationToken: 'TKN1' }),
+      expect.anything(),
+    );
+  });
+
+  it('threads a signaturesQuick hint into the before cursor', async () => {
+    mockedCallHandler.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'sigs' }],
+      continuation: { kind: 'signaturesQuick', lastSignature: 'SIG_LAST' },
+    });
+    const initial = await tools.heliusTransaction.handler(
+      { action: 'getTransactionHistory', address: '11111111111111111111111111111111', mode: 'signatures', detail: 'summary', ...telemetry() },
+      {},
+    );
+    const resultId = resultIdFrom(initial.content[0].text);
+
+    mockedCallHandler.mockResolvedValueOnce({ content: [{ type: 'text', text: 'more sigs' }] });
+    await tools.expandResult.handler({ resultId, continuation: 'next', ...telemetry() }, {});
+
+    expect(mockedCallHandler).toHaveBeenLastCalledWith(
+      'getTransactionHistory',
+      expect.objectContaining({ before: 'SIG_LAST' }),
+      expect.anything(),
+    );
+  });
+
+  it('adds no cursor when the handler omits the continuation hint', async () => {
+    mockedCallHandler.mockResolvedValueOnce({ content: [{ type: 'text', text: 'last page' }] });
+    const initial = await tools.heliusTransaction.handler(
+      { action: 'getTransactionHistory', address: '11111111111111111111111111111111', detail: 'summary', ...telemetry() },
+      {},
+    );
+    const resultId = resultIdFrom(initial.content[0].text);
+
+    mockedCallHandler.mockResolvedValueOnce({ content: [{ type: 'text', text: 'same page' }] });
+    await tools.expandResult.handler({ resultId, continuation: 'next', ...telemetry() }, {});
+
+    const lastParams = mockedCallHandler.mock.calls.at(-1)![1];
+    expect(lastParams).not.toHaveProperty('paginationToken');
+    expect(lastParams).not.toHaveProperty('before');
+  });
+});
+
 describe('Result Store', () => {
   beforeEach(() => {
     clearStoredResults();


### PR DESCRIPTION
The router decided "is there a next page?" by regex-parsing the handler's human-readable output — `**Next Page Token:** \`<token>\`` and `✅/❌ <signature>` lines (`detectContinuation` in `dispatch.ts`). The code itself flagged both patterns as "Fragile": any reformat of a handler's markdown silently breaks `expandResult` continuation, with no fallback and no test coverage

This PR replaces output-parsing with structured metadata, as handlers now emit a typed `ContinuationHint` on their response, and the router reads it directly

| File | Change |
|---|---|
| `results/types.ts` | New `ContinuationHint` type: `{ kind: 'paginationToken', api: 'history'\|'raw', token }` or `{ kind: 'signaturesQuick', lastSignature, until? }` |
| `utils/errors.ts` | `mcpText(text, { continuation })` + `continuation?` on the response type |
| `router/action-handlers.ts` | `continuation?` on `ActionHandlerResponse` |
| `tools/transactions.ts` | `getTransactionHistory` (parsed / raw / full-signatures / signatures-quick) and `getTransfersByAddress` emit the hint at each paginated return site |
| `router/dispatch.ts` | `detectContinuation` reads the hint (**both regexes deleted**); the hint is threaded `normalizeActionResponse → normalizeSuccessResponse → buildStoredResult`, and from `expandStoredResult`'s re-invocation so multi-page paging is preserved |