### PR TITLE
fix(mcp): Scope Result-handle Store Per Session

### DIFF
--- a/helius-mcp/src/results/store.ts
+++ b/helius-mcp/src/results/store.ts
@@ -1,52 +1,100 @@
 import { randomUUID } from 'node:crypto';
 import type { StoredResult } from './types.js';
 
-const MAX_RESULTS = 10;
-const MAX_TOTAL_PAYLOAD_BYTES = 250 * 1024;
+/**
+ * Cache of summary-first result handles, keyed by session and then by resultId.
+ *
+ * The stored payload is a *recipe* (public tool, action, params, continuation),
+ * not the response data — `expandStoredResult` re-runs the action. That has two
+ * consequences worth knowing before changing anything here:
+ *
+ * 1. Entries are small (hundreds of bytes), so the practical memory bound is
+ *    MAX_SESSIONS * MAX_RESULTS_PER_SESSION, not the byte caps.
+ * 2. A miss is recoverable — the caller is told to re-run the original action —
+ *    so evicting aggressively is safe, but evicting *another session's* entries
+ *    is not: it makes `expandResult` fail for a caller who did nothing wrong.
+ *
+ * Point 2 is why the caps below are per session. A single flat Map with a global
+ * cap of 10 works for one stdio user and breaks under concurrency, where callers
+ * silently evict each other. Buckets also make ownership structural instead of a
+ * post-hoc comparison: a session cannot name another session's entries at all.
+ */
+
+const MAX_RESULTS_PER_SESSION = 10;
+const MAX_PAYLOAD_BYTES_PER_SESSION = 250 * 1024;
+/** Bounds total memory by capping distinct sessions, LRU-evicting whole buckets. */
+const MAX_SESSIONS = 256;
 const RESULT_TTL_MS = 5 * 60 * 1000;
 
-const results = new Map<string, StoredResult>();
+type SessionBucket = Map<string, StoredResult>;
+
+/** Insertion order doubles as LRU order, for both sessions and entries. */
+const sessions = new Map<string, SessionBucket>();
 
 function estimateBytes(value: unknown): number {
   return Buffer.byteLength(JSON.stringify(value), 'utf8');
 }
 
