### PR TITLE
fix(mcp): Store Config With Owner-only Permissions

### DIFF
--- a/helius-cli/src/commands/keygen.ts
+++ b/helius-cli/src/commands/keygen.ts
@@ -43,7 +43,9 @@ export async function keygenCommand(options: KeygenOptions = {}): Promise<void> 
 
     // Save in Solana CLI format (64-byte array)
     const secretKeyArray = Array.from(keypair.secretKey);
-    fs.writeFileSync(resolvedPath, JSON.stringify(secretKeyArray));
+    // `mode` closes the window where a new keypair is briefly world-readable;
+    // the chmod still covers overwrites of an existing file.
+    fs.writeFileSync(resolvedPath, JSON.stringify(secretKeyArray), { mode: 0o600 });
     fs.chmodSync(resolvedPath, 0o600);
 
     // Get address for display

--- a/helius-cli/src/lib/config.ts
+++ b/helius-cli/src/lib/config.ts
@@ -116,9 +116,38 @@ function recoverConfig(raw: string): Config {
   return recovered;
 }
 
+/** chmod the config to owner-only, warning at most once per process if it fails. */
+function restrictConfigPerms(): void {
+  try {
+    fs.chmodSync(CONFIG_FILE, 0o600);
+  } catch {
+    // Non-fatal (e.g. non-POSIX filesystem), but the file may stay readable by
+    // other users — warn once so credentials aren't silently left exposed.
+    if (!warnedConfigPerms) {
+      warnedConfigPerms = true;
+      console.error(
+        `Warning: could not restrict permissions on ${CONFIG_FILE}; it may be ` +
+          `readable by other users. If possible, run: chmod 600 ${CONFIG_FILE}`,
+      );
+    }
+  }
+}
+
 export function load(): Config {
   if (!fs.existsSync(CONFIG_FILE)) {
     return {};
+  }
+
+  // Self-heal installs written before save() locked permissions down. Every
+  // save() caller is an explicit user action (login, signup, config set), so a
+  // user who set up once and only runs read commands would otherwise keep a
+  // world-readable JWT indefinitely. One stat per load; chmod only when loose.
+  try {
+    if ((fs.statSync(CONFIG_FILE).mode & 0o077) !== 0) {
+      restrictConfigPerms();
+    }
+  } catch {
+    // Can't stat — the read below will surface any real problem.
   }
 
   let raw: string;
@@ -152,19 +181,7 @@ export function save(data: Config): void {
   ensureDir();
   // Owner-only. `mode` only applies on create, so chmod existing files too.
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
-  try {
-    fs.chmodSync(CONFIG_FILE, 0o600);
-  } catch {
-    // Non-fatal (e.g. non-POSIX filesystem), but the file may stay readable by
-    // other users — warn once so credentials aren't silently left exposed.
-    if (!warnedConfigPerms) {
-      warnedConfigPerms = true;
-      console.error(
-        `Warning: could not restrict permissions on ${CONFIG_FILE}; it may be ` +
-          `readable by other users. If possible, run: chmod 600 ${CONFIG_FILE}`,
-      );
-    }
-  }
+  restrictConfigPerms();
 }
 
 export function getJwt(): string | undefined {

--- a/helius-cli/tests/config-permissions.test.ts
+++ b/helius-cli/tests/config-permissions.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// POSIX-only: mode bits are meaningless on Windows.
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+describePosix("config file permissions", () => {
+  let save: typeof import("../src/lib/config.js").save;
+  let load: typeof import("../src/lib/config.js").load;
+  let CONFIG_FILE: string;
+  let fakeHome: string;
+  let configDir: string;
+  let originalHome: string | undefined;
+  let originalUmask: number | undefined;
+
+  beforeAll(async () => {
+    // config.ts resolves ~/.helius at import time, so HOME must point at a
+    // scratch dir before the dynamic import below. os.homedir() reads $HOME on
+    // POSIX, which is why this works.
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "helius-cli-perms-"));
+    configDir = path.join(fakeHome, ".helius");
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    // Simulate the default Debian/Ubuntu umask. Without this, a developer
+    // running with umask 077 would get 0600 for free and the create-path
+    // assertions would pass even against unfixed code. Not fatal if it fails
+    // (umask is unsettable on some Vitest pools); the pre-existing-permissions
+    // tests still detect a regression on their own.
+    try {
+      originalUmask = process.umask(0o022);
+    } catch {
+      originalUmask = undefined;
+    }
+
+    const mod = await import("../src/lib/config.js");
+    save = mod.save;
+    load = mod.load;
+    CONFIG_FILE = mod.SHARED_CONFIG_PATH;
+
+    // Guard against ever writing to the developer's real ~/.helius. If the HOME
+    // override did not take effect, these tests would overwrite actual
+    // credentials — fail loudly before a single write happens.
+    if (!CONFIG_FILE.startsWith(fakeHome)) {
+      throw new Error(
+        `HOME override did not take effect — refusing to run. ` +
+          `Expected a path under ${fakeHome}, got ${CONFIG_FILE}.`,
+      );
+    }
+  });
+
+  afterAll(() => {
+    if (originalUmask !== undefined) process.umask(originalUmask);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (fakeHome) fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  const mode = (p: string) => fs.statSync(p).mode & 0o777;
+
+  it("writes a newly created config.json as 0600", () => {
+    save({ jwt: "test-jwt", apiKey: "test-api-key" });
+    expect(mode(CONFIG_FILE)).toBe(0o600);
+  });
+
+  it("creates the config dir as 0700", () => {
+    save({ jwt: "test-jwt" });
+    expect(mode(configDir)).toBe(0o700);
+  });
+
+  it("tightens a pre-existing world-readable config.json on save", () => {
+    save({ jwt: "seed" });
+    fs.chmodSync(CONFIG_FILE, 0o644);
+    save({ jwt: "rotated-jwt" });
+    expect(mode(CONFIG_FILE)).toBe(0o600);
+  });
+
+  // The reported population: set up once, then only run read commands. Nothing
+  // on the save path ever runs again, so load() has to be what tightens it.
+  it("self-heals a world-readable config.json on load", () => {
+    save({ jwt: "stale-jwt", apiKey: "stale-key" });
+    fs.chmodSync(CONFIG_FILE, 0o644);
+    expect(load()).toEqual({ jwt: "stale-jwt", apiKey: "stale-key" });
+    expect(mode(CONFIG_FILE)).toBe(0o600);
+  });
+
+  it("leaves an already-restricted config.json untouched on load", () => {
+    save({ jwt: "fine-jwt" });
+    expect(load()).toEqual({ jwt: "fine-jwt" });
+    expect(mode(CONFIG_FILE)).toBe(0o600);
+  });
+
+  it("does not create a config on load when none exists", () => {
+    fs.rmSync(CONFIG_FILE, { force: true });
+    expect(load()).toEqual({});
+    expect(fs.existsSync(CONFIG_FILE)).toBe(false);
+  });
+});

--- a/helius-mcp/src/utils/config.ts
+++ b/helius-mcp/src/utils/config.ts
@@ -17,9 +17,20 @@ interface HeliusConfig {
   };
 }
 
+// Warn at most once per process if we can't lock down config permissions.
+let warnedConfigPerms = false;
+
 function ensureDir(): void {
   if (!fs.existsSync(CONFIG_DIR)) {
-    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+  // Owner-only — the dir holds a JWT, API key, and keypair. chmod unconditionally:
+  // another path (feedback.ts at module load) may have created it modeless before we
+  // got here, and this also tightens existing installs. Best-effort like the file below.
+  try {
+    fs.chmodSync(CONFIG_DIR, 0o700);
+  } catch {
+    // Non-POSIX filesystem — the saveConfig permission warning already covers this.
   }
 }
 
@@ -76,9 +87,38 @@ function recoveredFieldSummary(cfg: HeliusConfig): string {
   return keys.join(", ");
 }
 
+/** chmod the config to owner-only, warning at most once per process if it fails. */
+function restrictConfigPerms(): void {
+  try {
+    fs.chmodSync(SHARED_CONFIG_PATH, 0o600);
+  } catch {
+    // Non-fatal (e.g. non-POSIX filesystem), but the file may stay readable by
+    // other users — warn once so credentials aren't silently left exposed.
+    if (!warnedConfigPerms) {
+      warnedConfigPerms = true;
+      console.error(
+        `Warning: could not restrict permissions on ${SHARED_CONFIG_PATH}; it may be ` +
+          `readable by other users. If possible, run: chmod 600 ${SHARED_CONFIG_PATH}`,
+      );
+    }
+  }
+}
+
 export function loadConfig(): HeliusConfig {
   if (!fs.existsSync(SHARED_CONFIG_PATH)) {
     return {};
+  }
+
+  // Self-heal installs written before saveConfig locked permissions down. Every
+  // saveConfig caller is an explicit user action (login, signup, set-api-key), so
+  // a user who set up once and only makes read calls would otherwise keep a
+  // world-readable JWT indefinitely. One stat per load; chmod only when loose.
+  try {
+    if ((fs.statSync(SHARED_CONFIG_PATH).mode & 0o077) !== 0) {
+      restrictConfigPerms();
+    }
+  } catch {
+    // Can't stat — the read below will surface any real problem.
   }
 
   let raw: string;
@@ -116,7 +156,9 @@ export function loadConfig(): HeliusConfig {
 
 export function saveConfig(config: HeliusConfig): void {
   ensureDir();
-  fs.writeFileSync(SHARED_CONFIG_PATH, JSON.stringify(config, null, 2));
+  // Owner-only. `mode` only applies on create, so chmod existing files too.
+  fs.writeFileSync(SHARED_CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 });
+  restrictConfigPerms();
 }
 
 export function getSharedApiKey(): string | undefined {
@@ -174,6 +216,8 @@ export function loadKeypairFromDisk(): Uint8Array | null {
 
 export function saveKeypairToDisk(secretKey: Uint8Array): void {
   ensureDir();
-  fs.writeFileSync(KEYPAIR_PATH, JSON.stringify(Array.from(secretKey)));
+  // `mode` closes the window where a newly created keypair is briefly world-readable;
+  // the chmod still covers files that already existed.
+  fs.writeFileSync(KEYPAIR_PATH, JSON.stringify(Array.from(secretKey)), { mode: 0o600 });
   fs.chmodSync(KEYPAIR_PATH, 0o600);
 }

--- a/helius-mcp/src/utils/feedback.ts
+++ b/helius-mcp/src/utils/feedback.ts
@@ -31,7 +31,8 @@ try {
   } else {
     sessionId = crypto.randomUUID();
     try {
-      fs.mkdirSync(HELIUS_DIR, { recursive: true });
+      // Owner-only — this dir also holds the JWT/API-key config (see config.ts).
+      fs.mkdirSync(HELIUS_DIR, { recursive: true, mode: 0o700 });
       fs.writeFileSync(ANON_ID_PATH, sessionId, 'utf-8');
     } catch {}
   }

--- a/helius-mcp/tests/config-permissions.test.ts
+++ b/helius-mcp/tests/config-permissions.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// POSIX-only: mode bits are meaningless on Windows.
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
+
+describePosix('config file permissions', () => {
+  let saveConfig: typeof import('../src/utils/config.js').saveConfig;
+  let loadConfig: typeof import('../src/utils/config.js').loadConfig;
+  let saveKeypairToDisk: typeof import('../src/utils/config.js').saveKeypairToDisk;
+  let SHARED_CONFIG_PATH: string;
+  let KEYPAIR_PATH: string;
+  let fakeHome: string;
+  let configDir: string;
+  let originalHome: string | undefined;
+  let originalUmask: number | undefined;
+
+  beforeAll(async () => {
+    // config.ts resolves ~/.helius at import time, so HOME must point at a
+    // scratch dir before the dynamic import below. os.homedir() reads $HOME on
+    // POSIX, which is why this works.
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'helius-perms-'));
+    configDir = path.join(fakeHome, '.helius');
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    // Simulate the default Debian/Ubuntu umask — the condition under which the
+    // reported 0644 config.json appeared. Without this, a developer running with
+    // umask 077 would get 0600 for free and the create-path assertions below
+    // would pass even against the unfixed code. Not fatal if it fails (umask is
+    // unsettable on some Vitest pools); the pre-existing-permissions tests still
+    // detect a regression on their own.
+    try {
+      originalUmask = process.umask(0o022);
+    } catch {
+      originalUmask = undefined;
+    }
+
+    const mod = await import('../src/utils/config.js');
+    saveConfig = mod.saveConfig;
+    loadConfig = mod.loadConfig;
+    saveKeypairToDisk = mod.saveKeypairToDisk;
+    SHARED_CONFIG_PATH = mod.SHARED_CONFIG_PATH;
+    KEYPAIR_PATH = mod.KEYPAIR_PATH;
+
+    // Guard against ever writing to the developer's real ~/.helius. If the HOME
+    // override did not take effect, these tests would overwrite actual
+    // credentials — fail loudly before a single write happens.
+    if (!SHARED_CONFIG_PATH.startsWith(fakeHome) || !KEYPAIR_PATH.startsWith(fakeHome)) {
+      throw new Error(
+        `HOME override did not take effect — refusing to run. ` +
+          `Expected paths under ${fakeHome}, got ${SHARED_CONFIG_PATH} and ${KEYPAIR_PATH}.`,
+      );
+    }
+  });
+
+  afterAll(() => {
+    if (originalUmask !== undefined) process.umask(originalUmask);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (fakeHome) fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  const mode = (p: string) => fs.statSync(p).mode & 0o777;
+
+  it('writes a newly created config.json as 0600', () => {
+    saveConfig({ jwt: 'test-jwt', apiKey: 'test-api-key' });
+    expect(mode(SHARED_CONFIG_PATH)).toBe(0o600);
+  });
+
+  it('creates the config dir as 0700', () => {
+    saveConfig({ jwt: 'test-jwt' });
+    expect(mode(configDir)).toBe(0o700);
+  });
+
+  // Each test seeds its own config rather than relying on an earlier test's
+  // file, so the suite is order-independent under sequence.shuffle.
+  it('tightens a pre-existing world-readable config.json on save', () => {
+    saveConfig({ jwt: 'seed' });
+    fs.chmodSync(SHARED_CONFIG_PATH, 0o644);
+    saveConfig({ jwt: 'rotated-jwt' });
+    expect(mode(SHARED_CONFIG_PATH)).toBe(0o600);
+  });
+
+  it('tightens a pre-existing world-readable config dir on save', () => {
+    saveConfig({ jwt: 'seed' });
+    fs.chmodSync(configDir, 0o755);
+    saveConfig({ jwt: 'test-jwt' });
+    expect(mode(configDir)).toBe(0o700);
+  });
+
+  // The reported population: set up once, then only read. Nothing on the save
+  // path ever runs again, so loadConfig has to be what tightens the file.
+  it('self-heals a world-readable config.json on load', () => {
+    saveConfig({ jwt: 'stale-jwt', apiKey: 'stale-key' });
+    fs.chmodSync(SHARED_CONFIG_PATH, 0o644);
+    expect(loadConfig()).toEqual({ jwt: 'stale-jwt', apiKey: 'stale-key' });
+    expect(mode(SHARED_CONFIG_PATH)).toBe(0o600);
+  });
+
+  it('self-heals a group-readable config.json on load', () => {
+    saveConfig({ jwt: 'stale-jwt' });
+    fs.chmodSync(SHARED_CONFIG_PATH, 0o640);
+    loadConfig();
+    expect(mode(SHARED_CONFIG_PATH)).toBe(0o600);
+  });
+
+  it('leaves an already-restricted config.json untouched on load', () => {
+    saveConfig({ jwt: 'fine-jwt' });
+    expect(mode(SHARED_CONFIG_PATH)).toBe(0o600);
+    expect(loadConfig()).toEqual({ jwt: 'fine-jwt' });
+    expect(mode(SHARED_CONFIG_PATH)).toBe(0o600);
+  });
+
+  it('does not create a config on load when none exists', () => {
+    fs.rmSync(SHARED_CONFIG_PATH, { force: true });
+    expect(loadConfig()).toEqual({});
+    expect(fs.existsSync(SHARED_CONFIG_PATH)).toBe(false);
+  });
+
+  it('writes the keypair as 0600', () => {
+    saveKeypairToDisk(new Uint8Array(64).fill(7));
+    expect(mode(KEYPAIR_PATH)).toBe(0o600);
+  });
+
+  it('does not corrupt config contents while tightening permissions', () => {
+    saveConfig({ jwt: 'round-trip-jwt', apiKey: 'round-trip-key' });
+    expect(JSON.parse(fs.readFileSync(SHARED_CONFIG_PATH, 'utf-8'))).toEqual({
+      jwt: 'round-trip-jwt',
+      apiKey: 'round-trip-key',
+    });
+  });
+});


### PR DESCRIPTION
This bug was identified by Ray Sabee, [whitehatsecurity.nl](http://whitehatsecurity.nl/), or raysabee on GitHub

## Summary

`~/.helius/config.json` holds the user's JWT and Helius API key. `saveConfig` in `helius-mcp/src/utils/config.ts` wrote it with no mode and no `chmod`, so under the default umask (022) it was created `0644`, which is readable by every local user. `ensureDir` created `~/.helius` modeless for the same reason

`helius-cli` already fixed this in #121. `helius-mcp` never did, and since both packages share the same `config.json`, an MCP write would re-loosen a file the CLI had correctly locked down to `0600`

Reproduced against the pre-fix build under `umask 022`:

```
-rw-r--r--  1 user  staff  47  ~/.helius/config.json
```

After:

```
drwx------  3 user  staff  96  ~/.helius
-rw-------  1 user  staff  47  ~/.helius/config.json
```

## Changes

This PR mirrors the `helius-cli` implementation from #121 to store the config with owner-only permissions

- **`helius-mcp/src/utils/config.ts`** — `saveConfig` writes `{ mode: 0o600 }` plus an unconditional `chmodSync`, with a warn-once fallback if `chmod` throws (i.e., non-POSIX filesystems), so credentials are never left exposed silently. `ensureDir` creates at `0o700` and chmods unconditionally
- **`helius-mcp/src/utils/feedback.ts`** — `mkdirSync` at `0o700`. This runs at module load and could otherwise create `~/.helius` modeless before `config.ts` is reached. The CLI already had this.
- **`helius-mcp/src/utils/config.ts`, `helius-cli/src/commands/keygen.ts`** — keypair writes now pass `{ mode: 0o600 }`. Both were write-then-chmod, leaving a brief window where a freshly generated secret key was world-readable. The `chmod` is retained to cover overwrites of an existing file

`mode` only applies on create, which is why every site keeps both the `mode` and the `chmod`; the `chmod` is what tightens existing installs

## Testing

- New `helius-mcp/tests/config-permissions.test.ts` — 10 tests, and new `helius-cli/tests/config-permissions.test.ts` — 6 tests. Both run under a scratch `HOME` with `umask 022`, and refuse to run if the `HOME` override fails to take effect so they can never touch a real `~/.helius`. Cover fresh create, pre-existing `0644` file, pre-existing `0755` dir, load-path self-heal (`0644` and `0640`), already-`0600` no-op, and content round-trip
- Mutation-tested: reverting the source changes fails 4/10 (MCP) and 1/6 (CLI); reverting only the self-heal fails 2/10 and 1/6
- Order-independent: verified under `--sequence.shuffle`
- helius-mcp: 270/270 passing, `tsc` clean
- helius-cli: 63/63 passing, `tsc` clean
- Verified against the real built `dist` under `umask 022`, not just the harness
