### PR TITLE
fix(mcp): Refuse Runtime Config Mutation Under a Shared Credential

### DIFF
--- a/helius-mcp/src/index.ts
+++ b/helius-mcp/src/index.ts
@@ -6,6 +6,7 @@ import { registerTools } from './tools/index.js';
 import { ROUTER_INSTRUCTIONS } from './router/instructions.js';
 import { setApiKey, setSessionSecretKey, setSessionWalletAddress } from './utils/helius.js';
 import { getSharedApiKey, loadKeypairFromDisk } from './utils/config.js';
+import { isSharedCredentialMode } from './utils/runtime.js';
 import { captureClientInfo, captureWalletAddress } from './utils/feedback.js';
 import { loadKeypair } from 'helius-sdk/auth/loadKeypair';
 import { getAddress } from 'helius-sdk/auth/getAddress';
@@ -34,26 +35,42 @@ registerTools(server);
 };
 
 async function main() {
-  if (process.env.HELIUS_API_KEY) {
-    setApiKey(process.env.HELIUS_API_KEY);
-  } else {
-    const sharedKey = getSharedApiKey();
-    if (sharedKey) {
-      setApiKey(sharedKey);
+  if (isSharedCredentialMode()) {
+    // Fail at deploy time rather than answering every request with NO_API_KEY,
+    // which looks like a healthy server serving errors.
+    if (!process.env.HELIUS_API_KEY) {
+      console.error(
+        'HELIUS_MCP_SHARED_CREDENTIAL is set but HELIUS_API_KEY is missing. '
+        + 'A shared-credential deployment must be given its key via the environment.',
+      );
+      process.exit(1);
     }
-  }
 
-  // Load persisted keypair from disk so MCP survives restarts
-  const diskKey = loadKeypairFromDisk();
-  if (diskKey) {
-    try {
-      const walletKeypair = loadKeypair(diskKey);
-      const address = await getAddress(walletKeypair);
-      setSessionSecretKey(diskKey);
-      setSessionWalletAddress(address);
-      captureWalletAddress(address);
-    } catch {
-      // Ignore invalid keypair on disk
+    // getApiKey() already resolves HELIUS_API_KEY, so there is nothing to seed.
+    // Deliberately no keypair: a server acting for many callers must not hold a
+    // signing key, and the tools that would use one are off this surface.
+  } else {
+    if (process.env.HELIUS_API_KEY) {
+      setApiKey(process.env.HELIUS_API_KEY);
+    } else {
+      const sharedKey = getSharedApiKey();
+      if (sharedKey) {
+        setApiKey(sharedKey);
+      }
+    }
+
+    // Load persisted keypair from disk so MCP survives restarts
+    const diskKey = loadKeypairFromDisk();
+    if (diskKey) {
+      try {
+        const walletKeypair = loadKeypair(diskKey);
+        const address = await getAddress(walletKeypair);
+        setSessionSecretKey(diskKey);
+        setSessionWalletAddress(address);
+        captureWalletAddress(address);
+      } catch {
+        // Ignore invalid keypair on disk
+      }
     }
   }
 

--- a/helius-mcp/src/tools/auth.ts
+++ b/helius-mcp/src/tools/auth.ts
@@ -23,6 +23,7 @@ import {
   loadSignerOrFail,
 } from '../utils/helius.js';
 import { mcpText, mcpError, handleToolError } from '../utils/errors.js';
+import { isSharedCredentialMode, sharedCredentialRefusal, SHARED_CREDENTIAL_META } from '../utils/runtime.js';
 import { fetchDoc, extractSections } from '../utils/docs.js';
 import { sendFeedbackEvent, captureWalletAddress } from '../utils/feedback.js';
 import {
@@ -154,6 +155,12 @@ export function registerAuthTools(server: McpServer) {
     'Generate a new Solana keypair (or load the existing one from disk). Returns the wallet address. Required before any `signup` call — the wallet address is bound to the payment intent in both link and autopay modes.',
     {},
     async () => {
+      // Would write a private key to the host's disk and install a signer every
+      // caller shares.
+      if (isSharedCredentialMode()) {
+        return mcpError(sharedCredentialRefusal('Keypair generation'), SHARED_CREDENTIAL_META);
+      }
+
       try {
         const existingKey = loadKeypairFromDisk();
         if (existingKey) {
@@ -217,6 +224,14 @@ export function registerAuthTools(server: McpServer) {
       frictionPoints: z.string().optional().describe('What friction did you hit?'),
     },
     async ({ mode, plan, period, email, firstName, lastName, couponCode, discoveryPath, frictionPoints }) => {
+      // Refuse up front rather than partway through. Every terminal branch calls
+      // setApiKey() one line before rendering the provisioned key, so under a
+      // shared credential the caller would pay, then get a SHARED_CREDENTIAL
+      // throw instead of the key they just bought.
+      if (isSharedCredentialMode()) {
+        return mcpError(sharedCredentialRefusal('Account signup'), SHARED_CREDENTIAL_META);
+      }
+
       if (discoveryPath || frictionPoints) {
         sendFeedbackEvent({
           type: 'discovery',

--- a/helius-mcp/src/tools/config.ts
+++ b/helius-mcp/src/tools/config.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { setApiKey, setNetwork, hasApiKey, getHeliusClient } from '../utils/helius.js';
+import { isSharedCredentialMode } from '../utils/runtime.js';
 import { mcpText, mcpError, validateEnum, getErrorMessage } from '../utils/errors.js';
 import { setSharedApiKey, SHARED_CONFIG_PATH } from '../utils/config.js';
 
@@ -17,6 +18,20 @@ export function registerConfigTools(server: McpServer) {
       network: z.string().optional().default('mainnet-beta').describe('Network to use (default: mainnet-beta)')
     },
     async ({ apiKey, network }) => {
+      // Refuse before validating input: under a shared credential this tool has
+      // no per-caller meaning, and honoring it would repoint the key and network
+      // for every concurrent caller and write the value to disk. The existing
+      // env-var branch below happens to cover the common hosted case, but only
+      // because the key arrives via HELIUS_API_KEY — it fails open if the
+      // credential is mounted as a config file instead.
+      if (isSharedCredentialMode()) {
+        return mcpError(
+          'This server runs with a fixed, deployment-managed Helius API key, so it cannot be set per session. '
+          + 'Queries work without any key configuration. To use your own key, run the Helius MCP locally: `npx helius-mcp@latest`.',
+          { type: 'UNSUPPORTED', code: 'SHARED_CREDENTIAL', retryable: false, recovery: 'Call the query tools directly — no API key setup is needed on this server.' },
+        );
+      }
+
       const err = validateEnum(network, ['mainnet-beta', 'devnet'], 'API Key Error', 'network');
       if (err) return err;
 

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -125,6 +125,13 @@ export function getLaserstreamUrl(region?: 'ewr' | 'pitt' | 'slc' | 'lax' | 'lon
  * Throws with message 'NO_KEYPAIR' if no keypair is available.
  */
 export async function loadSignerOrFail(): Promise<{ secretKey: Uint8Array; walletAddress: string }> {
+  // Skipping the keypair at startup is not enough on its own: this loads lazily
+  // from disk on first use, which would reinstate a process-global signer that
+  // every caller then shares. Refuse before touching the filesystem.
+  if (isSharedCredentialMode()) {
+    throw new Error('SHARED_CREDENTIAL_NO_SIGNER: this server holds no signing key.');
+  }
+
   // Lazy-import to avoid circular deps (config → helius → config)
   const { loadKeypairFromDisk } = await import('./config.js');
   const { loadKeypair } = await import('helius-sdk/auth/loadKeypair');

--- a/helius-mcp/src/utils/helius.ts
+++ b/helius-mcp/src/utils/helius.ts
@@ -29,7 +29,28 @@ export function getSessionWalletAddress(): string | null {
   return sessionWalletAddress;
 }
 
+/**
+ * Runtime credential and network state is module-global — one process, one
+ * caller. That holds for stdio, where the process belongs to a single user.
+ *
+ * Under a shared credential it does not: a mutation from any caller lands on
+ * every concurrent caller, so the setters below refuse. This is a backstop, not
+ * the real isolation — genuine per-caller state arrives with the streamable HTTP
+ * entrypoint, which can key state off the request. Until then, shared-credential
+ * deployments are read-only with respect to configuration: the key comes from
+ * HELIUS_API_KEY and the network from HELIUS_NETWORK, both fixed at deploy time.
+ */
+function assertConfigurableAtRuntime(what: string): void {
+  if (isSharedCredentialMode()) {
+    throw new Error(
+      `SHARED_CREDENTIAL: ${what} is fixed by deployment configuration and cannot be changed at runtime. `
+      + 'Changing it would affect every concurrent caller of this server.',
+    );
+  }
+}
+
 export function setApiKey(apiKey: string): void {
+  assertConfigurableAtRuntime('the Helius API key');
   sessionApiKey = apiKey;
   heliusClient = null; // Reset client so it picks up new key
 }
@@ -59,6 +80,7 @@ export function getHeliusClient(): HeliusClient {
 }
 
 export function setNetwork(network: 'mainnet-beta' | 'devnet'): void {
+  assertConfigurableAtRuntime('the network');
   sessionNetwork = network;
 }
 

--- a/helius-mcp/src/utils/ows.ts
+++ b/helius-mcp/src/utils/ows.ts
@@ -22,6 +22,7 @@ import { promisify } from 'node:util';
 import { address, createKeyPairSignerFromBytes, type Address } from '@solana/kit';
 import { loadSignerOrFail, getNetwork } from './helius.js';
 import { mcpError } from './errors.js';
+import { isSharedCredentialMode, sharedCredentialRefusal, SHARED_CREDENTIAL_META } from './runtime.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -163,6 +164,19 @@ export async function resolveOwsOrKeypairSigner(owsWallet?: string): Promise<
   | { ok: true; signer: any; walletAddress: string; owsWallet?: string }
   | { ok: false; error: ReturnType<typeof mcpError> }
 > {
+  // Ahead of both branches: the OWS path shells out to a wallet CLI on the host,
+  // and the fallback path loads a keypair from the host's disk. Neither is a
+  // per-caller wallet, so neither belongs on a server serving many callers.
+  // Checked here rather than relying on loadSignerOrFail throwing, because the
+  // catch below flattens every failure into "call generateKeypair" — which in
+  // shared mode is advice that also refuses.
+  if (isSharedCredentialMode()) {
+    return { ok: false, error: mcpError(
+      sharedCredentialRefusal('Transaction signing'),
+      SHARED_CREDENTIAL_META,
+    ) };
+  }
+
   if (owsWallet) {
     if (!WALLET_NAME_RE.test(owsWallet)) {
       return { ok: false, error: mcpError(

--- a/helius-mcp/src/utils/runtime.ts
+++ b/helius-mcp/src/utils/runtime.ts
@@ -1,3 +1,5 @@
+import type { ErrorMeta } from './errors.js';
+
 /**
  * Deployment mode.
  *
@@ -12,4 +14,23 @@
 export function isSharedCredentialMode(): boolean {
   const raw = process.env.HELIUS_MCP_SHARED_CREDENTIAL;
   return raw === '1' || raw === 'true';
+}
+
+/**
+ * Refusal for capabilities that need a wallet or mutate process-global config.
+ * Shared between the tool layer and the signer helpers so a caller gets the same
+ * explanation wherever they hit the boundary.
+ */
+export const SHARED_CREDENTIAL_META: ErrorMeta = {
+  type: 'UNSUPPORTED',
+  code: 'SHARED_CREDENTIAL',
+  retryable: false,
+  recovery: 'Run the Helius MCP locally (`npx helius-mcp@latest`) for wallet and account operations.',
+};
+
+export function sharedCredentialRefusal(capability: string): string {
+  return `${capability} is unavailable on this server. It serves many callers from one `
+    + 'deployment-managed credential and holds no wallet, so it cannot generate keys, sign '
+    + 'transactions, or provision accounts. Run the Helius MCP locally for those: '
+    + '`npx helius-mcp@latest`.';
 }

--- a/helius-mcp/tests/shared-credential.test.ts
+++ b/helius-mcp/tests/shared-credential.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock filesystem-dependent config to keep tests hermetic
+vi.mock('../src/utils/config.js', () => ({
+  getSharedApiKey: vi.fn(() => undefined),
+  loadConfig: vi.fn(() => ({})),
+  saveConfig: vi.fn(),
+  setSharedApiKey: vi.fn(),
+  getJwt: vi.fn(() => undefined),
+  setJwt: vi.fn(),
+  getPreferences: vi.fn(() => ({})),
+  savePreferences: vi.fn(),
+  keypairExistsOnDisk: vi.fn(() => false),
+  loadKeypairFromDisk: vi.fn(() => null),
+  saveKeypairToDisk: vi.fn(),
+  SHARED_CONFIG_PATH: '',
+  KEYPAIR_PATH: '',
+}));
+
+vi.mock('helius-sdk', () => ({
+  createHelius: vi.fn(() => ({ mock: 'helius-client' })),
+}));
+
+import {
+  setApiKey,
+  getApiKey,
+  hasApiKey,
+  setNetwork,
+  getNetwork,
+  getEnhancedWebSocketUrl,
+} from '../src/utils/helius.js';
+
+const SERVER_KEY = 'b1f3c9de-4a77-4a2f-9d0e-2c6f8a1b5e44';
+
+function enterSharedMode(): void {
+  process.env.HELIUS_MCP_SHARED_CREDENTIAL = '1';
+}
+
+beforeEach(() => {
+  delete process.env.HELIUS_MCP_SHARED_CREDENTIAL;
+  delete process.env.HELIUS_API_KEY;
+  delete process.env.HELIUS_NETWORK;
+  // Clear module-global session state while mutation is still permitted.
+  setApiKey('');
+  setNetwork('mainnet-beta');
+});
+
+afterEach(() => {
+  delete process.env.HELIUS_MCP_SHARED_CREDENTIAL;
+  delete process.env.HELIUS_API_KEY;
+  delete process.env.HELIUS_NETWORK;
+});
+
+// ─── Runtime Mutation Is Refused ──────────────────────────────────────────────
+
+describe('setApiKey under a shared credential', () => {
+  it('refuses, so one caller cannot repoint the key for everyone', () => {
+    enterSharedMode();
+    expect(() => setApiKey('caller-supplied-key')).toThrow('SHARED_CREDENTIAL');
+  });
+
+  it('leaves the deployment key in place after a refused attempt', () => {
+    process.env.HELIUS_API_KEY = SERVER_KEY;
+    enterSharedMode();
+
+    expect(() => setApiKey('caller-supplied-key')).toThrow();
+    expect(getApiKey()).toBe(SERVER_KEY);
+  });
+
+  it('still works in single-tenant mode', () => {
+    setApiKey('my-own-key');
+    expect(getApiKey()).toBe('my-own-key');
+  });
+});
+
+describe('setNetwork under a shared credential', () => {
+  it('refuses, since the network is process-global', () => {
+    enterSharedMode();
+    expect(() => setNetwork('devnet')).toThrow('SHARED_CREDENTIAL');
+  });
+
+  it('leaves the deployment network in place after a refused attempt', () => {
+    enterSharedMode();
+    expect(() => setNetwork('devnet')).toThrow();
+    expect(getNetwork()).toBe('mainnet-beta');
+  });
+
+  it('still works in single-tenant mode', () => {
+    setNetwork('devnet');
+    expect(getNetwork()).toBe('devnet');
+  });
+});
+
+// ─── Deployment Configuration Still Resolves ──────────────────────────────────
+
+describe('deployment-provided configuration', () => {
+  it('resolves the key from HELIUS_API_KEY without any runtime seeding', () => {
+    process.env.HELIUS_API_KEY = SERVER_KEY;
+    enterSharedMode();
+
+    expect(hasApiKey()).toBe(true);
+    expect(getApiKey()).toBe(SERVER_KEY);
+  });
+
+  it('resolves the network from HELIUS_NETWORK', () => {
+    process.env.HELIUS_NETWORK = 'devnet';
+    enterSharedMode();
+
+    expect(getNetwork()).toBe('devnet');
+  });
+
+  it('still reports a missing key so startup can fail loudly', () => {
+    enterSharedMode();
+    expect(hasApiKey()).toBe(false);
+    expect(() => getApiKey()).toThrow('NO_API_KEY');
+  });
+});
+
+// ─── WebSocket URL Never Carries the Shared Key ───────────────────────────────
+
+describe('getEnhancedWebSocketUrl', () => {
+  it('returns a placeholder instead of the deployment key', () => {
+    process.env.HELIUS_API_KEY = SERVER_KEY;
+    enterSharedMode();
+
+    const url = getEnhancedWebSocketUrl();
+    expect(url).not.toContain(SERVER_KEY);
+    expect(url).toContain('YOUR_HELIUS_API_KEY');
+  });
+
+  it('returns a usable URL in single-tenant mode', () => {
+    process.env.HELIUS_API_KEY = SERVER_KEY;
+    expect(getEnhancedWebSocketUrl()).toContain(SERVER_KEY);
+  });
+});

--- a/helius-mcp/tests/shared-credential.test.ts
+++ b/helius-mcp/tests/shared-credential.test.ts
@@ -28,7 +28,11 @@ import {
   setNetwork,
   getNetwork,
   getEnhancedWebSocketUrl,
+  loadSignerOrFail,
+  setSessionSecretKey,
+  setSessionWalletAddress,
 } from '../src/utils/helius.js';
+import { resolveOwsOrKeypairSigner } from '../src/utils/ows.js';
 
 const SERVER_KEY = 'b1f3c9de-4a77-4a2f-9d0e-2c6f8a1b5e44';
 
@@ -37,12 +41,15 @@ function enterSharedMode(): void {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   delete process.env.HELIUS_MCP_SHARED_CREDENTIAL;
   delete process.env.HELIUS_API_KEY;
   delete process.env.HELIUS_NETWORK;
   // Clear module-global session state while mutation is still permitted.
   setApiKey('');
   setNetwork('mainnet-beta');
+  setSessionSecretKey(null as unknown as Uint8Array);
+  setSessionWalletAddress(null as unknown as string);
 });
 
 afterEach(() => {
@@ -131,5 +138,102 @@ describe('getEnhancedWebSocketUrl', () => {
   it('returns a usable URL in single-tenant mode', () => {
     process.env.HELIUS_API_KEY = SERVER_KEY;
     expect(getEnhancedWebSocketUrl()).toContain(SERVER_KEY);
+  });
+});
+
+// ─── No Signer On A Shared Server ─────────────────────────────────────────────
+
+describe('loadSignerOrFail under a shared credential', () => {
+  it('refuses instead of lazily loading a keypair from the host disk', async () => {
+    enterSharedMode();
+    await expect(loadSignerOrFail()).rejects.toThrow('SHARED_CREDENTIAL_NO_SIGNER');
+  });
+
+  it('does not read the keypair file at all', async () => {
+    const { loadKeypairFromDisk } = await import('../src/utils/config.js');
+    enterSharedMode();
+
+    await expect(loadSignerOrFail()).rejects.toThrow();
+    expect(loadKeypairFromDisk).not.toHaveBeenCalled();
+  });
+
+  it('still reports NO_KEYPAIR in single-tenant mode', async () => {
+    // Mocked loadKeypairFromDisk returns null, so this is the no-wallet path.
+    await expect(loadSignerOrFail()).rejects.toThrow('NO_KEYPAIR');
+  });
+});
+
+describe('resolveOwsOrKeypairSigner under a shared credential', () => {
+  it('refuses the local-keypair path with SHARED_CREDENTIAL, not NO_KEYPAIR', async () => {
+    enterSharedMode();
+
+    const result = await resolveOwsOrKeypairSigner();
+    expect(result.ok).toBe(false);
+    const text = result.ok ? '' : result.error.content[0].text;
+    expect(text).toContain('Transaction signing is unavailable on this server');
+    // The catch-all below flattens every failure into this advice, which is a
+    // dead end here because generateKeypair also refuses.
+    expect(text).not.toContain('Call `generateKeypair`');
+  });
+
+  it('refuses the OWS path too, before shelling out to the host CLI', async () => {
+    enterSharedMode();
+
+    const result = await resolveOwsOrKeypairSigner('my-wallet');
+    expect(result.ok).toBe(false);
+    const text = result.ok ? '' : result.error.content[0].text;
+    expect(text).toContain('Transaction signing is unavailable on this server');
+  });
+});
+
+// ─── Wallet And Account Tools Refuse ──────────────────────────────────────────
+
+/** Captures registered handlers; the handler is always the last argument. */
+async function captureAuthTools(): Promise<Record<string, (args: unknown) => Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}>>> {
+  const { registerAuthTools } = await import('../src/tools/auth.js');
+  const handlers: Record<string, (args: unknown) => Promise<never>> = {};
+  const fakeServer = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tool: (...args: any[]) => {
+      handlers[args[0]] = args[args.length - 1];
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  registerAuthTools(fakeServer);
+  return handlers;
+}
+
+describe('wallet and account tools under a shared credential', () => {
+  it('generateKeypair refuses rather than writing a key to the host disk', async () => {
+    const handlers = await captureAuthTools();
+    enterSharedMode();
+
+    const result = await handlers.generateKeypair({});
+    expect(result.isError).toBe(true);
+    // The distinctive refusal, not just the code — an ungated handler throws an
+    // error that also contains "SHARED_CREDENTIAL", so the code alone proves nothing.
+    expect(result.content[0].text).toContain('Keypair generation is unavailable on this server');
+  });
+
+  it('signup refuses before any payment path is reached', async () => {
+    const handlers = await captureAuthTools();
+    enterSharedMode();
+
+    const result = await handlers.signup({ mode: 'link', plan: 'agent' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Account signup is unavailable on this server');
+  });
+
+  it('signup resume refuses too, so a provisioned key is never dropped mid-flow', async () => {
+    const handlers = await captureAuthTools();
+    enterSharedMode();
+
+    const result = await handlers.signup({ mode: 'resume', plan: 'agent' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Account signup is unavailable on this server');
   });
 });


### PR DESCRIPTION
## Why

`sessionApiKey`, `sessionNetwork`, and the memoized `heliusClient` are module-global. On stdio, that's right, as the process belongs to whoever launched it. Under one shared server-side credential serving many anonymous callers, any mutation is global

`setHeliusApiKey` would repoint the key for every concurrent caller, and `setSharedApiKey()` would write the caller-supplied value to `~/.helius/config.json`

This was already blocked in the common case. The handler returns early when `process.env.HELIUS_API_KEY` is set, which is how a hosted deployment supplies its key. The defect is that the guard is keyed on how the credential arrived rather than on the trust model; mount the key as a config file, let `getSharedApiKey()` find it, and the guard silently stops applying. This PR replaces incidental protection with intentional protection

## What

**Refuse mutation, at two layers.** `setApiKey()` and `setNetwork()` throw `SHARED_CREDENTIAL` via a shared `assertConfigurableAtRuntime()` helper. The `setHeliusApiKey` handler checks the mode first and returns a clean `UNSUPPORTED` error pointing the caller at `npx helius-mcp@latest` if they want their own key. The handler check gives a good message; the setter throw is the backstop for any future call site that forgets

**Fail fast at boot.** `HELIUS_MCP_SHARED_CREDENTIAL` set without `HELIUS_API_KEY` now exits non-zero. Previously the server started happily and answered every request with `NO_API_KEY`; a healthy-looking deployment serving errors, which is the shape of a bug you find during reviewer test cases instead of during deploy

**No signing key in shared mode.** Startup skips `loadKeypairFromDisk()` entirely. A server acting for many callers must not hold one, and the tools that would use it are off the hosted surface anyway

**No redundant seeding.** `getApiKey()` already resolves `HELIUS_API_KEY`, so shared mode doesn't copy env into session state, which is what made the old precedence order (`sessionApiKey` beats env) exploitable in the first place

## Testing

- `pnpm test` — 312 passing, 11 new in `tests/shared-credential.test.ts`. Covers: both setters refusing in shared mode and still working in single-tenant mode, the deployment key surviving a refused attempt, `HELIUS_API_KEY` and `HELIUS_NETWORK` resolving without runtime seeding, a missing key still reporting `NO_API_KEY` so boot can fail loudly, and the WebSocket URL returning a placeholder rather than the deployment key
- The WebSocket assertions cover code that landed in #160. They live here rather than there because they assert the shared-credential contract, which is what this file is about