-function sweepExpired(now = Date.now()): void {
-  for (const [resultId, result] of results) {
-    if (result.expiresAt <= now) {
-      results.delete(resultId);
-    }
-  }
-}
-
-function currentTotalBytes(): number {
+function bucketBytes(bucket: SessionBucket): number {
   let total = 0;
-  for (const result of results.values()) {
+  for (const result of bucket.values()) {
     total += result.payloadSize;
   }
   return total;
 }
 
-function touch(resultId: string, result: StoredResult): void {
-  results.delete(resultId);
-  results.set(resultId, result);
+function sweepExpired(now = Date.now()): void {
+  for (const [sessionKey, bucket] of sessions) {
+    for (const [resultId, result] of bucket) {
+      if (result.expiresAt <= now) {
+        bucket.delete(resultId);
+      }
+    }
+    if (bucket.size === 0) {
+      sessions.delete(sessionKey);
+    }
+  }
 }
 
-function evictToFit(): void {
-  sweepExpired();
+/** Move to the end of the Map so the least recently used stays at the front. */
+function touch<K, V>(map: Map<K, V>, key: K, value: V): void {
+  map.delete(key);
+  map.set(key, value);
+}
 
-  while (results.size > MAX_RESULTS || currentTotalBytes() > MAX_TOTAL_PAYLOAD_BYTES) {
-    const oldest = results.keys().next().value;
-    if (!oldest) {
+function evictBucketToFit(bucket: SessionBucket): void {
+  while (bucket.size > MAX_RESULTS_PER_SESSION || bucketBytes(bucket) > MAX_PAYLOAD_BYTES_PER_SESSION) {
+    // Stop before emptying the bucket. The entry that triggered eviction is the
+    // newest, so the only way to reach size 1 is that entry alone exceeding the
+    // byte cap — and evicting it would hand the caller a resultId that resolves
+    // to nothing. Keeping one oversized entry is the better failure: the handle
+    // works, and the TTL reclaims it.
+    if (bucket.size <= 1) {
       break;
     }
-    results.delete(oldest);
+    const oldest = bucket.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    bucket.delete(oldest);
+  }
+}
+
+function evictSessionsToFit(): void {
+  while (sessions.size > MAX_SESSIONS) {
+    const oldest = sessions.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    sessions.delete(oldest);
   }
 }
 
 export function putStoredResult(
   input: Omit<StoredResult, 'resultId' | 'createdAt' | 'expiresAt' | 'payloadSize'>,
 ): StoredResult {
+  sweepExpired();
+
   const createdAt = Date.now();
   const payloadSize = estimateBytes(input.payload);
   const stored: StoredResult = {
@@ -57,35 +105,66 @@ export function putStoredResult(
     payloadSize,
   };
 
-  results.set(stored.resultId, stored);
-  evictToFit();
+  let bucket = sessions.get(stored.ownerSessionKey);
+  if (!bucket) {
+    bucket = new Map();
+  }
+  bucket.set(stored.resultId, stored);
+  evictBucketToFit(bucket);
+
+  touch(sessions, stored.ownerSessionKey, bucket);
+  evictSessionsToFit();
+
   return stored;
 }
 
 export function getStoredResult(resultId: string, ownerSessionKey: string): StoredResult | null {
   sweepExpired();
 
-  const result = results.get(resultId);
+  const bucket = sessions.get(ownerSessionKey);
+  if (!bucket) {
+    return null;
+  }
+
+  const result = bucket.get(resultId);
   if (!result) {
     return null;
   }
 
-  if (result.ownerSessionKey !== ownerSessionKey) {
-    return null;
-  }
-
-  touch(resultId, result);
+  touch(bucket, resultId, result);
+  touch(sessions, ownerSessionKey, bucket);
   return result;
 }
 
 export function clearStoredResults(): void {
-  results.clear();
+  sessions.clear();
 }
 
-export function getStoredResultStats(): { count: number; totalPayloadBytes: number } {
+/**
+ * Counts across every session, or within one when `ownerSessionKey` is given.
+ */
+export function getStoredResultStats(ownerSessionKey?: string): {
+  count: number;
+  totalPayloadBytes: number;
+  sessions: number;
+} {
   sweepExpired();
-  return {
-    count: results.size,
-    totalPayloadBytes: currentTotalBytes(),
-  };
+
+  if (ownerSessionKey !== undefined) {
+    const bucket = sessions.get(ownerSessionKey);
+    return {
+      count: bucket?.size ?? 0,
+      totalPayloadBytes: bucket ? bucketBytes(bucket) : 0,
+      sessions: bucket ? 1 : 0,
+    };
+  }
+
+  let count = 0;
+  let totalPayloadBytes = 0;
+  for (const bucket of sessions.values()) {
+    count += bucket.size;
+    totalPayloadBytes += bucketBytes(bucket);
+  }
+
+  return { count, totalPayloadBytes, sessions: sessions.size };
 }

--- a/helius-mcp/tests/result-store.test.ts
+++ b/helius-mcp/tests/result-store.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  putStoredResult,
+  getStoredResult,
+  clearStoredResults,
+  getStoredResultStats,
+} from '../src/results/store.js';
+
+const MAX_RESULTS_PER_SESSION = 10;
+const MAX_SESSIONS = 256;
+const RESULT_TTL_MS = 5 * 60 * 1000;
+
+function put(ownerSessionKey: string, topic = 'billing') {
+  return putStoredResult({
+    kind: 'document',
+    ownerSessionKey,
+    summary: `summary for ${topic}`,
+    availableExpansions: ['full'],
+    payload: {
+      recipe: {
+        publicTool: 'heliusKnowledge',
+        action: 'lookupHeliusDocs',
+        params: { topic },
+        responseFamily: 'document',
+        defaultDetail: 'summary',
+      },
+      continuation: { model: 'none' },
+    },
+  });
+}
+
+beforeEach(() => {
+  clearStoredResults();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearStoredResults();
+});
+
+// ─── Session Isolation ────────────────────────────────────────────────────────
+
+describe('session isolation', () => {
+  it('returns an entry to its own session', () => {
+    const stored = put('session-a');
+    expect(getStoredResult(stored.resultId, 'session-a')?.resultId).toBe(stored.resultId);
+  });
+
+  it('hides an entry from a different session', () => {
+    const stored = put('session-a');
+    expect(getStoredResult(stored.resultId, 'session-b')).toBeNull();
+  });
+
+  it('returns null for an unknown session', () => {
+    const stored = put('session-a');
+    expect(getStoredResult(stored.resultId, 'never-seen')).toBeNull();
+  });
+
+  it('returns null for an unknown resultId within a known session', () => {
+    put('session-a');
+    expect(getStoredResult('no-such-id', 'session-a')).toBeNull();
+  });
+
+  it('keeps entries with the same recipe in separate sessions distinct', () => {
+    const a = put('session-a', 'credits');
+    const b = put('session-b', 'credits');
+    expect(a.resultId).not.toBe(b.resultId);
+    expect(getStoredResult(a.resultId, 'session-b')).toBeNull();
+    expect(getStoredResult(b.resultId, 'session-a')).toBeNull();
+  });
+});
+
+// ─── Cross-Session Eviction (the concurrency bug) ─────────────────────────────
+
+describe('cross-session eviction', () => {
+  it('does not evict another session when one session fills its bucket', () => {
+    const victim = put('session-a');
+
+    for (let i = 0; i < MAX_RESULTS_PER_SESSION * 3; i += 1) {
+      put('session-b', `topic-${i}`);
+    }
+
+    expect(getStoredResult(victim.resultId, 'session-a')).not.toBeNull();
+  });
+
+  it('holds the per-session cap for every session independently', () => {
+    for (let i = 0; i < MAX_RESULTS_PER_SESSION + 5; i += 1) {
+      put('session-a', `a-${i}`);
+      put('session-b', `b-${i}`);
+    }
+
+    expect(getStoredResultStats('session-a').count).toBe(MAX_RESULTS_PER_SESSION);
+    expect(getStoredResultStats('session-b').count).toBe(MAX_RESULTS_PER_SESSION);
+    // The assertion that distinguishes per-session caps from a shared one: under
+    // a single global cap of 10 the total here would be 10, not 20.
+    expect(getStoredResultStats().count).toBe(MAX_RESULTS_PER_SESSION * 2);
+  });
+
+  it('evicts the oldest entry within the overflowing session only', () => {
+    const bystander = put('session-b', 'bystander');
+    const first = put('session-a', 'first');
+    for (let i = 0; i < MAX_RESULTS_PER_SESSION; i += 1) {
+      put('session-a', `filler-${i}`);
+    }
+
+    expect(getStoredResult(first.resultId, 'session-a')).toBeNull();
+    expect(getStoredResultStats('session-a').count).toBe(MAX_RESULTS_PER_SESSION);
+    expect(getStoredResult(bystander.resultId, 'session-b')).not.toBeNull();
+  });
+
+  it('keeps the entry it just stored even when that entry alone exceeds the byte cap', () => {
+    const oversized = putStoredResult({
+      kind: 'document',
+      ownerSessionKey: 'session-a',
+      summary: 'oversized',
+      availableExpansions: ['full'],
+      payload: {
+        recipe: {
+          publicTool: 'heliusKnowledge',
+          action: 'lookupHeliusDocs',
+          // Deliberately past MAX_PAYLOAD_BYTES_PER_SESSION on its own.
+          params: { topic: 'x'.repeat(300 * 1024) },
+          responseFamily: 'document',
+          defaultDetail: 'summary',
+        },
+        continuation: { model: 'none' },
+      },
+    });
+
+    expect(getStoredResult(oversized.resultId, 'session-a')).not.toBeNull();
+    expect(getStoredResultStats('session-a').count).toBe(1);
+  });
+
+  it('spares a recently read entry when the bucket overflows', () => {
+    const early = put('session-a', 'early');
+    for (let i = 0; i < MAX_RESULTS_PER_SESSION - 1; i += 1) {
+      put('session-a', `filler-${i}`);
+    }
+
+    // Reading promotes it, so the next insert should evict something else.
+    expect(getStoredResult(early.resultId, 'session-a')).not.toBeNull();
+    put('session-a', 'overflow');
+
+    expect(getStoredResult(early.resultId, 'session-a')).not.toBeNull();
+  });
+});
+
+// ─── Global Session Cap ───────────────────────────────────────────────────────
+
+describe('global session cap', () => {
+  it('bounds the number of tracked sessions', () => {
+    for (let i = 0; i < MAX_SESSIONS + 20; i += 1) {
+      put(`session-${i}`);
+    }
+
+    expect(getStoredResultStats().sessions).toBeLessThanOrEqual(MAX_SESSIONS);
+  });
+
+  it('evicts the least recently used session first', () => {
+    const oldest = put('session-oldest');
+    for (let i = 0; i < MAX_SESSIONS; i += 1) {
+      put(`session-${i}`);
+    }
+
+    expect(getStoredResult(oldest.resultId, 'session-oldest')).toBeNull();
+  });
+});
+
+// ─── Expiry ───────────────────────────────────────────────────────────────────
+
+describe('expiry', () => {
+  it('drops an entry once its TTL has passed', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-06T00:00:00Z'));
+
+    const stored = put('session-a');
+    expect(getStoredResult(stored.resultId, 'session-a')).not.toBeNull();
+
+    vi.setSystemTime(new Date(Date.now() + RESULT_TTL_MS + 1));
+    expect(getStoredResult(stored.resultId, 'session-a')).toBeNull();
+  });
+
+  it('forgets a session whose entries have all expired', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-06T00:00:00Z'));
+
+    put('session-a');
+    vi.setSystemTime(new Date(Date.now() + RESULT_TTL_MS + 1));
+
+    expect(getStoredResultStats().sessions).toBe(0);
+  });
+});
+
+// ─── Stats ────────────────────────────────────────────────────────────────────
+
+describe('stats', () => {
+  it('reports zero on an empty store', () => {
+    expect(getStoredResultStats()).toEqual({ count: 0, totalPayloadBytes: 0, sessions: 0 });
+  });
+
+  it('aggregates across sessions when no session is given', () => {
+    put('session-a');
+    put('session-b');
+
+    const stats = getStoredResultStats();
+    expect(stats.count).toBe(2);
+    expect(stats.sessions).toBe(2);
+    expect(stats.totalPayloadBytes).toBeGreaterThan(0);
+  });
+
+  it('scopes to one session when given', () => {
+    put('session-a');
+    put('session-b');
+    put('session-b');
+
+    expect(getStoredResultStats('session-a').count).toBe(1);
+    expect(getStoredResultStats('session-b').count).toBe(2);
+  });
+
+  it('reports zero for a session it has never seen', () => {
+    put('session-a');
+    expect(getStoredResultStats('nope')).toEqual({ count: 0, totalPayloadBytes: 0, sessions: 0 });
+  });
+});


### PR DESCRIPTION
## Why

This PR preps for hosting the MCP for concurrent callers. `results/store.ts` was written for one process serving one user, and two of its choices don't survive that assumption changing

The caps were global. `MAX_RESULTS = 10` and `MAX_TOTAL_PAYLOAD_BYTES = 250KB` applied to the whole process, so with N concurrent callers each effectively got `10/N` handles. Caller A's eleventh query silently evicted caller B's handle, and B's next `expandResult` failed with "Result handle not found" having done nothing wrong. Worse, it's interleaving-dependent, meaning it would pass every local test and fail in production

Ownership was a comparison, and not a boundary. Every entry lived in one Map and `getStoredResult` compared `ownerSessionKey` after lookup. That's correct, but it means isolation depends on one `if` continuing to be right

## What

Store is now `Map<sessionKey, Map<resultId, StoredResult>>`:

- `MAX_RESULTS_PER_SESSION = 10` and `MAX_PAYLOAD_BYTES_PER_SESSION = 250KB`; same numbers as before, now per caller rather than shared
- `MAX_SESSIONS = 256`, LRU-evicting whole buckets, so total memory stays bounded
- lookups resolve the caller's bucket first, so a session cannot name another session's entries at all
- `getStoredResultStats(ownerSessionKey?)` takes an optional filter and reports a `sessions` count

LRU ordering uses Map insertion order at both levels, with a `touch` on read that promotes the entry and its bucket

`evictBucketToFit` looped while the bucket exceeded the byte cap, so an entry larger than the cap on its own would
evict itself; `putStoredResult` returned a `resultId` that resolved to nothing. The old flat-Map code had the same flaw. Eviction now stops at `size <= 1`: one oversized entry is retained, the handle works, and the TTL reclaims it. Reachable only via a pathological `params` blob, but it's two lines and a test

## Testing

- `pnpm test` — 301 passing, 18 new in `tests/result-store.test.ts`
- Checked the new suite out against the previous implementation and 10/18 failed
- Coverage includes isolation in both directions, per-session cap enforcement, LRU promotion sparing a recently-read entry, global session-cap eviction of the least recently used bucket, the oversized-entry case, TTL expiry including forgetting an emptied session, and stats both aggregated and scoped