### PR TITLE
fix(mcp): Point docs fetcher at helius.dev instead of raw.githubusercontent.com

### DIFF
--- a/helius-mcp/src/utils/docs.ts
+++ b/helius-mcp/src/utils/docs.ts
@@ -96,7 +96,7 @@ export async function fetchDoc(docKey: string): Promise<string> {
     return cached.content;
   }
 
-  // Fetch from GitHub
+  // Fetch from the docs site
   const url = `${DOCS_BASE_URL}${docInfo.path}`;
   try {
     const response = await fetch(url);

--- a/helius-mcp/src/utils/docs.ts
+++ b/helius-mcp/src/utils/docs.ts
@@ -1,12 +1,12 @@
 /**
  * Helius Documentation Fetcher
  *
- * Fetches official Helius documentation from GitHub for accurate, up-to-date information.
+ * Fetches official Helius documentation from helius.dev for accurate, up-to-date information.
  * Uses llms.txt files which are AI-optimized summaries of the documentation.
  */
 
-// GitHub raw URL base for Helius docs
-const DOCS_BASE_URL = 'https://raw.githubusercontent.com/helius-labs/docs/main';
+// Base URL for the published Helius docs site
+const DOCS_BASE_URL = 'https://www.helius.dev/docs';
 
 // Available llms.txt documentation files
 export const DOCS_INDEX: Record<string, { path: string; description: string }> = {
@@ -35,7 +35,7 @@ export const DOCS_INDEX: Record<string, { path: string; description: string }> =
     description: 'Standard Solana WebSocket subscriptions',
   },
   'enhanced-websockets': {
-    path: '/enhanced-websockets/llms.txt',
+    path: '/api-reference/rpc/websocket/llms.txt',
     description: 'Enhanced WebSockets: transactionSubscribe, accountSubscribe, filtering',
   },
   webhooks: {

--- a/helius-mcp/tests/docs.test.ts
+++ b/helius-mcp/tests/docs.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DOCS_INDEX,
+  clearDocsCache,
+  fetchDoc,
+  getAvailableDocTopics,
+} from '../src/utils/docs.js';
+
+// The docs live on the published Helius docs site. Every DOCS_INDEX path is
+// resolved against this origin, so a wrong origin silently breaks every
+// doc-backed tool at once rather than failing loudly at build time.
+const DOCS_ORIGIN = 'https://www.helius.dev/docs';
+
+/** Records the URLs fetchDoc requests, without touching the network. */
+function stubFetch(): string[] {
+  const requested: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: unknown) => {
+      requested.push(String(url));
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => '# doc',
+      } as unknown as Response;
+    })
+  );
+  return requested;
+}
+
+describe('DOCS_INDEX', () => {
+  beforeEach(() => {
+    clearDocsCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('gives every topic an llms.txt path and a description', () => {
+    for (const [key, info] of Object.entries(DOCS_INDEX)) {
+      expect(info.path, key).toMatch(/^\/[\w\-/]*llms\.txt$/);
+      expect(info.description.length, key).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolves every topic against the published docs site', async () => {
+    const requested = stubFetch();
+
+    for (const key of getAvailableDocTopics()) {
+      await fetchDoc(key);
+    }
+
+    const expected = Object.values(DOCS_INDEX).map((info) => `${DOCS_ORIGIN}${info.path}`);
+    expect(requested).toHaveLength(Object.keys(DOCS_INDEX).length);
+    expect(new Set(requested)).toEqual(new Set(expected));
+  });
+
+  it('never requests docs from the unauthenticated GitHub raw host', async () => {
+    const requested = stubFetch();
+
+    for (const key of getAvailableDocTopics()) {
+      await fetchDoc(key);
+    }
+
+    expect(requested.filter((url) => !url.startsWith(`${DOCS_ORIGIN}/`))).toEqual([]);
+  });
+});

--- a/helius-mcp/tests/docs.test.ts
+++ b/helius-mcp/tests/docs.test.ts
@@ -45,7 +45,7 @@ describe('DOCS_INDEX', () => {
     }
   });
 
-  it('resolves every topic against the published docs site', async () => {
+  it('resolves every topic against the published docs site and nowhere else', async () => {
     const requested = stubFetch();
 
     for (const key of getAvailableDocTopics()) {
@@ -55,15 +55,5 @@ describe('DOCS_INDEX', () => {
     const expected = Object.values(DOCS_INDEX).map((info) => `${DOCS_ORIGIN}${info.path}`);
     expect(requested).toHaveLength(Object.keys(DOCS_INDEX).length);
     expect(new Set(requested)).toEqual(new Set(expected));
-  });
-
-  it('never requests docs from the unauthenticated GitHub raw host', async () => {
-    const requested = stubFetch();
-
-    for (const key of getAvailableDocTopics()) {
-      await fetchDoc(key);
-    }
-
-    expect(requested.filter((url) => !url.startsWith(`${DOCS_ORIGIN}/`))).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

`DOCS_INDEX` resolved every path against `https://raw.githubusercontent.com/helius-labs/docs/main`, which returns **404 to unauthenticated requests**. `fetchDoc()` sends no `Authorization` header and has no fallback, so every live docs fetch fails for users of the published package.

Calling the published `helius-mcp@2.1.0` `fetchDoc()` across the index: **0 ok, 16 failed**. That breaks `lookupHeliusDocs`, `getSenderInfo`, `getWebhookGuide`, `getRateLimitInfo`, `getLatencyComparison`, `getLaserstreamInfo`, `getEnhancedWebSocketInfo` and `getHeliusPlanInfo` — 11 call sites across 6 modules.

## Fix

```diff
-const DOCS_BASE_URL = 'https://raw.githubusercontent.com/helius-labs/docs/main';
+const DOCS_BASE_URL = 'https://www.helius.dev/docs';
```

15 of 16 paths already resolve there unchanged — only the host was wrong. The exception is `enhanced-websockets`, which 404s on the docs site too:

```diff
   'enhanced-websockets': {
-    path: '/enhanced-websockets/llms.txt',
+    path: '/api-reference/rpc/websocket/llms.txt',
```

That doc is titled "LaserStream WebSocket API" and covers `transactionSubscribe` and enhanced `accountSubscribe`. The canonical index at `helius.dev/docs/llms.txt` publishes no separate enhanced-websockets document, so this is the only WebSocket `llms.txt` upstream.

**One thing worth your call:** this leaves `websocket` and `enhanced-websockets` sharing a path. I took the conservative route — the alternative is dropping the key and repointing `product-catalog.ts` at `websocket`, which is cleaner but breaks `lookupHeliusDocs`'s public topic enum. Happy to switch. (The key can't just be deleted; `validate-catalog.ts` requires every `docKey` to exist in `DOCS_INDEX`.)

## Verification

All 16 keys now return 200 with `text/plain` content. The 15 distinct paths are exactly the 14 `llms.txt` files declared in `helius.dev/docs/llms.txt`, plus the index itself — no invented paths, no gaps.

Adds `tests/docs.test.ts`: two offline tests (fetch stubbed, no network in CI) pinning the origin so this can't silently regress. Confirmed they fail when `DOCS_BASE_URL` is reverted.

`pnpm build` ✅ · `pnpm validate` ✅ (15 products) · `pnpm test` ✅ **260 passed**

<details>
<summary>Ruled out: build-time substitution, machine-specific causes</summary>

- The published tarball contains the bad URL verbatim in `dist/utils/docs.js` — `build` is plain `tsc`, no bundler or `--define`, no `sed` step in any workflow
- Control URL on the same host returns 200: `raw.githubusercontent.com/helius-labs/core-ai/main/README.md`
- No proxy, no credentials sent (`fetch(url)` takes no options, `docs.ts:102`); native `fetch` returns a real HTTP 404, not a DNS/TLS error
- `helius.dev` serves a genuine 404 (`Asset not found`) for unknown paths, so the 200s are real documents, not a catch-all route

</details>

Two things I left alone: `fetchDoc` has no fallback or failure telemetry, and `listHeliusDocTopics` advertises topics it can't serve because it reads the local index without fetching. Both contributed to this going unnoticed — happy to open follow-ups.

