### PR TITLE
fix(mcp): Redact Helius API Key From Tool Output Under a Shared Credential

### DIFF
--- a/helius-mcp/src/router/responses.ts
+++ b/helius-mcp/src/router/responses.ts
@@ -1,4 +1,5 @@
 import { extractSections } from '../utils/docs.js';
+import { redactSecrets } from '../utils/redact.js';
 import type { DetailLevel, ResponseFamily } from './types.js';
 
 // ── Markdown-dependent patterns ──────────────────────────────────────────
@@ -238,14 +239,14 @@ export function applyRangeSelection(text: string, range?: string): string {
 
 export function mcpText(text: string, meta?: Record<string, unknown>): RouterResponse {
   return {
-    content: [{ type: 'text', text }],
+    content: [{ type: 'text', text: redactSecrets(text) }],
     ...(meta === undefined ? {} : { _meta: meta }),
   };
 }
 
 export function mcpErrorCompact(text: string, meta?: Record<string, unknown>): RouterResponse {
   return {
-    content: [{ type: 'text', text }],
+    content: [{ type: 'text', text: redactSecrets(text) }],
     isError: true,
     ...(meta === undefined ? {} : { _meta: meta }),
   };

--- a/helius-mcp/src/utils/errors.ts
+++ b/helius-mcp/src/utils/errors.ts
@@ -1,6 +1,7 @@
 // ─── MCP Response Builders ───
 
 import type { ContinuationHint } from '../results/types.js';
+import { redactSecrets } from './redact.js';
 
 type McpToolResponse = {
   content: [{ type: 'text'; text: string }];
@@ -18,7 +19,7 @@ export type ErrorMeta = {
 
 export function mcpText(text: string, opts?: { continuation?: ContinuationHint }): McpToolResponse {
   return {
-    content: [{ type: 'text', text }],
+    content: [{ type: 'text', text: redactSecrets(text) }],
     ...(opts?.continuation ? { continuation: opts.continuation } : {}),
   };
 }
@@ -27,7 +28,7 @@ export function mcpError(text: string, meta?: ErrorMeta): McpToolResponse {
   const body = meta
     ? '```json\n' + JSON.stringify(meta) + '\n```\n\n' + text
     : text;
-  return { content: [{ type: 'text', text: body }], isError: true };
+  return { content: [{ type: 'text', text: redactSecrets(body) }], isError: true };
 }
 
 // ─── Error Message Extraction ───

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -2,6 +2,8 @@ import { createHelius, type HeliusClient } from 'helius-sdk';
 import { MCP_USER_AGENT } from '../http.js';
 import { getSharedApiKey } from './config.js';
 import { wrapClientWithResilience, withResilience, READ_TIMEOUT_MS } from './resilience.js';
+import { registerSecret } from './redact.js';
+import { isSharedCredentialMode } from './runtime.js';
 
 let sessionApiKey: string | null = null;
 let sessionNetwork: 'mainnet-beta' | 'devnet' = 'mainnet-beta';
@@ -37,6 +39,8 @@ export function getApiKey(): string {
   if (!apiKey) {
     throw new Error('NO_API_KEY: Set HELIUS_API_KEY environment variable or use setHeliusApiKey tool');
   }
+  // Register wherever the key came from so the output scrubber can catch it.
+  registerSecret(apiKey);
   return apiKey;
 }
 
@@ -67,12 +71,19 @@ export function getNetwork(): 'mainnet-beta' | 'devnet' {
 }
 
 export function getEnhancedWebSocketUrl(): string {
-  const apiKey = getApiKey();
   const network = getNetwork();
-  if (network === 'devnet') {
-    return `wss://atlas-devnet.helius-rpc.com/?api-key=${apiKey}`;
+  const host = network === 'devnet'
+    ? 'wss://atlas-devnet.helius-rpc.com'
+    : 'wss://atlas-mainnet.helius-rpc.com';
+
+  // Under a shared server-side credential this URL is tool output that reaches
+  // the caller, so it gets a placeholder the caller substitutes with their own
+  // key. Single-tenant stdio still returns a ready-to-use URL.
+  if (isSharedCredentialMode()) {
+    return `${host}/?api-key=YOUR_HELIUS_API_KEY`;
   }
-  return `wss://atlas-mainnet.helius-rpc.com/?api-key=${apiKey}`;
+
+  return `${host}/?api-key=${getApiKey()}`;
 }
 
 export function getLaserstreamUrl(region?: 'ewr' | 'pitt' | 'slc' | 'lax' | 'lon' | 'ams' | 'fra' | 'tyo' | 'sgp'): string {

--- a/helius-mcp/src/utils/redact.ts
+++ b/helius-mcp/src/utils/redact.ts
@@ -1,0 +1,48 @@
+import { isSharedCredentialMode } from './runtime.js';
+
+/**
+ * Last-resort scrubber for outbound tool text.
+ *
+ * Tools are expected not to emit the API key in the first place; this exists to
+ * catch the paths nobody audited — an upstream error message that echoes a
+ * request URL, a doc snippet with a key in an example, a future tool that
+ * formats an endpoint. It only runs in shared-credential mode, so the
+ * single-tenant stdio build keeps printing the user's own key where that is the
+ * point of the tool.
+ */
+
+const REDACTED = '***REDACTED***';
+
+/** Matches `api-key=<value>` in a query string, however the URL is delimited. */
+const API_KEY_QUERY_RE = /([?&]api-key=)[^&\s'"`)\]}<]+/gi;
+
+const secrets = new Set<string>();
+
+/**
+ * Register a credential to scrub from output. Called wherever a key is
+ * resolved, so the registry covers session, env, and on-disk sources without
+ * each caller having to know which one won.
+ */
+export function registerSecret(value: string | null | undefined): void {
+  // Short values would match far too much text; a real Helius key is a UUID.
+  if (value && value.length >= 8) {
+    secrets.add(value);
+  }
+}
+
+export function clearRegisteredSecrets(): void {
+  secrets.clear();
+}
+
+export function redactSecrets(text: string): string {
+  if (!isSharedCredentialMode()) {
+    return text;
+  }
+
+  let out = text.replace(API_KEY_QUERY_RE, `$1${REDACTED}`);
+  for (const secret of secrets) {
+    // split/join rather than RegExp so key contents need no escaping.
+    out = out.split(secret).join(REDACTED);
+  }
+  return out;
+}

--- a/helius-mcp/src/utils/runtime.ts
+++ b/helius-mcp/src/utils/runtime.ts
@@ -1,0 +1,15 @@
+/**
+ * Deployment mode.
+ *
+ * The stdio build is single-tenant: the Helius API key belongs to whoever is
+ * running the process, so echoing it back — e.g. in the Enhanced WebSocket URL
+ * that `accountSubscribe` prints — is both expected and necessary.
+ *
+ * A hosted build is the opposite: one shared server-side credential serves many
+ * anonymous callers, so the key must never reach tool output. Set
+ * `HELIUS_MCP_SHARED_CREDENTIAL=1` on that deployment.
+ */
+export function isSharedCredentialMode(): boolean {
+  const raw = process.env.HELIUS_MCP_SHARED_CREDENTIAL;
+  return raw === '1' || raw === 'true';
+}

--- a/helius-mcp/tests/redact.test.ts
+++ b/helius-mcp/tests/redact.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { registerSecret, clearRegisteredSecrets, redactSecrets } from '../src/utils/redact.js';
+import { isSharedCredentialMode } from '../src/utils/runtime.js';
+
+const KEY = 'b1f3c9de-4a77-4a2f-9d0e-2c6f8a1b5e44';
+
+function shared(): void {
+  process.env.HELIUS_MCP_SHARED_CREDENTIAL = '1';
+}
+
+beforeEach(() => {
+  clearRegisteredSecrets();
+  delete process.env.HELIUS_MCP_SHARED_CREDENTIAL;
+});
+
+afterEach(() => {
+  clearRegisteredSecrets();
+  delete process.env.HELIUS_MCP_SHARED_CREDENTIAL;
+});
+
+// ─── Mode Detection ───────────────────────────────────────────────────────────
+
+describe('isSharedCredentialMode', () => {
+  it('is off by default so the stdio build is unaffected', () => {
+    expect(isSharedCredentialMode()).toBe(false);
+  });
+
+  it('accepts "1" and "true"', () => {
+    process.env.HELIUS_MCP_SHARED_CREDENTIAL = '1';
+    expect(isSharedCredentialMode()).toBe(true);
+    process.env.HELIUS_MCP_SHARED_CREDENTIAL = 'true';
+    expect(isSharedCredentialMode()).toBe(true);
+  });
+
+  it('ignores other values', () => {
+    process.env.HELIUS_MCP_SHARED_CREDENTIAL = 'no';
+    expect(isSharedCredentialMode()).toBe(false);
+  });
+});
+
+// ─── Single-Tenant Passthrough ────────────────────────────────────────────────
+
+describe('redactSecrets outside shared-credential mode', () => {
+  it('leaves a registered key untouched', () => {
+    registerSecret(KEY);
+    expect(redactSecrets(`key is ${KEY}`)).toBe(`key is ${KEY}`);
+  });
+
+  it('leaves a WebSocket URL usable', () => {
+    const url = `wss://atlas-mainnet.helius-rpc.com/?api-key=${KEY}`;
+    expect(redactSecrets(url)).toBe(url);
+  });
+});
+
+// ─── Shared-Credential Redaction ──────────────────────────────────────────────
+
+describe('redactSecrets in shared-credential mode', () => {
+  it('redacts a registered key', () => {
+    shared();
+    registerSecret(KEY);
+    const out = redactSecrets(`key is ${KEY}`);
+    expect(out).not.toContain(KEY);
+    expect(out).toContain('***REDACTED***');
+  });
+
+  it('redacts every occurrence', () => {
+    shared();
+    registerSecret(KEY);
+    const out = redactSecrets(`${KEY} and again ${KEY}`);
+    expect(out).not.toContain(KEY);
+  });
+
+  it('redacts an api-key query param even when the key was never registered', () => {
+    shared();
+    const out = redactSecrets(`https://api.helius.xyz/v0/addresses/x?api-key=${KEY}`);
+    expect(out).not.toContain(KEY);
+    expect(out).toContain('api-key=***REDACTED***');
+  });
+
+  it('redacts a key in a ws URL and keeps the host readable', () => {
+    shared();
+    registerSecret(KEY);
+    const out = redactSecrets(`wss://atlas-mainnet.helius-rpc.com/?api-key=${KEY}`);
+    expect(out).not.toContain(KEY);
+    expect(out).toContain('atlas-mainnet.helius-rpc.com');
+  });
+
+  it('stops at the next query param rather than eating the rest of the URL', () => {
+    shared();
+    const out = redactSecrets(`https://api.helius.xyz/v0/x?api-key=${KEY}&limit=10`);
+    expect(out).not.toContain(KEY);
+    expect(out).toContain('&limit=10');
+  });
+
+  it('stops at a closing backtick in fenced output', () => {
+    shared();
+    const out = redactSecrets(`\`https://api.helius.xyz/x?api-key=${KEY}\` then prose`);
+    expect(out).not.toContain(KEY);
+    expect(out).toContain('` then prose');
+  });
+
+  it('leaves text without secrets unchanged', () => {
+    shared();
+    registerSecret(KEY);
+    const text = '## Balance\n\n**SOL:** 1.234';
+    expect(redactSecrets(text)).toBe(text);
+  });
+
+  it('ignores short or empty values so ordinary text survives', () => {
+    shared();
+    registerSecret('');
+    registerSecret('abc');
+    const text = 'abc is a common substring';
+    expect(redactSecrets(text)).toBe(text);
+  });
+});


### PR DESCRIPTION
## Why

We currently post the API key:

`getEnhancedWebSocketUrl()` builds `wss://atlas-mainnet.helius-rpc.com/?api-key=<key>`,
and `enhanced-websockets.ts` prints that straight into tool output:

```ts
`**URL:** \`${wsUrl}\``
```

This is okay for single-tenant; that's the correct behavior. It's the user's own key and the URL is useless without it. Multi-tenant on a shared credential: every caller gets Helius's production key in plaintext

## What

**`HELIUS_MCP_SHARED_CREDENTIAL=1`** — new env flag marking a deployment as one-credential-many-callers. Unset by default, so this PR is a no-op for the npm package and the Claude/Cursor plugins, but is necessary for our OpenAI plugin

When set:

1. `getEnhancedWebSocketUrl()` returns a `YOUR_HELIUS_API_KEY` placeholder rather than the live key. Output stays instructive instead of breaking.
2. `redactSecrets()` scrubs outbound text at both response boundaries — `router/responses.ts` (`mcpText`, `mcpErrorCompact`, and `mcpResultHandle` via `mcpText`) and `utils/errors.ts` (`mcpText`, `mcpError`)

Redaction matches two ways: registered credential values, and any `api-key=` query param regardless of whether that value was ever registered. Keys register in `getApiKey()`, so session, `HELIUS_API_KEY`, and `~/.helius/config.json` sources are all covered without callers knowing which one won

## Testing

- `pnpm test` — 283 passing (270 before, 13 new in `tests/redact.test.ts`)
- New coverage: mode detection and its default-off state, passthrough when the flag
is unset (both a bare key and a full ws URL survive), redaction of registered keys and unregistered `api-key=` params, multiple occurrences, boundary handling (stops at `&nextparam` and at a closing backtick rather than eating the rest of the line), and the two false-positive guards (clean text unchanged, short/empty values ignored)